### PR TITLE
Made many definitions opaque

### DIFF
--- a/Definition/Conversion/EqRelInstance.agda
+++ b/Definition/Conversion/EqRelInstance.agda
@@ -279,90 +279,95 @@ opaque
 ~-to-conv (↑ x x₁) = convConvTerm (lift~toConv↑ x₁) (sym x)
 
 
--- Algorithmic equality instance of the generic equality relation.
-instance eqRelInstance : EqRelSet
-eqRelInstance = record {
-  _⊢_≅_ = _⊢_[conv↑]_;
-  _⊢_≅_∷_ = _⊢_[conv↑]_∷_;
-  _⊢_~_∷_ = _⊢_~_∷_;
-  ~-to-≅ₜ = ~-to-conv;
-  ≅-eq = soundnessConv↑;
-  ≅ₜ-eq = soundnessConv↑Term;
-  ≅-univ = univConv↑;
-  ≅-sym = symConv;
-  ≅ₜ-sym = symConvTerm;
-  ~-sym = ~-sym;
-  ≅-trans = transConv;
-  ≅ₜ-trans = transConvTerm;
-  ~-trans = ~-trans;
-  ≅-conv = convConvTerm;
-  ~-conv = ~-conv;
-  ≅-wk = wkConv↑;
-  ≅ₜ-wk = wkConv↑Term;
-  ~-wk = ~-wk;
-  ≅-red = λ x x₁ x₂ x₃ x₄ → reductionConv↑ x x₁ x₄;
-  ≅ₜ-red = λ x x₁ x₂ x₃ x₄ x₅ x₆ → reductionConv↑Term x x₁ x₂ x₆;
-  ≅-Urefl = liftConv ∘ᶠ U-refl;
-  ≅-ℕrefl = liftConv ∘ᶠ ℕ-refl;
-  ≅ₜ-ℕrefl = λ x → liftConvTerm (univ (ℕⱼ x) (ℕⱼ x) (ℕ-refl x));
-  ≅-Emptyrefl = liftConv ∘ᶠ Empty-refl;
-  ≅ₜ-Emptyrefl = λ x → liftConvTerm (univ (Emptyⱼ x) (Emptyⱼ x) (Empty-refl x));
-  ≅-Unitrefl = λ ⊢Γ → liftConv ∘→ Unit-refl ⊢Γ;
-  ≅ₜ-Unitrefl = λ ⊢Γ ok →
-                  liftConvTerm $
-                  univ (Unitⱼ ⊢Γ ok) (Unitⱼ ⊢Γ ok) (Unit-refl ⊢Γ ok);
-  ≅ₜ-η-unit = λ [e] [e'] → let u , uWhnf , uRed = whNormTerm [e]
-                               u' , u'Whnf , u'Red = whNormTerm [e']
-                               [u] = ⊢u-redₜ uRed
-                               [u'] = ⊢u-redₜ u'Red
-                           in  [↑]ₜ Unit u u'
-                               (red (idRed:*: (syntacticTerm [e])))
-                               (redₜ uRed)
-                               (redₜ u'Red)
-                               Unitₙ uWhnf u'Whnf
-                               (η-unit [u] [u'] uWhnf u'Whnf);
-  ≅-ΠΣ-cong = λ x x₁ x₂ ok → liftConv (ΠΣ-cong x x₁ x₂ ok);
-  ≅ₜ-ΠΣ-cong = λ x x₁ x₂ ok →
-    let _ , F∷U , H∷U = syntacticEqTerm (soundnessConv↑Term x₁)
-        _ , G∷U , E∷U = syntacticEqTerm (soundnessConv↑Term x₂)
-        ⊢Γ = wfTerm F∷U
-        F<>H = univConv↑ x₁
-        G<>E = univConv↑ x₂
-        F≡H = soundnessConv↑ F<>H
-        E∷U′ = stabilityTerm (reflConEq ⊢Γ ∙ F≡H) E∷U
-    in
-    liftConvTerm $
-    univ (ΠΣⱼ F∷U G∷U ok) (ΠΣⱼ H∷U E∷U′ ok) (ΠΣ-cong x F<>H G<>E ok);
-  ≅ₜ-zerorefl = liftConvTerm ∘ᶠ zero-refl;
-  ≅-suc-cong = liftConvTerm ∘ᶠ suc-cong;
-  ≅-prod-cong = λ x x₁ x₂ x₃ x₄ →
-                  liftConvTerm (prod-cong x x₁ x₂ x₃ x₄);
-  ≅-η-eq = λ x x₁ x₂ x₃ x₄ x₅ → liftConvTerm (η-eq x₁ x₂ x₃ x₄ x₅);
-  ≅-Σ-η = λ x x₁ x₂ x₃ x₄ x₅ x₆ x₇ → (liftConvTerm (Σ-η x₂ x₃ x₄ x₅ x₆ x₇));
-  ~-var = ~-var;
-  ~-app = ~-app;
-  ~-fst = λ x x₁ x₂ → ~-fst x₂;
-  ~-snd = λ x x₁ x₂ → ~-snd x₂;
-  ~-natrec = ~-natrec;
-  ~-prodrec = λ ⊢A ⊢B C↑D t₁~t₂ u₁↑u₂ _ →
-                ~-prodrec ⊢A ⊢B C↑D t₁~t₂ u₁↑u₂;
-  ~-emptyrec = ~-emptyrec;
-  ≅-Id-cong = λ { A₁≡A₂ t₁≡t₂ u₁≡u₂ →
-    liftConv (Id-cong A₁≡A₂ t₁≡t₂ u₁≡u₂) };
-  ≅ₜ-Id-cong = λ { A₁≡A₂ t₁≡t₂ u₁≡u₂ →
-    case soundnessConv↑Term A₁≡A₂ of λ {
-      ⊢A₁≡A₂ →
-    case syntacticEqTerm ⊢A₁≡A₂ of λ {
-      (_ , ⊢A₁ , ⊢A₂) →
-    case syntacticEqTerm (soundnessConv↑Term t₁≡t₂) of λ {
-      (_ , ⊢t₁ , ⊢t₂) →
-    case syntacticEqTerm (soundnessConv↑Term u₁≡u₂) of λ {
-      (_ , ⊢u₁ , ⊢u₂) →
-    liftConvTerm $
-    univ (Idⱼ ⊢A₁ ⊢t₁ ⊢u₁)
-      (Idⱼ ⊢A₂ (conv ⊢t₂ (univ ⊢A₁≡A₂)) (conv ⊢u₂ (univ ⊢A₁≡A₂)))
-      (Id-cong (univConv↑ A₁≡A₂) t₁≡t₂ u₁≡u₂) }}}}};
-  ≅ₜ-rflrefl = liftConvTerm ∘→ rfl-refl ∘→ refl;
-  ~-J = ~-J;
-  ~-K = ~-K;
-  ~-[]-cong = ~-[]-cong }
+transparent
+
+  -- Algorithmic equality instance of the generic equality relation.
+  instance eqRelInstance : EqRelSet
+  eqRelInstance = record {
+    _⊢_≅_ = _⊢_[conv↑]_;
+    _⊢_≅_∷_ = _⊢_[conv↑]_∷_;
+    _⊢_~_∷_ = _⊢_~_∷_;
+    ~-to-≅ₜ = ~-to-conv;
+    ≅-eq = soundnessConv↑;
+    ≅ₜ-eq = soundnessConv↑Term;
+    ≅-univ = univConv↑;
+    ≅-sym = symConv;
+    ≅ₜ-sym = symConvTerm;
+    ~-sym = ~-sym;
+    ≅-trans = transConv;
+    ≅ₜ-trans = transConvTerm;
+    ~-trans = ~-trans;
+    ≅-conv = convConvTerm;
+    ~-conv = ~-conv;
+    ≅-wk = wkConv↑;
+    ≅ₜ-wk = wkConv↑Term;
+    ~-wk = ~-wk;
+    ≅-red = λ x x₁ x₂ x₃ x₄ → reductionConv↑ x x₁ x₄;
+    ≅ₜ-red = λ x x₁ x₂ x₃ x₄ x₅ x₆ → reductionConv↑Term x x₁ x₂ x₆;
+    ≅-Urefl = liftConv ∘ᶠ U-refl;
+    ≅-ℕrefl = liftConv ∘ᶠ ℕ-refl;
+    ≅ₜ-ℕrefl = λ x → liftConvTerm (univ (ℕⱼ x) (ℕⱼ x) (ℕ-refl x));
+    ≅-Emptyrefl = liftConv ∘ᶠ Empty-refl;
+    ≅ₜ-Emptyrefl = λ x →
+                     liftConvTerm $
+                     univ (Emptyⱼ x) (Emptyⱼ x) (Empty-refl x);
+    ≅-Unitrefl = λ ⊢Γ → liftConv ∘→ Unit-refl ⊢Γ;
+    ≅ₜ-Unitrefl = λ ⊢Γ ok →
+                    liftConvTerm $
+                    univ (Unitⱼ ⊢Γ ok) (Unitⱼ ⊢Γ ok) (Unit-refl ⊢Γ ok);
+    ≅ₜ-η-unit = λ [e] [e'] → let u , uWhnf , uRed = whNormTerm [e]
+                                 u' , u'Whnf , u'Red = whNormTerm [e']
+                                 [u] = ⊢u-redₜ uRed
+                                 [u'] = ⊢u-redₜ u'Red
+                             in  [↑]ₜ Unit u u'
+                                 (red (idRed:*: (syntacticTerm [e])))
+                                 (redₜ uRed)
+                                 (redₜ u'Red)
+                                 Unitₙ uWhnf u'Whnf
+                                 (η-unit [u] [u'] uWhnf u'Whnf);
+    ≅-ΠΣ-cong = λ x x₁ x₂ ok → liftConv (ΠΣ-cong x x₁ x₂ ok);
+    ≅ₜ-ΠΣ-cong = λ x x₁ x₂ ok →
+      let _ , F∷U , H∷U = syntacticEqTerm (soundnessConv↑Term x₁)
+          _ , G∷U , E∷U = syntacticEqTerm (soundnessConv↑Term x₂)
+          ⊢Γ = wfTerm F∷U
+          F<>H = univConv↑ x₁
+          G<>E = univConv↑ x₂
+          F≡H = soundnessConv↑ F<>H
+          E∷U′ = stabilityTerm (reflConEq ⊢Γ ∙ F≡H) E∷U
+      in
+      liftConvTerm $
+      univ (ΠΣⱼ F∷U G∷U ok) (ΠΣⱼ H∷U E∷U′ ok) (ΠΣ-cong x F<>H G<>E ok);
+    ≅ₜ-zerorefl = liftConvTerm ∘ᶠ zero-refl;
+    ≅-suc-cong = liftConvTerm ∘ᶠ suc-cong;
+    ≅-prod-cong = λ x x₁ x₂ x₃ x₄ →
+                    liftConvTerm (prod-cong x x₁ x₂ x₃ x₄);
+    ≅-η-eq = λ x x₁ x₂ x₃ x₄ x₅ → liftConvTerm (η-eq x₁ x₂ x₃ x₄ x₅);
+    ≅-Σ-η = λ x x₁ x₂ x₃ x₄ x₅ x₆ x₇ →
+              liftConvTerm (Σ-η x₂ x₃ x₄ x₅ x₆ x₇);
+    ~-var = ~-var;
+    ~-app = ~-app;
+    ~-fst = λ x x₁ x₂ → ~-fst x₂;
+    ~-snd = λ x x₁ x₂ → ~-snd x₂;
+    ~-natrec = ~-natrec;
+    ~-prodrec = λ ⊢A ⊢B C↑D t₁~t₂ u₁↑u₂ _ →
+                  ~-prodrec ⊢A ⊢B C↑D t₁~t₂ u₁↑u₂;
+    ~-emptyrec = ~-emptyrec;
+    ≅-Id-cong = λ { A₁≡A₂ t₁≡t₂ u₁≡u₂ →
+      liftConv (Id-cong A₁≡A₂ t₁≡t₂ u₁≡u₂) };
+    ≅ₜ-Id-cong = λ { A₁≡A₂ t₁≡t₂ u₁≡u₂ →
+      case soundnessConv↑Term A₁≡A₂ of λ {
+        ⊢A₁≡A₂ →
+      case syntacticEqTerm ⊢A₁≡A₂ of λ {
+        (_ , ⊢A₁ , ⊢A₂) →
+      case syntacticEqTerm (soundnessConv↑Term t₁≡t₂) of λ {
+        (_ , ⊢t₁ , ⊢t₂) →
+      case syntacticEqTerm (soundnessConv↑Term u₁≡u₂) of λ {
+        (_ , ⊢u₁ , ⊢u₂) →
+      liftConvTerm $
+      univ (Idⱼ ⊢A₁ ⊢t₁ ⊢u₁)
+        (Idⱼ ⊢A₂ (conv ⊢t₂ (univ ⊢A₁≡A₂)) (conv ⊢u₂ (univ ⊢A₁≡A₂)))
+        (Id-cong (univConv↑ A₁≡A₂) t₁≡t₂ u₁≡u₂) }}}}};
+    ≅ₜ-rflrefl = liftConvTerm ∘→ rfl-refl ∘→ refl;
+    ~-J = ~-J;
+    ~-K = ~-K;
+    ~-[]-cong = ~-[]-cong }

--- a/Definition/LogicalRelation.agda
+++ b/Definition/LogicalRelation.agda
@@ -2,6 +2,8 @@
 -- The logical relation for reducibility
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 open import Definition.Typed.EqualityRelation
 open import Definition.Typed.Restrictions
 open import Graded.Modality
@@ -146,17 +148,21 @@ mutual
     zeroᵣ : [Natural]-prop Γ zero zero
     ne    : ∀ {n n′} → Γ ⊩neNf n ≡ n′ ∷ ℕ → [Natural]-prop Γ n n′
 
--- Natural extraction from term WHNF property
-natural : ∀ {n} → Natural-prop Γ n → Natural n
-natural (sucᵣ x) = sucₙ
-natural zeroᵣ = zeroₙ
-natural (ne (neNfₜ neK ⊢k k≡k)) = ne neK
+opaque
 
--- Natural extraction from term equality WHNF property
-split : ∀ {a b} → [Natural]-prop Γ a b → Natural a × Natural b
-split (sucᵣ x) = sucₙ , sucₙ
-split zeroᵣ = zeroₙ , zeroₙ
-split (ne (neNfₜ₌ neK neM k≡m)) = ne neK , ne neM
+  -- Natural extraction from term WHNF property
+  natural : ∀ {n} → Natural-prop Γ n → Natural n
+  natural (sucᵣ x) = sucₙ
+  natural zeroᵣ = zeroₙ
+  natural (ne (neNfₜ neK ⊢k k≡k)) = ne neK
+
+opaque
+
+  -- Natural extraction from term equality WHNF property
+  split : ∀ {a b} → [Natural]-prop Γ a b → Natural a × Natural b
+  split (sucᵣ x) = sucₙ , sucₙ
+  split zeroᵣ = zeroₙ , zeroₙ
+  split (ne (neNfₜ₌ neK neM k≡m)) = ne neK , ne neM
 
 -- Reducibility of Empty
 
@@ -196,11 +202,15 @@ record _⊩Empty_≡_∷Empty (Γ : Con Term ℓ) (t u : Term ℓ) : Set a where
     k≡k′ : Γ ⊢ k ≅ k′ ∷ Empty
     prop : [Empty]-prop Γ k k′
 
-empty : ∀ {n} → Empty-prop Γ n → Neutral n
-empty (ne (neNfₜ neK _ _)) = neK
+opaque
 
-esplit : ∀ {a b} → [Empty]-prop Γ a b → Neutral a × Neutral b
-esplit (ne (neNfₜ₌ neK neM k≡m)) = neK , neM
+  empty : ∀ {n} → Empty-prop Γ n → Neutral n
+  empty (ne (neNfₜ neK _ _)) = neK
+
+opaque
+
+  esplit : ∀ {a b} → [Empty]-prop Γ a b → Neutral a × Neutral b
+  esplit (ne (neNfₜ₌ neK neM k≡m)) = neK , neM
 
 -- Reducibility of Unit
 
@@ -705,30 +715,32 @@ data ⊩Id≡∷-view
   (_ , _ , _ , _ , rflₙ , ne _ , ())
   (_ , _ , _ , _ , ne _ , rflₙ , ())
 
--- A kind of constructor for _⊩ₗId_≡_∷_/_.
+opaque
 
-⊩Id≡∷ :
-  ∀ {A} {Γ : Con Term ℓ} {⊩A : Γ ⊩′⟨ l ⟩Id A} →
-  let open _⊩ₗId_ ⊩A in
-  ((t′ , _ , t′-id , _) : Γ ⊩⟨ l ⟩ t ∷ A / Idᵣ ⊩A)
-  ((u′ , _ , u′-id , _) : Γ ⊩⟨ l ⟩ u ∷ A / Idᵣ ⊩A) →
-  Identity-rec t′-id
-    (Identity-rec u′-id
-       (Lift _ ⊤)
-       (Lift _ ⊥))
-    (Identity-rec u′-id
-       (Lift _ ⊥)
-       (Γ ⊢ t′ ~ u′ ∷ Id Ty lhs rhs)) →
-  Γ ⊩⟨ l ⟩ t ≡ u ∷ A / Idᵣ ⊩A
-⊩Id≡∷ ⊩t@(t′ , t⇒*t′ , t′-id , _) ⊩u@(u′ , u⇒*u′ , u′-id , _) rest =
-    t′ , u′ , t⇒*t′ , u⇒*u′ , t′-id , u′-id
-  , (case ⊩Id∷-view-inhabited ⊩t of λ where
-       (rflᵣ lhs≡rhs) → case ⊩Id∷-view-inhabited ⊩u of λ where
-         (rflᵣ _) → lhs≡rhs
-         (ne _ _) → case rest of λ ()
-       (ne _ _) → case ⊩Id∷-view-inhabited ⊩u of λ where
-         (rflᵣ _) → case rest of λ ()
-         (ne _ _) → rest)
+  -- A kind of constructor for _⊩ₗId_≡_∷_/_.
+
+  ⊩Id≡∷ :
+    ∀ {A} {Γ : Con Term ℓ} {⊩A : Γ ⊩′⟨ l ⟩Id A} →
+    let open _⊩ₗId_ ⊩A in
+    ((t′ , _ , t′-id , _) : Γ ⊩⟨ l ⟩ t ∷ A / Idᵣ ⊩A)
+    ((u′ , _ , u′-id , _) : Γ ⊩⟨ l ⟩ u ∷ A / Idᵣ ⊩A) →
+    Identity-rec t′-id
+      (Identity-rec u′-id
+         (Lift _ ⊤)
+         (Lift _ ⊥))
+      (Identity-rec u′-id
+         (Lift _ ⊥)
+         (Γ ⊢ t′ ~ u′ ∷ Id Ty lhs rhs)) →
+    Γ ⊩⟨ l ⟩ t ≡ u ∷ A / Idᵣ ⊩A
+  ⊩Id≡∷ ⊩t@(t′ , t⇒*t′ , t′-id , _) ⊩u@(u′ , u⇒*u′ , u′-id , _) rest =
+      t′ , u′ , t⇒*t′ , u⇒*u′ , t′-id , u′-id
+    , (case ⊩Id∷-view-inhabited ⊩t of λ where
+         (rflᵣ lhs≡rhs) → case ⊩Id∷-view-inhabited ⊩u of λ where
+           (rflᵣ _) → lhs≡rhs
+           (ne _ _) → case rest of λ ()
+         (ne _ _) → case ⊩Id∷-view-inhabited ⊩u of λ where
+           (rflᵣ _) → case rest of λ ()
+           (ne _ _) → rest)
 
 -- A kind of inverse of ⊩Id≡∷.
 

--- a/Definition/LogicalRelation/Application.agda
+++ b/Definition/LogicalRelation/Application.agda
@@ -36,35 +36,37 @@ private
     Γ : Con Term n
     p p′ p₁ p₂ q : M
 
+opaque
+  unfolding B-intr
 
--- Helper function for application of specific type derivations.
-appTerm′ : ∀ {F G t u l l′ l″}
-          ([F] : Γ ⊩⟨ l″ ⟩ F)
-          ([G[u]] : Γ ⊩⟨ l′ ⟩ G [ u ]₀)
-          ([ΠFG] : Γ ⊩⟨ l ⟩B⟨ BΠ p q ⟩ Π p , q ▷ F ▹ G)
-          ([t] : Γ ⊩⟨ l ⟩ t ∷ Π p , q ▷ F ▹ G / B-intr BΠ! [ΠFG])
-          ([u] : Γ ⊩⟨ l″ ⟩ u ∷ F / [F])
-        → Γ ⊩⟨ l′ ⟩ t ∘⟨ p ⟩ u ∷ G [ u ]₀ / [G[u]]
-appTerm′ {n} {Γ = Γ} {p = p} {q = q} {F = F} {G} {t} {u}
-         [F] [G[u]] (noemb (Bᵣ F′ G′ D ⊢F ⊢G A≡A [F′] [G′] G-ext ok))
-         (Πₜ f d funcF f≡f [f] [f]₁) [u] =
-  let ΠFG≡ΠF′G′ = whnfRed* (red D) ΠΣₙ
-      F≡F′ , G≡G′ , _ = B-PE-injectivity BΠ! BΠ! ΠFG≡ΠF′G′
-      F≡idF′ = PE.trans F≡F′ (PE.sym (wk-id _))
-      idG′ᵤ≡Gᵤ = PE.cong (λ x → x [ u ]₀) (PE.trans (wk-lift-id G′) (PE.sym G≡G′))
-      idf∘u≡f∘u = (PE.cong (λ x → x ∘⟨ p ⟩ u) (wk-id f))
-      ⊢Γ = wf ⊢F
-      [u]′ = irrelevanceTerm′ F≡idF′ [F] ([F′] id ⊢Γ) [u]
-      [f∘u] = irrelevanceTerm″ idG′ᵤ≡Gᵤ idf∘u≡f∘u
-                ([G′] id ⊢Γ [u]′) [G[u]] ([f]₁ id ⊢Γ [u]′)
-      ⊢u = escapeTerm [F] [u]
-      d′ = PE.subst (λ x → Γ ⊢ t ⇒* f ∷ x)
-             (PE.cong₂ (λ F G → Π p , q ▷ F ▹ G)
-                       (PE.sym F≡F′) (PE.sym G≡G′))
-             (conv* (redₜ d)
-                (ΠΣ-cong ⊢F (refl ⊢F) (refl ⊢G) ok))
-  in  proj₁ (redSubst*Term (app-subst* d′ ⊢u) [G[u]] [f∘u])
-appTerm′ [F] [G[u]] (emb 0<1 x) [t] [u] = appTerm′ [F] [G[u]] x [t] [u]
+  -- Helper function for application of specific type derivations.
+  appTerm′ : ∀ {F G t u l l′ l″}
+            ([F] : Γ ⊩⟨ l″ ⟩ F)
+            ([G[u]] : Γ ⊩⟨ l′ ⟩ G [ u ]₀)
+            ([ΠFG] : Γ ⊩⟨ l ⟩B⟨ BΠ p q ⟩ Π p , q ▷ F ▹ G)
+            ([t] : Γ ⊩⟨ l ⟩ t ∷ Π p , q ▷ F ▹ G / B-intr BΠ! [ΠFG])
+            ([u] : Γ ⊩⟨ l″ ⟩ u ∷ F / [F])
+          → Γ ⊩⟨ l′ ⟩ t ∘⟨ p ⟩ u ∷ G [ u ]₀ / [G[u]]
+  appTerm′ {n} {Γ = Γ} {p = p} {q = q} {F = F} {G} {t} {u}
+           [F] [G[u]] (noemb (Bᵣ F′ G′ D ⊢F ⊢G A≡A [F′] [G′] G-ext ok))
+           (Πₜ f d funcF f≡f [f] [f]₁) [u] =
+    let ΠFG≡ΠF′G′ = whnfRed* (red D) ΠΣₙ
+        F≡F′ , G≡G′ , _ = B-PE-injectivity BΠ! BΠ! ΠFG≡ΠF′G′
+        F≡idF′ = PE.trans F≡F′ (PE.sym (wk-id _))
+        idG′ᵤ≡Gᵤ = PE.cong (λ x → x [ u ]₀) (PE.trans (wk-lift-id G′) (PE.sym G≡G′))
+        idf∘u≡f∘u = (PE.cong (λ x → x ∘⟨ p ⟩ u) (wk-id f))
+        ⊢Γ = wf ⊢F
+        [u]′ = irrelevanceTerm′ F≡idF′ [F] ([F′] id ⊢Γ) [u]
+        [f∘u] = irrelevanceTerm″ idG′ᵤ≡Gᵤ idf∘u≡f∘u
+                  ([G′] id ⊢Γ [u]′) [G[u]] ([f]₁ id ⊢Γ [u]′)
+        ⊢u = escapeTerm [F] [u]
+        d′ = PE.subst (λ x → Γ ⊢ t ⇒* f ∷ x)
+               (PE.cong₂ (λ F G → Π p , q ▷ F ▹ G)
+                         (PE.sym F≡F′) (PE.sym G≡G′))
+               (conv* (redₜ d)
+                  (ΠΣ-cong ⊢F (refl ⊢F) (refl ⊢G) ok))
+    in  proj₁ (redSubst*Term (app-subst* d′ ⊢u) [G[u]] [f∘u])
+  appTerm′ [F] [G[u]] (emb 0<1 x) [t] [u] = appTerm′ [F] [G[u]] x [t] [u]
 
 -- Application of reducible terms.
 appTerm : ∀ {F G t u l l′ l″}
@@ -78,80 +80,83 @@ appTerm [F] [G[u]] [ΠFG] [t] [u] =
   let [t]′ = irrelevanceTerm [ΠFG] (B-intr BΠ! (Π-elim [ΠFG])) [t]
   in  appTerm′ [F] [G[u]] (Π-elim [ΠFG]) [t]′ [u]
 
--- Helper function for application congruence of specific type derivations.
-app-congTerm′ : ∀ {Γ : Con Term n} {F G t t′ u u′ l l′}
-          ([F] : Γ ⊩⟨ l′ ⟩ F)
-          ([G[u]] : Γ ⊩⟨ l′ ⟩ G [ u ]₀)
-          ([ΠFG] : Γ ⊩⟨ l ⟩B⟨ BΠ p q ⟩ Π p , q ▷ F ▹ G)
-          ([t≡t′] : Γ ⊩⟨ l ⟩ t ≡ t′ ∷ Π p , q ▷ F ▹ G / B-intr BΠ! [ΠFG])
-          ([u] : Γ ⊩⟨ l′ ⟩ u ∷ F / [F])
-          ([u′] : Γ ⊩⟨ l′ ⟩ u′ ∷ F / [F])
-          ([u≡u′] : Γ ⊩⟨ l′ ⟩ u ≡ u′ ∷ F / [F])
-        → Γ ⊩⟨ l′ ⟩ t ∘⟨ p ⟩ u ≡ t′ ∘⟨ p ⟩ u′ ∷ G [ u ]₀ / [G[u]]
-app-congTerm′ {n} {p = p} {q = q} {Γ = Γ} {F′} {G′} {t = t} {t′ = t′}
-              [F] [G[u]] (noemb (Bᵣ F G D ⊢F ⊢G A≡A [F]₁ [G] G-ext ok))
-              (Πₜ₌ f g [ ⊢t , ⊢f , d ] [ ⊢t′ , ⊢g , d′ ] funcF funcG t≡u
-                   (Πₜ f′ [ _ , ⊢f′ , d″ ] funcF′ f≡f [f] [f]₁)
-                   (Πₜ g′ [ _ , ⊢g′ , d‴ ] funcG′ g≡g [g] [g]₁) [t≡u])
-              [a] [a′] [a≡a′] =
-  let [ΠFG] = Πᵣ′ F G D ⊢F ⊢G A≡A [F]₁ [G] G-ext ok
-      ΠFG≡ΠF′G′ = whnfRed* (red D) ΠΣₙ
-      F≡F′ , G≡G′ , _ = B-PE-injectivity BΠ! BΠ! ΠFG≡ΠF′G′
-      f≡f′ = whrDet*Term (d , functionWhnf funcF) (d″ , functionWhnf funcF′)
-      g≡g′ = whrDet*Term (d′ , functionWhnf funcG) (d‴ , functionWhnf funcG′)
-      F≡wkidF′ = PE.trans F≡F′ (PE.sym (wk-id _))
-      t∘x≡wkidt∘x : {a b : Term n} {p : M} → wk id a ∘⟨ p ⟩ b PE.≡ a ∘⟨ p ⟩ b
-      t∘x≡wkidt∘x {a} {b} {p} = PE.cong (λ (x : Term n) → x ∘⟨ p ⟩ b) (wk-id a)
-      t∘x≡wkidt∘x′ : {a : Term n} {p : M} → wk id g′ ∘⟨ p ⟩ a PE.≡ g ∘⟨ p ⟩ a
-      t∘x≡wkidt∘x′ {a} {p} = PE.cong (λ (x : Term n) → x ∘⟨ p ⟩ a)
-                                     (PE.trans (wk-id _) (PE.sym g≡g′))
-      wkidG₁[u]≡G[u] = PE.cong (λ (x : Term (1+ n)) → x [ _ ]₀)
-                               (PE.trans (wk-lift-id _) (PE.sym G≡G′))
-      wkidG₁[u′]≡G[u′] = PE.cong (λ (x : Term (1+ n)) → x [ _ ]₀)
-                                 (PE.trans (wk-lift-id _) (PE.sym G≡G′))
-      ⊢Γ = wf ⊢F
-      [u]′ = irrelevanceTerm′ F≡wkidF′ [F] ([F]₁ id ⊢Γ) [a]
-      [u′]′ = irrelevanceTerm′ F≡wkidF′ [F] ([F]₁ id ⊢Γ) [a′]
-      [u≡u′]′ = irrelevanceEqTerm′ F≡wkidF′ [F] ([F]₁ id ⊢Γ) [a≡a′]
-      [G[u′]] = irrelevance′ wkidG₁[u′]≡G[u′] ([G] id ⊢Γ [u′]′)
-      [G[u≡u′]] = irrelevanceEq″ wkidG₁[u]≡G[u] wkidG₁[u′]≡G[u′]
-                                  ([G] id ⊢Γ [u]′) [G[u]]
-                                  (G-ext id ⊢Γ [u]′ [u′]′ [u≡u′]′)
-      [f′] : Γ ⊩⟨ _ ⟩ f′ ∷ Π p , q ▷ F′ ▹ G′ / [ΠFG]
-      [f′] = Πₜ f′ (idRedTerm:*: ⊢f′) funcF′ f≡f [f] [f]₁
-      [g′] : Γ ⊩⟨ _ ⟩ g′ ∷ Π p , q ▷ F′ ▹ G′ / [ΠFG]
-      [g′] = Πₜ g′ (idRedTerm:*: ⊢g′) funcG′ g≡g [g] [g]₁
-      [f∘u] = appTerm [F] [G[u]] [ΠFG]
-                      (irrelevanceTerm″ PE.refl (PE.sym f≡f′) [ΠFG] [ΠFG] [f′])
-                      [a]
-      [g∘u′] = appTerm [F] [G[u′]] [ΠFG]
-                       (irrelevanceTerm″ PE.refl (PE.sym g≡g′) [ΠFG] [ΠFG] [g′])
-                       [a′]
-      [tu≡t′u] = irrelevanceEqTerm″ t∘x≡wkidt∘x t∘x≡wkidt∘x wkidG₁[u]≡G[u]
-                                     ([G] id ⊢Γ [u]′) [G[u]]
-                                     ([t≡u] id ⊢Γ [u]′)
-      [t′u≡t′u′] = irrelevanceEqTerm″ t∘x≡wkidt∘x′ t∘x≡wkidt∘x′ wkidG₁[u]≡G[u]
-                                      ([G] id ⊢Γ [u]′) [G[u]]
-                                      ([g] id ⊢Γ [u]′ [u′]′ [u≡u′]′)
-      ΠFG≡ΠF′G′₁ = PE.cong₂ (λ (F : Term n) (G : Term (1+ n)) → Π p , q ▷ F ▹ G)
-                            (PE.sym F≡F′) (PE.sym G≡G′)
-      ΠFG≡ΠF′G′₂ = PE.cong₂ (λ (F : Term n) (G : Term (1+ n)) → Π p , q ▷ F ▹ G)
-                            (PE.sym F≡F′) (PE.sym G≡G′)
-      d₁ = PE.subst (λ x → Γ ⊢ t ⇒* f ∷ x) ΠFG≡ΠF′G′₁
-             (conv* d (ΠΣ-cong ⊢F (refl ⊢F) (refl ⊢G) ok))
-      d₂ = PE.subst (λ x → Γ ⊢ t′ ⇒* g ∷ x) ΠFG≡ΠF′G′₂
-             (conv* d′ (ΠΣ-cong ⊢F (refl ⊢F) (refl ⊢G) ok))
-      [tu≡fu] = proj₂ (redSubst*Term (app-subst* d₁ (escapeTerm [F] [a]))
-                                     [G[u]] [f∘u])
-      [gu′≡t′u′] = convEqTerm₂ [G[u]] [G[u′]] [G[u≡u′]]
-                     (symEqTerm [G[u′]]
-                       (proj₂ (redSubst*Term (app-subst* d₂ (escapeTerm [F] [a′]))
-                                             [G[u′]] [g∘u′])))
-  in  transEqTerm [G[u]] (transEqTerm [G[u]] [tu≡fu] [tu≡t′u])
-                  (transEqTerm [G[u]] [t′u≡t′u′] [gu′≡t′u′])
+opaque
+  unfolding B-intr
 
-app-congTerm′ [F] [G[u]] (emb 0<1 x) [t≡t′] [u] [u′] [u≡u′] =
-  app-congTerm′ [F] [G[u]] x [t≡t′] [u] [u′] [u≡u′]
+  -- Helper function for application congruence of specific type derivations.
+  app-congTerm′ : ∀ {Γ : Con Term n} {F G t t′ u u′ l l′}
+            ([F] : Γ ⊩⟨ l′ ⟩ F)
+            ([G[u]] : Γ ⊩⟨ l′ ⟩ G [ u ]₀)
+            ([ΠFG] : Γ ⊩⟨ l ⟩B⟨ BΠ p q ⟩ Π p , q ▷ F ▹ G)
+            ([t≡t′] : Γ ⊩⟨ l ⟩ t ≡ t′ ∷ Π p , q ▷ F ▹ G / B-intr BΠ! [ΠFG])
+            ([u] : Γ ⊩⟨ l′ ⟩ u ∷ F / [F])
+            ([u′] : Γ ⊩⟨ l′ ⟩ u′ ∷ F / [F])
+            ([u≡u′] : Γ ⊩⟨ l′ ⟩ u ≡ u′ ∷ F / [F])
+          → Γ ⊩⟨ l′ ⟩ t ∘⟨ p ⟩ u ≡ t′ ∘⟨ p ⟩ u′ ∷ G [ u ]₀ / [G[u]]
+  app-congTerm′ {n} {p = p} {q = q} {Γ = Γ} {F′} {G′} {t = t} {t′ = t′}
+                [F] [G[u]] (noemb (Bᵣ F G D ⊢F ⊢G A≡A [F]₁ [G] G-ext ok))
+                (Πₜ₌ f g [ ⊢t , ⊢f , d ] [ ⊢t′ , ⊢g , d′ ] funcF funcG t≡u
+                     (Πₜ f′ [ _ , ⊢f′ , d″ ] funcF′ f≡f [f] [f]₁)
+                     (Πₜ g′ [ _ , ⊢g′ , d‴ ] funcG′ g≡g [g] [g]₁) [t≡u])
+                [a] [a′] [a≡a′] =
+    let [ΠFG] = Πᵣ′ F G D ⊢F ⊢G A≡A [F]₁ [G] G-ext ok
+        ΠFG≡ΠF′G′ = whnfRed* (red D) ΠΣₙ
+        F≡F′ , G≡G′ , _ = B-PE-injectivity BΠ! BΠ! ΠFG≡ΠF′G′
+        f≡f′ = whrDet*Term (d , functionWhnf funcF) (d″ , functionWhnf funcF′)
+        g≡g′ = whrDet*Term (d′ , functionWhnf funcG) (d‴ , functionWhnf funcG′)
+        F≡wkidF′ = PE.trans F≡F′ (PE.sym (wk-id _))
+        t∘x≡wkidt∘x : {a b : Term n} {p : M} → wk id a ∘⟨ p ⟩ b PE.≡ a ∘⟨ p ⟩ b
+        t∘x≡wkidt∘x {a} {b} {p} = PE.cong (λ (x : Term n) → x ∘⟨ p ⟩ b) (wk-id a)
+        t∘x≡wkidt∘x′ : {a : Term n} {p : M} → wk id g′ ∘⟨ p ⟩ a PE.≡ g ∘⟨ p ⟩ a
+        t∘x≡wkidt∘x′ {a} {p} = PE.cong (λ (x : Term n) → x ∘⟨ p ⟩ a)
+                                       (PE.trans (wk-id _) (PE.sym g≡g′))
+        wkidG₁[u]≡G[u] = PE.cong (λ (x : Term (1+ n)) → x [ _ ]₀)
+                                 (PE.trans (wk-lift-id _) (PE.sym G≡G′))
+        wkidG₁[u′]≡G[u′] = PE.cong (λ (x : Term (1+ n)) → x [ _ ]₀)
+                                   (PE.trans (wk-lift-id _) (PE.sym G≡G′))
+        ⊢Γ = wf ⊢F
+        [u]′ = irrelevanceTerm′ F≡wkidF′ [F] ([F]₁ id ⊢Γ) [a]
+        [u′]′ = irrelevanceTerm′ F≡wkidF′ [F] ([F]₁ id ⊢Γ) [a′]
+        [u≡u′]′ = irrelevanceEqTerm′ F≡wkidF′ [F] ([F]₁ id ⊢Γ) [a≡a′]
+        [G[u′]] = irrelevance′ wkidG₁[u′]≡G[u′] ([G] id ⊢Γ [u′]′)
+        [G[u≡u′]] = irrelevanceEq″ wkidG₁[u]≡G[u] wkidG₁[u′]≡G[u′]
+                                    ([G] id ⊢Γ [u]′) [G[u]]
+                                    (G-ext id ⊢Γ [u]′ [u′]′ [u≡u′]′)
+        [f′] : Γ ⊩⟨ _ ⟩ f′ ∷ Π p , q ▷ F′ ▹ G′ / [ΠFG]
+        [f′] = Πₜ f′ (idRedTerm:*: ⊢f′) funcF′ f≡f [f] [f]₁
+        [g′] : Γ ⊩⟨ _ ⟩ g′ ∷ Π p , q ▷ F′ ▹ G′ / [ΠFG]
+        [g′] = Πₜ g′ (idRedTerm:*: ⊢g′) funcG′ g≡g [g] [g]₁
+        [f∘u] = appTerm [F] [G[u]] [ΠFG]
+                        (irrelevanceTerm″ PE.refl (PE.sym f≡f′) [ΠFG] [ΠFG] [f′])
+                        [a]
+        [g∘u′] = appTerm [F] [G[u′]] [ΠFG]
+                         (irrelevanceTerm″ PE.refl (PE.sym g≡g′) [ΠFG] [ΠFG] [g′])
+                         [a′]
+        [tu≡t′u] = irrelevanceEqTerm″ t∘x≡wkidt∘x t∘x≡wkidt∘x wkidG₁[u]≡G[u]
+                                       ([G] id ⊢Γ [u]′) [G[u]]
+                                       ([t≡u] id ⊢Γ [u]′)
+        [t′u≡t′u′] = irrelevanceEqTerm″ t∘x≡wkidt∘x′ t∘x≡wkidt∘x′ wkidG₁[u]≡G[u]
+                                        ([G] id ⊢Γ [u]′) [G[u]]
+                                        ([g] id ⊢Γ [u]′ [u′]′ [u≡u′]′)
+        ΠFG≡ΠF′G′₁ = PE.cong₂ (λ (F : Term n) (G : Term (1+ n)) → Π p , q ▷ F ▹ G)
+                              (PE.sym F≡F′) (PE.sym G≡G′)
+        ΠFG≡ΠF′G′₂ = PE.cong₂ (λ (F : Term n) (G : Term (1+ n)) → Π p , q ▷ F ▹ G)
+                              (PE.sym F≡F′) (PE.sym G≡G′)
+        d₁ = PE.subst (λ x → Γ ⊢ t ⇒* f ∷ x) ΠFG≡ΠF′G′₁
+               (conv* d (ΠΣ-cong ⊢F (refl ⊢F) (refl ⊢G) ok))
+        d₂ = PE.subst (λ x → Γ ⊢ t′ ⇒* g ∷ x) ΠFG≡ΠF′G′₂
+               (conv* d′ (ΠΣ-cong ⊢F (refl ⊢F) (refl ⊢G) ok))
+        [tu≡fu] = proj₂ (redSubst*Term (app-subst* d₁ (escapeTerm [F] [a]))
+                                       [G[u]] [f∘u])
+        [gu′≡t′u′] = convEqTerm₂ [G[u]] [G[u′]] [G[u≡u′]]
+                       (symEqTerm [G[u′]]
+                         (proj₂ (redSubst*Term (app-subst* d₂ (escapeTerm [F] [a′]))
+                                               [G[u′]] [g∘u′])))
+    in  transEqTerm [G[u]] (transEqTerm [G[u]] [tu≡fu] [tu≡t′u])
+                    (transEqTerm [G[u]] [t′u≡t′u′] [gu′≡t′u′])
+
+  app-congTerm′ [F] [G[u]] (emb 0<1 x) [t≡t′] [u] [u′] [u≡u′] =
+    app-congTerm′ [F] [G[u]] x [t≡t′] [u] [u′] [u≡u′]
 
 -- Application congruence of reducible terms.
 app-congTerm : ∀ {F G t t′ u u′ l l′}

--- a/Definition/LogicalRelation/Properties/Escape.agda
+++ b/Definition/LogicalRelation/Properties/Escape.agda
@@ -143,6 +143,8 @@ escapeTermEq
   ≅ₜ-red (red D) (redₜ d) (redₜ d′) ΠΣₙ
     (productWhnf pProd) (productWhnf rProd) p≅r
 escapeTermEq {Γ = Γ} (Idᵣ ⊩A) t≡u@(_ , _ , t⇒*t′ , u⇒*u′ , _) =
+  case ≅ₜ-red (red ⇒*Id) (redₜ t⇒*t′) (redₜ u⇒*u′) Idₙ of λ
+    lemma →
   case ⊩Id≡∷-view-inhabited ⊩A t≡u of λ where
     (ne t′-n u′-n t′~u′) →
       lemma (ne t′-n) (ne u′-n) (~-to-≅ₜ t′~u′)
@@ -157,8 +159,6 @@ escapeTermEq {Γ = Γ} (Idᵣ ⊩A) t≡u@(_ , _ , t⇒*t′ , u⇒*u′ , _) =
          (Γ ⊢ rfl ≅ rfl ∷ Id Ty lhs rhs)    □)
   where
   open _⊩ₗId_ ⊩A
-
-  lemma = ≅ₜ-red (red ⇒*Id) (redₜ t⇒*t′) (redₜ u⇒*u′) Idₙ
 escapeTermEq (emb 0<1 A) t≡u = escapeTermEq A t≡u
 
 -- If the type Unit is in the logical relation, then the Unit type is

--- a/Definition/LogicalRelation/Properties/Neutral.agda
+++ b/Definition/LogicalRelation/Properties/Neutral.agda
@@ -44,17 +44,21 @@ neu : ∀ {l A} (neA : Neutral A)
     → Γ ⊩⟨ l ⟩ A
 neu neA A A~A = ne′ _ (idRed:*: A) neA A~A
 
-  -- Helper function for reducible neutral equality of a specific type of derivation.
-neuEq′ : ∀ {l A B} ([A] : Γ ⊩⟨ l ⟩ne A)
-         (neA : Neutral A)
-         (neB : Neutral B)
-       → Γ ⊢ A → Γ ⊢ B
-       → Γ ⊢ A ~ B ∷ U
-       → Γ ⊩⟨ l ⟩ A ≡ B / ne-intr [A]
-neuEq′ (noemb (ne K [ ⊢A , ⊢B , D ] neK K≡K)) neA neB A B A~B =
-  let A≡K = whnfRed* D (ne neA)
-  in  ne₌ _ (idRed:*: B) neB (PE.subst (λ x → _ ⊢ x ~ _ ∷ _) A≡K A~B)
-neuEq′ (emb 0<1 x) neB A:≡:B = neuEq′ x neB A:≡:B
+opaque
+  unfolding ne-intr
+
+  -- Helper function for reducible neutral equality of a specific type
+  -- of derivation.
+  neuEq′ : ∀ {l A B} ([A] : Γ ⊩⟨ l ⟩ne A)
+           (neA : Neutral A)
+           (neB : Neutral B)
+         → Γ ⊢ A → Γ ⊢ B
+         → Γ ⊢ A ~ B ∷ U
+         → Γ ⊩⟨ l ⟩ A ≡ B / ne-intr [A]
+  neuEq′ (noemb (ne K [ ⊢A , ⊢B , D ] neK K≡K)) neA neB A B A~B =
+    let A≡K = whnfRed* D (ne neA)
+    in  ne₌ _ (idRed:*: B) neB (PE.subst (λ x → _ ⊢ x ~ _ ∷ _) A≡K A~B)
+  neuEq′ (emb 0<1 x) neB A:≡:B = neuEq′ x neB A:≡:B
 
 -- Neutrally equal types are of reducible equality.
 neuEq : ∀ {l A B} ([A] : Γ ⊩⟨ l ⟩ A)

--- a/Definition/LogicalRelation/Properties/Successor.agda
+++ b/Definition/LogicalRelation/Properties/Successor.agda
@@ -22,6 +22,7 @@ open import Definition.LogicalRelation R
 open import Definition.LogicalRelation.Irrelevance R
 open import Definition.LogicalRelation.ShapeView R
 
+open import Tools.Function
 open import Tools.Nat
 open import Tools.Product
 
@@ -30,19 +31,22 @@ private
     m : Nat
     Γ : Con Term m
 
+opaque
+  unfolding ℕ-intr
 
--- Helper function for successors for specific reducible derivations.
-sucTerm′ : ∀ {l n}
-           ([ℕ] : Γ ⊩⟨ l ⟩ℕ ℕ)
-         → Γ ⊩⟨ l ⟩ n ∷ ℕ / ℕ-intr [ℕ]
-         → Γ ⊩⟨ l ⟩ suc n ∷ ℕ / ℕ-intr [ℕ]
-sucTerm′ (noemb D) (ℕₜ n [ ⊢t , ⊢u , d ] n≡n prop) =
-  let natN = natural prop
-  in  ℕₜ _ [ sucⱼ ⊢t , sucⱼ ⊢t , id (sucⱼ ⊢t) ]
-         (≅-suc-cong (≅ₜ-red (red D) d d ℕₙ
-                             (naturalWhnf natN) (naturalWhnf natN) n≡n))
-         (sucᵣ (ℕₜ n [ ⊢t , ⊢u , d ] n≡n prop))
-sucTerm′ (emb 0<1 x) [n] = sucTerm′ x [n]
+  -- Helper function for successors for specific reducible derivations.
+  sucTerm′ : ∀ {l n}
+             ([ℕ] : Γ ⊩⟨ l ⟩ℕ ℕ)
+           → Γ ⊩⟨ l ⟩ n ∷ ℕ / ℕ-intr [ℕ]
+           → Γ ⊩⟨ l ⟩ suc n ∷ ℕ / ℕ-intr [ℕ]
+  sucTerm′ (noemb D) (ℕₜ n [ ⊢t , ⊢u , d ] n≡n prop) =
+    let natN = natural prop
+    in  ℕₜ _ [ sucⱼ ⊢t , sucⱼ ⊢t , id (sucⱼ ⊢t) ]
+           (≅-suc-cong $
+            ≅ₜ-red (red D) d d ℕₙ
+              (naturalWhnf natN) (naturalWhnf natN) n≡n)
+           (sucᵣ (ℕₜ n [ ⊢t , ⊢u , d ] n≡n prop))
+  sucTerm′ (emb 0<1 x) [n] = sucTerm′ x [n]
 
 -- Reducible natural numbers can be used to construct reducible successors.
 sucTerm : ∀ {l n} ([ℕ] : Γ ⊩⟨ l ⟩ ℕ)
@@ -54,18 +58,24 @@ sucTerm [ℕ] [n] =
                       [ℕ]
                       (sucTerm′ (ℕ-elim [ℕ]) [n]′)
 
--- Helper function for successor equality for specific reducible derivations.
-sucEqTerm′ : ∀ {l n n′}
-             ([ℕ] : Γ ⊩⟨ l ⟩ℕ ℕ)
-           → Γ ⊩⟨ l ⟩ n ≡ n′ ∷ ℕ / ℕ-intr [ℕ]
-           → Γ ⊩⟨ l ⟩ suc n ≡ suc n′ ∷ ℕ / ℕ-intr [ℕ]
-sucEqTerm′ (noemb D) (ℕₜ₌ k k′ [ ⊢t , ⊢u , d ]
-                              [ ⊢t₁ , ⊢u₁ , d₁ ] t≡u prop) =
-  let natK , natK′ = split prop
-  in  ℕₜ₌ _ _ (idRedTerm:*: (sucⱼ ⊢t)) (idRedTerm:*: (sucⱼ ⊢t₁))
-        (≅-suc-cong (≅ₜ-red (red D) d d₁ ℕₙ (naturalWhnf natK) (naturalWhnf natK′) t≡u))
-        (sucᵣ (ℕₜ₌ k k′ [ ⊢t , ⊢u , d ] [ ⊢t₁ , ⊢u₁ , d₁ ] t≡u prop))
-sucEqTerm′ (emb 0<1 x) [n≡n′] = sucEqTerm′ x [n≡n′]
+opaque
+  unfolding ℕ-intr
+
+  -- Helper function for successor equality for specific reducible
+  -- derivations.
+  sucEqTerm′ : ∀ {l n n′}
+               ([ℕ] : Γ ⊩⟨ l ⟩ℕ ℕ)
+             → Γ ⊩⟨ l ⟩ n ≡ n′ ∷ ℕ / ℕ-intr [ℕ]
+             → Γ ⊩⟨ l ⟩ suc n ≡ suc n′ ∷ ℕ / ℕ-intr [ℕ]
+  sucEqTerm′ (noemb D) (ℕₜ₌ k k′ [ ⊢t , ⊢u , d ]
+                                [ ⊢t₁ , ⊢u₁ , d₁ ] t≡u prop) =
+    let natK , natK′ = split prop
+    in  ℕₜ₌ _ _ (idRedTerm:*: (sucⱼ ⊢t)) (idRedTerm:*: (sucⱼ ⊢t₁))
+          (≅-suc-cong $
+           ≅ₜ-red (red D) d d₁ ℕₙ (naturalWhnf natK) (naturalWhnf natK′)
+             t≡u)
+          (sucᵣ (ℕₜ₌ k k′ [ ⊢t , ⊢u , d ] [ ⊢t₁ , ⊢u₁ , d₁ ] t≡u prop))
+  sucEqTerm′ (emb 0<1 x) [n≡n′] = sucEqTerm′ x [n≡n′]
 
 -- Reducible natural number equality can be used to construct reducible equality
 -- of the successors of the numbers.

--- a/Definition/LogicalRelation/Properties/Universe.agda
+++ b/Definition/LogicalRelation/Properties/Universe.agda
@@ -27,24 +27,33 @@ private
     n : Nat
     Γ : Con Term n
 
--- Helper function for reducible terms of type U for specific type derivations.
-univEq′ : ∀ {l A} ([U] : Γ ⊩⟨ l ⟩U) → Γ ⊩⟨ l ⟩ A ∷ U / U-intr [U] → Γ ⊩⟨ ⁰ ⟩ A
-univEq′ (noemb (Uᵣ .⁰ 0<1 ⊢Γ)) (Uₜ A₁ d typeA A≡A [A]) = [A]
-univEq′ (emb 0<1 x) [A] = univEq′ x [A]
+opaque
+  unfolding U-intr
+
+  -- Helper function for reducible terms of type U for specific type
+  -- derivations.
+  univEq′ :
+    ∀ {l A} ([U] : Γ ⊩⟨ l ⟩U) → Γ ⊩⟨ l ⟩ A ∷ U / U-intr [U] → Γ ⊩⟨ ⁰ ⟩ A
+  univEq′ (noemb (Uᵣ .⁰ 0<1 ⊢Γ)) (Uₜ A₁ d typeA A≡A [A]) = [A]
+  univEq′ (emb 0<1 x) [A] = univEq′ x [A]
 
 -- Reducible terms of type U are reducible types.
 univEq : ∀ {l A} ([U] : Γ ⊩⟨ l ⟩ U) → Γ ⊩⟨ l ⟩ A ∷ U / [U] → Γ ⊩⟨ ⁰ ⟩ A
 univEq [U] [A] = univEq′ (U-elim [U])
                          (irrelevanceTerm [U] (U-intr (U-elim [U])) [A])
 
--- Helper function for reducible term equality of type U for specific type derivations.
-univEqEq′ : ∀ {l l′ A B} ([U] : Γ ⊩⟨ l ⟩U) ([A] : Γ ⊩⟨ l′ ⟩ A)
-         → Γ ⊩⟨ l ⟩ A ≡ B ∷ U / U-intr [U]
-         → Γ ⊩⟨ l′ ⟩ A ≡ B / [A]
-univEqEq′ (noemb (Uᵣ .⁰ 0<1 ⊢Γ)) [A]
-          (Uₜ₌ A₁ B₁ d d′ typeA typeB A≡B [t] [u] [t≡u]) =
-  irrelevanceEq [t] [A] [t≡u]
-univEqEq′ (emb 0<1 x) [A] [A≡B] = univEqEq′ x [A] [A≡B]
+opaque
+  unfolding U-intr
+
+  -- Helper function for reducible term equality of type U for
+  -- specific type derivations.
+  univEqEq′ : ∀ {l l′ A B} ([U] : Γ ⊩⟨ l ⟩U) ([A] : Γ ⊩⟨ l′ ⟩ A)
+           → Γ ⊩⟨ l ⟩ A ≡ B ∷ U / U-intr [U]
+           → Γ ⊩⟨ l′ ⟩ A ≡ B / [A]
+  univEqEq′ (noemb (Uᵣ .⁰ 0<1 ⊢Γ)) [A]
+            (Uₜ₌ A₁ B₁ d d′ typeA typeB A≡B [t] [u] [t≡u]) =
+    irrelevanceEq [t] [A] [t≡u]
+  univEqEq′ (emb 0<1 x) [A] [A≡B] = univEqEq′ x [A] [A≡B]
 
 -- Reducible term equality of type U is reducible type equality.
 univEqEq : ∀ {l l′ A B} ([U] : Γ ⊩⟨ l ⟩ U) ([A] : Γ ⊩⟨ l′ ⟩ A)

--- a/Definition/LogicalRelation/ShapeView.agda
+++ b/Definition/LogicalRelation/ShapeView.agda
@@ -41,28 +41,30 @@ data MaybeEmb {ℓ′} (l : TypeLevel) (⊩⟨_⟩ : TypeLevel → Set ℓ′) :
   noemb : ⊩⟨ l ⟩ → MaybeEmb l ⊩⟨_⟩
   emb   : ∀ {l′} → l′ < l → MaybeEmb l′ ⊩⟨_⟩ → MaybeEmb l ⊩⟨_⟩
 
--- Specific reducible types with possible embedding
+transparent
 
-_⊩⟨_⟩U : (Γ : Con Term n) (l : TypeLevel) → Set a
-Γ ⊩⟨ l ⟩U = MaybeEmb l (λ l′ → Γ ⊩′⟨ l′ ⟩U)
+  -- Specific reducible types with possible embedding
 
-_⊩⟨_⟩ℕ_ : (Γ : Con Term n) (l : TypeLevel) (A : Term n) → Set a
-Γ ⊩⟨ l ⟩ℕ A = MaybeEmb l (λ l′ → Γ ⊩ℕ A)
+  _⊩⟨_⟩U : (Γ : Con Term n) (l : TypeLevel) → Set a
+  Γ ⊩⟨ l ⟩U = MaybeEmb l (λ l′ → Γ ⊩′⟨ l′ ⟩U)
 
-_⊩⟨_⟩Empty_ : (Γ : Con Term n) (l : TypeLevel) (A : Term n) → Set a
-Γ ⊩⟨ l ⟩Empty A = MaybeEmb l (λ l′ → Γ ⊩Empty A)
+  _⊩⟨_⟩ℕ_ : (Γ : Con Term n) (l : TypeLevel) (A : Term n) → Set a
+  Γ ⊩⟨ l ⟩ℕ A = MaybeEmb l (λ l′ → Γ ⊩ℕ A)
 
-_⊩⟨_⟩Unit_ : (Γ : Con Term n) (l : TypeLevel) (A : Term n) → Set a
-Γ ⊩⟨ l ⟩Unit A = MaybeEmb l (λ l′ → Γ ⊩Unit A)
+  _⊩⟨_⟩Empty_ : (Γ : Con Term n) (l : TypeLevel) (A : Term n) → Set a
+  Γ ⊩⟨ l ⟩Empty A = MaybeEmb l (λ l′ → Γ ⊩Empty A)
 
-_⊩⟨_⟩ne_ : (Γ : Con Term n) (l : TypeLevel) (A : Term n) → Set a
-Γ ⊩⟨ l ⟩ne A = MaybeEmb l (λ l′ → Γ ⊩ne A)
+  _⊩⟨_⟩Unit_ : (Γ : Con Term n) (l : TypeLevel) (A : Term n) → Set a
+  Γ ⊩⟨ l ⟩Unit A = MaybeEmb l (λ l′ → Γ ⊩Unit A)
 
-_⊩⟨_⟩B⟨_⟩_ : (Γ : Con Term n) (l : TypeLevel) (W : BindingType) (A : Term n) → Set a
-Γ ⊩⟨ l ⟩B⟨ W ⟩ A = MaybeEmb l (λ l′ → Γ ⊩′⟨ l′ ⟩B⟨ W ⟩ A)
+  _⊩⟨_⟩ne_ : (Γ : Con Term n) (l : TypeLevel) (A : Term n) → Set a
+  Γ ⊩⟨ l ⟩ne A = MaybeEmb l (λ l′ → Γ ⊩ne A)
 
-_⊩⟨_⟩Id_ : Con Term n → TypeLevel → Term n → Set a
-Γ ⊩⟨ l ⟩Id A = MaybeEmb l (λ l′ → Γ ⊩′⟨ l′ ⟩Id A)
+  _⊩⟨_⟩B⟨_⟩_ : Con Term n → TypeLevel → BindingType → Term n → Set a
+  Γ ⊩⟨ l ⟩B⟨ W ⟩ A = MaybeEmb l (λ l′ → Γ ⊩′⟨ l′ ⟩B⟨ W ⟩ A)
+
+  _⊩⟨_⟩Id_ : Con Term n → TypeLevel → Term n → Set a
+  Γ ⊩⟨ l ⟩Id A = MaybeEmb l (λ l′ → Γ ⊩′⟨ l′ ⟩Id A)
 
 -- Construct a general reducible type from a specific
 
@@ -235,7 +237,8 @@ B-elim W [Π] = B-elim′ W (id (escape [Π])) [Π]
 
 Σ-elim :
   ∀ {F G m l} →
-  Γ ⊩⟨ l ⟩ Σ p , q ▷ F ▹ G → Γ ⊩⟨ l ⟩B⟨ BΣ m p q ⟩ Σ p , q ▷ F ▹ G
+  Γ ⊩⟨ l ⟩ Σ⟨ m ⟩ p , q ▷ F ▹ G →
+  Γ ⊩⟨ l ⟩B⟨ BΣ m p q ⟩ Σ⟨ m ⟩ p , q ▷ F ▹ G
 Σ-elim [Σ] = B-elim′ BΣ! (id (escape [Σ])) [Σ]
 
 Id-elim′ : Γ ⊢ A ⇒* Id B t u → Γ ⊩⟨ l ⟩ A → Γ ⊩⟨ l ⟩Id A

--- a/Definition/LogicalRelation/Substitution.agda
+++ b/Definition/LogicalRelation/Substitution.agda
@@ -2,6 +2,8 @@
 -- The logical relation for validity
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 open import Definition.Typed.EqualityRelation
 open import Definition.Typed.Restrictions
 open import Graded.Modality

--- a/Definition/LogicalRelation/Substitution/Introductions/Empty.agda
+++ b/Definition/LogicalRelation/Substitution/Introductions/Empty.agda
@@ -35,10 +35,14 @@ private
 Emptyᵛ : ∀ {l} ([Γ] : ⊩ᵛ Γ) → Γ ⊩ᵛ⟨ l ⟩ Empty / [Γ]
 Emptyᵛ [Γ] = wrap λ ⊢Δ [σ] → Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)) , λ _ x₂ → id (Emptyⱼ ⊢Δ)
 
--- Validity of the Empty type as a term.
-Emptyᵗᵛ : ([Γ] : ⊩ᵛ Γ)
-    → Γ ⊩ᵛ⟨ ¹ ⟩ Empty ∷ U / [Γ] / Uᵛ [Γ]
-Emptyᵗᵛ [Γ] ⊢Δ [σ] = let ⊢Empty  = Emptyⱼ ⊢Δ
+opaque
+  unfolding Uᵛ
+
+  -- Validity of the Empty type as a term.
+  Emptyᵗᵛ : ([Γ] : ⊩ᵛ Γ)
+      → Γ ⊩ᵛ⟨ ¹ ⟩ Empty ∷ U / [Γ] / Uᵛ [Γ]
+  Emptyᵗᵛ [Γ] ⊢Δ [σ] =
+                     let ⊢Empty  = Emptyⱼ ⊢Δ
                          [Empty] = Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))
                  in  Uₜ Empty (idRedTerm:*: ⊢Empty) Emptyₙ (≅ₜ-Emptyrefl ⊢Δ) [Empty]
                  ,   (λ x x₁ → Uₜ₌ Empty Empty (idRedTerm:*: ⊢Empty) (idRedTerm:*: ⊢Empty) Emptyₙ Emptyₙ

--- a/Definition/LogicalRelation/Substitution/Introductions/Nat.agda
+++ b/Definition/LogicalRelation/Substitution/Introductions/Nat.agda
@@ -36,20 +36,27 @@ private
 ℕᵛ : ∀ {l} ([Γ] : ⊩ᵛ Γ) → Γ ⊩ᵛ⟨ l ⟩ ℕ / [Γ]
 ℕᵛ [Γ] = wrap λ ⊢Δ [σ] → ℕᵣ (idRed:*: (ℕⱼ ⊢Δ)) , λ _ x₂ → id (ℕⱼ ⊢Δ)
 
--- Validity of the natural number type as a term.
-ℕᵗᵛ : ([Γ] : ⊩ᵛ Γ)
-    → Γ ⊩ᵛ⟨ ¹ ⟩ ℕ ∷ U / [Γ] / Uᵛ [Γ]
-ℕᵗᵛ [Γ] ⊢Δ [σ] = let ⊢ℕ  = ℕⱼ ⊢Δ
+opaque
+  unfolding Uᵛ
+
+  -- Validity of the natural number type as a term.
+  ℕᵗᵛ : ([Γ] : ⊩ᵛ Γ)
+      → Γ ⊩ᵛ⟨ ¹ ⟩ ℕ ∷ U / [Γ] / Uᵛ [Γ]
+  ℕᵗᵛ [Γ] ⊢Δ [σ] =
+                 let ⊢ℕ  = ℕⱼ ⊢Δ
                      [ℕ] = ℕᵣ (idRed:*: (ℕⱼ ⊢Δ))
                  in  Uₜ ℕ (idRedTerm:*: ⊢ℕ) ℕₙ (≅ₜ-ℕrefl ⊢Δ) [ℕ]
                  ,   (λ x x₁ → Uₜ₌ ℕ ℕ (idRedTerm:*: ⊢ℕ) (idRedTerm:*: ⊢ℕ) ℕₙ ℕₙ
                                    (≅ₜ-ℕrefl ⊢Δ) [ℕ] [ℕ] (id (ℕⱼ ⊢Δ)))
 
--- Validity of zero.
-zeroᵛ : ∀ {l} ([Γ] : ⊩ᵛ Γ)
-      → Γ ⊩ᵛ⟨ l ⟩ zero ∷ ℕ / [Γ] / ℕᵛ [Γ]
-zeroᵛ [Γ] ⊢Δ [σ] =
-  ℕₜ zero (idRedTerm:*: (zeroⱼ ⊢Δ)) (≅ₜ-zerorefl ⊢Δ) zeroᵣ
+opaque
+  unfolding ℕᵛ
+
+  -- Validity of zero.
+  zeroᵛ : ∀ {l} ([Γ] : ⊩ᵛ Γ)
+        → Γ ⊩ᵛ⟨ l ⟩ zero ∷ ℕ / [Γ] / ℕᵛ [Γ]
+  zeroᵛ [Γ] ⊢Δ [σ] =
+      ℕₜ zero (idRedTerm:*: (zeroⱼ ⊢Δ)) (≅ₜ-zerorefl ⊢Δ) zeroᵣ
     , (λ _ x₁ → ℕₜ₌ zero zero (idRedTerm:*: (zeroⱼ ⊢Δ)) (idRedTerm:*: (zeroⱼ ⊢Δ))
                     (≅ₜ-zerorefl ⊢Δ) zeroᵣ)
 

--- a/Definition/LogicalRelation/Substitution/Introductions/Natrec.agda
+++ b/Definition/LogicalRelation/Substitution/Introductions/Natrec.agda
@@ -2,6 +2,8 @@
 -- Validity of natrec.
 ------------------------------------------------------------------------
 
+{-# OPTIONS --hidden-argument-puns #-}
+
 open import Definition.Typed.EqualityRelation
 open import Definition.Typed.Restrictions
 open import Graded.Modality
@@ -23,6 +25,7 @@ open import Definition.Typed.RedSteps R
 open import Definition.LogicalRelation R
 open import Definition.LogicalRelation.Irrelevance R
 open import Definition.LogicalRelation.Properties R
+import Definition.LogicalRelation.Properties.Escape as E
 open import Definition.LogicalRelation.Substitution R
 open import Definition.LogicalRelation.Substitution.Properties R
 import Definition.LogicalRelation.Substitution.Irrelevance R as S
@@ -30,6 +33,7 @@ open import Definition.LogicalRelation.Substitution.Reflexivity R
 open import Definition.LogicalRelation.Substitution.Introductions.Nat R
 
 open import Tools.Fin
+open import Tools.Function
 open import Tools.Nat
 open import Tools.Product
 open import Tools.Empty
@@ -37,7 +41,7 @@ import Tools.PropositionalEquality as PE
 
 private
   variable
-    m : Nat
+    k k′ m : Nat
     Γ Δ : Con Term m
     p p′ q q′ r r′ : M
 
@@ -74,25 +78,33 @@ sucCaseSubstEq F = PE.trans (substCompEq F)
                             (PE.trans (substVar-to-subst sucCaseSubst F)
                                       (PE.sym (substCompEq F)))
 
--- Reducibility of natural recursion under a valid substitution.
-natrecTerm : ∀ {F z s n σ l}
-             ([Γ]  : ⊩ᵛ Γ)
-             ([F]  : Γ ∙ ℕ ⊩ᵛ⟨ l ⟩ F / _∙_ {l = l} [Γ] (ℕᵛ [Γ]))
-             ([F₀] : Γ ⊩ᵛ⟨ l ⟩ F [ zero ]₀ / [Γ])
-             ([F₊] : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ F [ suc (var x1) ]↑² / ((_∙_ {l = l} [Γ] (ℕᵛ [Γ])) ∙ [F]))
-             ([z]  : Γ ⊩ᵛ⟨ l ⟩ z ∷ F [ zero ]₀ / [Γ] / [F₀])
-             ([s]  : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ s ∷ F [ suc (var x1) ]↑²
-                       / [Γ] ∙ (ℕᵛ {l = l} [Γ]) ∙ [F] / [F₊])
-             (⊢Δ   : ⊢ Δ)
-             ([σ]  : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
-             ([σn] : Δ ⊩⟨ l ⟩ n ∷ ℕ / ℕᵣ (idRed:*: (ℕⱼ ⊢Δ)))
-           → Δ ⊩⟨ l ⟩ natrec p q r (F [ liftSubst σ ]) (z [ σ ]) (s [ liftSubstn σ 2 ]) n
-               ∷ F [ liftSubst σ ] [ n ]₀
-               / irrelevance′ (PE.sym (singleSubstComp n σ F))
-                              (proj₁ (unwrap [F] ⊢Δ ([σ] , [σn])))
-natrecTerm {k} {Γ = Γ} {k′} {Δ = Δ} {p = p} {q} {r} {F = F} {z} {s} {n} {σ} {l} [Γ] [F] [F₀] [F₊] [z] [s] ⊢Δ [σ]
-           (ℕₜ .(suc m) d n≡n (sucᵣ {m} [m])) =
-  let [ℕ] = ℕᵛ {l = l} [Γ]
+opaque
+  unfolding ℕᵛ
+
+  -- Reducibility of natural recursion under a valid substitution.
+  natrecTerm :
+    ∀ {Γ : Con Term k} {Δ : Con Term k′} {F z s n σ l}
+    ([Γ]  : ⊩ᵛ Γ)
+    ([F]  : Γ ∙ ℕ ⊩ᵛ⟨ l ⟩ F / [Γ] ∙ ℕᵛ [Γ])
+    ([F₀] : Γ ⊩ᵛ⟨ l ⟩ F [ zero ]₀ / [Γ])
+    ([F₊] : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ F [ suc (var x1) ]↑² / [Γ] ∙ ℕᵛ [Γ] ∙ [F])
+    ([z]  : Γ ⊩ᵛ⟨ l ⟩ z ∷ F [ zero ]₀ / [Γ] / [F₀])
+    ([s]  : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ s ∷ F [ suc (var x1) ]↑²
+              / [Γ] ∙ ℕᵛ {l = l} [Γ] ∙ [F] / [F₊])
+    (⊢Δ   : ⊢ Δ)
+    ([σ]  : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
+    ([σn] : Δ ⊩⟨ l ⟩ n ∷ ℕ / ℕᵣ (idRed:*: (ℕⱼ ⊢Δ)))
+    (⊩F[⇑σ][n] : Δ ⊩⟨ l ⟩ F [ liftSubst σ ] [ n ]₀) →
+    Δ ⊩⟨ l ⟩
+      natrec p q r (F [ liftSubst σ ]) (z [ σ ])
+        (s [ liftSubstn σ 2 ]) n ∷
+      F [ liftSubst σ ] [ n ]₀ / ⊩F[⇑σ][n]
+  natrecTerm
+    {k} {k′} {p} {q} {r} {Γ} {Δ} {F} {z} {s} {n} {σ} {l}
+    [Γ] [F] [F₀] [F₊] [z] [s] ⊢Δ [σ]
+    (ℕₜ .(suc m) d n≡n (sucᵣ {n = m} [m])) ⊩F[⇑σ][n] =
+    let
+      [ℕ] = ℕᵛ {l = l} [Γ]
       [σℕ] = proj₁ (unwrap [ℕ] ⊢Δ [σ])
       [Γℕ] = _∙_ {A = ℕ} [Γ] [ℕ]
       ⊢ℕ = escape [σℕ]
@@ -126,10 +138,12 @@ natrecTerm {k} {Γ = Γ} {k′} {Δ = Δ} {p = p} {q} {r} {F = F} {z} {s} {n} {�
                                  [σFₙ]′ [σFₙ]
                                  (proj₂ (unwrap [F] ⊢Δ ([σ] , [σn])) ([σ] , [σsm])
                                         (reflSubst [Γ] ⊢Δ [σ] , [σn≡σsm]))
+      ⊩F[⇑σ][m] = irrelevance′ (PE.sym (singleSubstComp m σ F))
+                    (proj₁ (unwrap [F] ⊢Δ ([σ] , [m])))
       [natrecM]′ = natrecTerm {p = p} {r = r} {F = F} {z = z} {s = s}
-                              [Γ] [F] [F₀] [F₊] [z] [s] ⊢Δ [σ] [m]
+                     [Γ] [F] [F₀] [F₊] [z] [s] ⊢Δ [σ] [m] ⊩F[⇑σ][m]
       [natrecM] = irrelevanceTerm′ (singleSubstComp m σ F)
-                                   (irrelevance′ (PE.sym (singleSubstComp m σ F)) (proj₁ (unwrap [F] ⊢Δ ([σ] , [m]))))
+                                   ⊩F[⇑σ][m]
                                    (proj₁ (unwrap [F] ⊢Δ ([σ] , [m])) )
                                    [natrecM]′
       [natrec]′ = proj₁ ([s] {σ = consSubst (consSubst σ m) (natrec p q r _ _ _ m)}
@@ -154,13 +168,17 @@ natrecTerm {k} {Γ = Γ} {k′} {Δ = Δ} {p = p} {q} {r} {F = F} {z} {s} {n} {�
                             (doubleSubstComp s m (natrec p q r (F [ liftSubst σ ]) (z [ σ ])
                                                                (s [ liftSubstn σ 2 ]) m) σ)
                             (reduction ⇨∷* reduction′)
-  in proj₁ (redSubst*Term reduction″ [σFₙ]
-                          (convTerm₂ [σFₙ] [σFₛₘ] [Fₙ≡Fₛₘ] [natrec]))
+    in irrelevanceTerm [σFₙ] ⊩F[⇑σ][n] $
+       redSubst*Term reduction″ [σFₙ]
+         (convTerm₂ [σFₙ] [σFₛₘ] [Fₙ≡Fₛₘ] [natrec])
+         .proj₁
 
-natrecTerm {k} {Γ = Γ} {k′} {Δ = Δ} {r = r} {F = F} {z} {s} {n} {σ} {l}
-           [Γ] [F] [F₀] [F₊] [z] [s] ⊢Δ [σ]
-           (ℕₜ .zero d n≡n zeroᵣ) =
-  let [ℕ] = ℕᵛ {l = l} [Γ]
+  natrecTerm
+    {k} {k′} {r} {Γ} {Δ} {F} {z} {s} {n} {σ} {l}
+    [Γ] [F] [F₀] [F₊] [z] [s] ⊢Δ [σ]
+    (ℕₜ .zero d n≡n zeroᵣ) ⊩F[⇑σ][n] =
+    let
+      [ℕ] = ℕᵛ {l = l} [Γ]
       [σℕ] = proj₁ (unwrap [ℕ] ⊢Δ [σ])
       [Γℕ] = _∙_ {A = ℕ} [Γ] [ℕ]
       ⊢ℕ = escape (proj₁ (unwrap [ℕ] ⊢Δ [σ]))
@@ -203,13 +221,17 @@ natrecTerm {k} {Γ = Γ} {k′} {Δ = Δ} {r = r} {F = F} {z} {s} {n} {σ} {l}
                                                                 [t≡t′])))))
                   ⇨∷* (conv* (natrec-zero ⊢F ⊢z ⊢s ⇨ id ⊢z)
                              (sym (≅-eq (escapeEq [σFₙ] [Fₙ≡F₀]″))))
-  in  proj₁ (redSubst*Term reduction [σFₙ]
-                           (convTerm₂ [σFₙ] (proj₁ (unwrap [F₀] ⊢Δ [σ])) [Fₙ≡F₀] [σz]))
+    in irrelevanceTerm [σFₙ] ⊩F[⇑σ][n] $
+       redSubst*Term reduction [σFₙ]
+         (convTerm₂ [σFₙ] (proj₁ (unwrap [F₀] ⊢Δ [σ])) [Fₙ≡F₀] [σz])
+         .proj₁
 
-natrecTerm {k} {Γ = Γ} {k′} {Δ = Δ} {p = p} {r = r} {F = F} {z} {s} {n} {σ} {l}
-           [Γ] [F] [F₀] [F₊] [z] [s] ⊢Δ [σ]
-           (ℕₜ m d n≡n (ne (neNfₜ neM ⊢m m≡m))) =
-  let [ℕ] = ℕᵛ {l = l} [Γ]
+  natrecTerm
+    {k} {k′} {p} {r} {Γ} {Δ} {F} {z} {s} {n} {σ} {l}
+    [Γ] [F] [F₀] [F₊] [z] [s] ⊢Δ [σ]
+    (ℕₜ m d n≡n (ne (neNfₜ neM ⊢m m≡m))) ⊩F[⇑σ][n] =
+    let
+      [ℕ] = ℕᵛ {l = l} [Γ]
       [σℕ] = proj₁ (unwrap [ℕ] ⊢Δ [σ])
       [Γℕ] = _∙_ {A = ℕ} [Γ] [ℕ]
       ⊢ℕ = escape (proj₁ (unwrap [ℕ] ⊢Δ [σ]))
@@ -258,62 +280,69 @@ natrecTerm {k} {Γ = Γ} {k′} {Δ = Δ} {p = p} {r = r} {F = F} {z} {s} {n} {�
                                                      ([σ] , [t′])
                                                      (reflSubst [Γ] ⊢Δ [σ] ,
                                                                 [t≡t′])))))
-  in  proj₁ (redSubst*Term reduction [σFₙ]
-                           (convTerm₂ [σFₙ] [σFₘ] [Fₙ≡Fₘ] natrecM))
+    in  irrelevanceTerm [σFₙ] ⊩F[⇑σ][n] $
+        redSubst*Term reduction [σFₙ]
+          (convTerm₂ [σFₙ] [σFₘ] [Fₙ≡Fₘ] natrecM)
+          .proj₁
 
+opaque
+  unfolding ℕᵛ E.escape idRed:*:
 
--- Reducibility of natural recursion congruence under a valid substitution equality.
-natrec-congTerm : ∀ {F F′ z z′ s s′ n m σ σ′ l}
-                  ([Γ]      : ⊩ᵛ Γ)
-                  ([F]      : Γ ∙ ℕ ⊩ᵛ⟨ l ⟩ F / _∙_ {l = l} [Γ] (ℕᵛ [Γ]))
-                  ([F′]     : Γ ∙ ℕ ⊩ᵛ⟨ l ⟩ F′ / _∙_ {l = l} [Γ] (ℕᵛ [Γ]))
-                  ([F≡F′]   : Γ ∙ ℕ ⊩ᵛ⟨ l ⟩ F ≡ F′ / _∙_ {l = l} [Γ] (ℕᵛ [Γ])
-                                    / [F])
-                  ([F₀]     : Γ ⊩ᵛ⟨ l ⟩ F [ zero ]₀ / [Γ])
-                  ([F′₀]    : Γ ⊩ᵛ⟨ l ⟩ F′ [ zero ]₀ / [Γ])
-                  ([F₀≡F′₀] : Γ ⊩ᵛ⟨ l ⟩ F [ zero ]₀ ≡ F′ [ zero ]₀ / [Γ] / [F₀])
-                  ([F₊]     : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ F [ suc (var x1) ]↑²
-                                /  _∙_ {l = l} [Γ] (ℕᵛ [Γ]) ∙ [F])
-                  ([F′₊]    : Γ ∙ ℕ ∙ F′ ⊩ᵛ⟨ l ⟩ F′ [ suc (var x1) ]↑²
-                                / _∙_ {l = l} [Γ] (ℕᵛ [Γ]) ∙ [F′])
-                  ([F₊≡F₊′] : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ F [ suc (var x1) ]↑²
-                                ≡ F′ [ suc (var x1) ]↑²
-                                / _∙_ {l = l} [Γ] (ℕᵛ [Γ]) ∙ [F] / [F₊])
-                  ([z]      : Γ ⊩ᵛ⟨ l ⟩ z ∷ F [ zero ]₀ / [Γ] / [F₀])
-                  ([z′]     : Γ ⊩ᵛ⟨ l ⟩ z′ ∷ F′ [ zero ]₀ / [Γ] / [F′₀])
-                  ([z≡z′]   : Γ ⊩ᵛ⟨ l ⟩ z ≡ z′ ∷ F [ zero ]₀ / [Γ] / [F₀])
-                  ([s]      : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ s ∷ F [ suc (var x1) ]↑²
-                                / _∙_ {l = l} [Γ] (ℕᵛ [Γ]) ∙ [F] / [F₊])
-                  ([s′]     : Γ ∙ ℕ ∙ F′ ⊩ᵛ⟨ l ⟩ s′
-                                ∷ F′ [ suc (var x1) ]↑²
-                                / _∙_ {l = l} [Γ] (ℕᵛ [Γ]) ∙ [F′] / [F′₊])
-                  ([s≡s′]   : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ s ≡ s′
-                                ∷ F [ suc (var x1) ]↑²
-                                / _∙_ {l = l} [Γ] (ℕᵛ [Γ]) ∙ [F] / [F₊])
-                  (⊢Δ       : ⊢ Δ)
-                  ([σ]      : Δ ⊩ˢ σ  ∷ Γ / [Γ] / ⊢Δ)
-                  ([σ′]     : Δ ⊩ˢ σ′ ∷ Γ / [Γ] / ⊢Δ)
-                  ([σ≡σ′]   : Δ ⊩ˢ σ ≡ σ′ ∷ Γ / [Γ] / ⊢Δ / [σ])
-                  ([σn]     : Δ ⊩⟨ l ⟩ n ∷ ℕ / ℕᵣ (idRed:*: (ℕⱼ ⊢Δ)))
-                  ([σm]     : Δ ⊩⟨ l ⟩ m ∷ ℕ / ℕᵣ (idRed:*: (ℕⱼ ⊢Δ)))
-                  ([σn≡σm]  : Δ ⊩⟨ l ⟩ n ≡ m ∷ ℕ / ℕᵣ (idRed:*: (ℕⱼ ⊢Δ)))
-                → Δ ⊩⟨ l ⟩ natrec p q r (F [ liftSubst σ ])
-                                  (z [ σ ]) (s [ liftSubstn σ 2 ]) n
-                    ≡ natrec p q r (F′ [ liftSubst σ′ ])
-                             (z′ [ σ′ ]) (s′ [ liftSubstn σ′ 2 ]) m
-                    ∷ F [ liftSubst σ ] [ n ]₀
-                    / irrelevance′ (PE.sym (singleSubstComp n σ F))
-                                   (proj₁ (unwrap [F] ⊢Δ ([σ] , [σn])))
-natrec-congTerm {k} {Γ = Γ} {k′} {Δ = Δ} {p = p} {q} {r}
-                {F = F} {F′ = F′} {z = z} {z′ = z′}
-                {s = s} {s′ = s′} {n = n} {m = m} {σ = σ} {σ′ = σ′} {l = l}
-                [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                (ℕₜ .(suc n′) d n≡n (sucᵣ {n′} [n′]))
-                (ℕₜ .(suc m′) d′ m≡m (sucᵣ {m′} [m′]))
-                (ℕₜ₌ .(suc n″) .(suc m″) d₁ d₁′
-                     t≡u (sucᵣ {n″} {m″} [n″≡m″])) =
-  let n″≡n′ = suc-PE-injectivity (whrDet*Term (redₜ d₁ , sucₙ) (redₜ d , sucₙ))
+  -- Reducibility of natural recursion congruence under a valid
+  -- substitution equality.
+  natrec-congTerm :
+    ∀ {Γ : Con Term k} {Δ : Con Term k′} {F F′ z z′ s s′ n m σ σ′ l}
+    ([Γ]      : ⊩ᵛ Γ)
+    ([F]      : Γ ∙ ℕ ⊩ᵛ⟨ l ⟩ F / [Γ] ∙ ℕᵛ {l = l} [Γ])
+    ([F′]     : Γ ∙ ℕ ⊩ᵛ⟨ l ⟩ F′ / [Γ] ∙ ℕᵛ {l = l} [Γ])
+    ([F≡F′]   : Γ ∙ ℕ ⊩ᵛ⟨ l ⟩ F ≡ F′ / [Γ] ∙ ℕᵛ [Γ] / [F])
+    ([F₀]     : Γ ⊩ᵛ⟨ l ⟩ F [ zero ]₀ / [Γ])
+    ([F′₀]    : Γ ⊩ᵛ⟨ l ⟩ F′ [ zero ]₀ / [Γ])
+    ([F₀≡F′₀] : Γ ⊩ᵛ⟨ l ⟩ F [ zero ]₀ ≡ F′ [ zero ]₀ / [Γ] / [F₀])
+    ([F₊]     : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ F [ suc (var x1) ]↑² /
+                  [Γ] ∙ ℕᵛ [Γ] ∙ [F])
+    ([F′₊]    : Γ ∙ ℕ ∙ F′ ⊩ᵛ⟨ l ⟩ F′ [ suc (var x1) ]↑² /
+                  [Γ] ∙ ℕᵛ [Γ] ∙ [F′])
+    ([F₊≡F₊′] : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩
+                  F [ suc (var x1) ]↑² ≡
+                  F′ [ suc (var x1) ]↑² /
+                  [Γ] ∙ ℕᵛ [Γ] ∙ [F] / [F₊])
+    ([z]      : Γ ⊩ᵛ⟨ l ⟩ z ∷ F [ zero ]₀ / [Γ] / [F₀])
+    ([z′]     : Γ ⊩ᵛ⟨ l ⟩ z′ ∷ F′ [ zero ]₀ / [Γ] / [F′₀])
+    ([z≡z′]   : Γ ⊩ᵛ⟨ l ⟩ z ≡ z′ ∷ F [ zero ]₀ / [Γ] / [F₀])
+    ([s]      : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ s ∷ F [ suc (var x1) ]↑² /
+                  [Γ] ∙ ℕᵛ [Γ] ∙ [F] / [F₊])
+    ([s′]     : Γ ∙ ℕ ∙ F′ ⊩ᵛ⟨ l ⟩ s′ ∷ F′ [ suc (var x1) ]↑² /
+                  [Γ] ∙ ℕᵛ [Γ] ∙ [F′] / [F′₊])
+    ([s≡s′]   : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ s ≡ s′ ∷ F [ suc (var x1) ]↑² /
+                  [Γ] ∙ ℕᵛ [Γ] ∙ [F] / [F₊])
+    (⊢Δ       : ⊢ Δ)
+    ([σ]      : Δ ⊩ˢ σ  ∷ Γ / [Γ] / ⊢Δ)
+    ([σ′]     : Δ ⊩ˢ σ′ ∷ Γ / [Γ] / ⊢Δ)
+    ([σ≡σ′]   : Δ ⊩ˢ σ ≡ σ′ ∷ Γ / [Γ] / ⊢Δ / [σ])
+    ([σn]     : Δ ⊩⟨ l ⟩ n ∷ ℕ / ℕᵣ (idRed:*: (ℕⱼ ⊢Δ)))
+    ([σm]     : Δ ⊩⟨ l ⟩ m ∷ ℕ / ℕᵣ (idRed:*: (ℕⱼ ⊢Δ)))
+    ([σn≡σm]  : Δ ⊩⟨ l ⟩ n ≡ m ∷ ℕ / ℕᵣ (idRed:*: (ℕⱼ ⊢Δ)))
+    (⊩F[⇑σ][n] : Δ ⊩⟨ l ⟩ F [ liftSubst σ ] [ n ]₀) →
+    Δ ⊩⟨ l ⟩
+      natrec p q r (F [ liftSubst σ ]) (z [ σ ])
+        (s [ liftSubstn σ 2 ]) n ≡
+      natrec p q r (F′ [ liftSubst σ′ ]) (z′ [ σ′ ])
+        (s′ [ liftSubstn σ′ 2 ]) m ∷
+      F [ liftSubst σ ] [ n ]₀ /
+      ⊩F[⇑σ][n]
+  natrec-congTerm
+    {k} {k′} {p} {q} {r} {Γ} {Δ}
+    {F} {F′} {z} {z′} {s} {s′} {n} {m} {σ} {σ′} {l}
+    [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
+    [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
+    (ℕₜ .(suc n′) d n≡n (sucᵣ {n = n′} [n′]))
+    (ℕₜ .(suc m′) d′ m≡m (sucᵣ {n = m′} [m′]))
+    (ℕₜ₌ .(suc n″) .(suc m″) d₁ d₁′ t≡u
+       (sucᵣ {n = n″} {n′ = m″} [n″≡m″]))
+    ⊩F[⇑σ][n] =
+    let
+      n″≡n′ = suc-PE-injectivity (whrDet*Term (redₜ d₁ , sucₙ) (redₜ d , sucₙ))
       m″≡m′ = suc-PE-injectivity (whrDet*Term (redₜ d₁′ , sucₙ) (redₜ d′ , sucₙ))
       [ℕ] = ℕᵛ {l = l} [Γ]
       [Γℕ] = _∙_ {A = ℕ} [Γ] [ℕ]
@@ -412,10 +441,11 @@ natrec-congTerm {k} {Γ = Γ} {k′} {Δ = Δ} {p = p} {q} {r}
       [σFₙ≡σ′F′ₘ] = transEq [σFₙ] [σ′Fₘ] [σ′F′ₘ] [σFₙ≡σ′Fₘ] [σ′Fₘ≡σ′F′ₘ]
       [σFₙ≡σ′Fₛₘ′] = transEq [σFₙ] [σ′Fₘ] [σ′Fₛₘ′] [σFₙ≡σ′Fₘ] [Fₘ≡Fₛₘ′]
       natrecN = natrecTerm {p = p} {r = r} {F = F} {z} {s} {n′} {σ = σ}
-                           [Γ] [F] [F₀] [F₊] [z] [s] ⊢Δ [σ] [n′]
+                           [Γ] [F] [F₀] [F₊] [z] [s] ⊢Δ [σ] [n′] [σFₙ′]
       natrecN′ = irrelevanceTerm′ (singleSubstComp n′ σ F) [σFₙ′] [σFₙ′]′ natrecN
       natrecM = natrecTerm {p = p} {r = r} {F = F′} {z′} {s′} {m′} {σ = σ′}
                            [Γ] [F′] [F′₀] [F′₊] [z′] [s′] ⊢Δ [σ′] [m′]
+                           [σ′F′ₘ′]
       natrecM′ = irrelevanceTerm′ (singleSubstComp m′ σ′ F′) [σ′F′ₘ′] [σ′F′ₘ′]′ natrecM
       natrecM″ = convTerm₂ [σ′Fₘ′] [σ′F′ₘ′] [σ′Fₘ′≡σ′F′ₘ′] natrecM
       natrecM‴ = irrelevanceTerm′ (singleSubstComp m′ σ′ F) [σ′Fₘ′] [σ′Fₘ′]′ natrecM″
@@ -427,6 +457,7 @@ natrec-congTerm {k} {Γ = Γ} {k′} {Δ = Δ} {p = p} {q} {r}
                                  [F₊] [F′₊] [F₊≡F′₊] [z] [z′] [z≡z′]
                                  [s] [s′] [s≡s′]
                                  ⊢Δ [σ] [σ′] [σ≡σ′] [n′] [m′] [n′≡m′]
+                                 [σFₙ′]
       [nr≡nr′]′ = irrelevanceEqTerm′ (singleSubstComp n′ σ F) [σFₙ′] [σFₙ′]′ [nr≡nr′]
       σ₊ = consSubst (consSubst σ n′) (natrec p q r (F [ liftSubst σ ])
                                               (z [ σ ]) (s [ liftSubstn σ 2 ]) n′)
@@ -489,18 +520,21 @@ natrec-congTerm {k} {Γ = Γ} {k′} {Δ = Δ} {p = p} {q} {r}
                                  (convTerm₂ [σ′F′ₘ] [σ′F′ₛₘ′]
                                             [F′ₘ≡F′ₛₘ′] [s′₊]′))
       eq₄′ = convEqTerm₂ [σFₙ] [σ′F′ₘ] [σFₙ≡σ′F′ₘ] eq₄
-  in  transEqTerm [σFₙ] eq₁′
-                  (transEqTerm [σFₙ] eq₂″
-                               (transEqTerm [σFₙ] eq₃″ (symEqTerm [σFₙ] eq₄′)))
+    in irrelevanceEqTerm [σFₙ] ⊩F[⇑σ][n] $
+       transEqTerm [σFₙ] eq₁′
+         (transEqTerm [σFₙ] eq₂″
+            (transEqTerm [σFₙ] eq₃″ (symEqTerm [σFₙ] eq₄′)))
 
-natrec-congTerm {Γ = Γ} {k′} {Δ = Δ} {p = p} {q} {r}
-                {F = F} {F′ = F′} {z = z} {z′ = z′} {s = s}
-                {s′ = s′} {n = n} {m = m} {σ = σ} {σ′ = σ′} {l = l}
-                [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                (ℕₜ .zero d n≡n zeroᵣ) (ℕₜ .zero d₁ m≡m zeroᵣ)
-                (ℕₜ₌ .zero .zero d₂ d′ t≡u zeroᵣ) =
-  let [ℕ] = ℕᵛ {l = l} [Γ]
+  natrec-congTerm
+    {k′} {p} {q} {r} {Γ} {Δ}
+    {F} {F′} {z} {z′} {s} {s′} {n} {m} {σ} {σ′} {l}
+    [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
+    [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
+    (ℕₜ .zero d n≡n zeroᵣ) (ℕₜ .zero d₁ m≡m zeroᵣ)
+    (ℕₜ₌ .zero .zero d₂ d′ t≡u zeroᵣ)
+    ⊩F[⇑σ][n] =
+    let
+      [ℕ] = ℕᵛ {l = l} [Γ]
       [σℕ] = proj₁ (unwrap [ℕ] ⊢Δ [σ])
       ⊢ℕ = escape [σℕ]
       ⊢F = escape (proj₁ (unwrap [F] {σ = liftSubst σ} (⊢Δ ∙ ⊢ℕ)
@@ -610,19 +644,23 @@ natrec-congTerm {Γ = Γ} {k′} {Δ = Δ} {p = p} {q} {r}
       eq₂ = proj₂ (redSubst*Term reduction₂ [σ′F′ₘ]
                                  (convTerm₂ [σ′F′ₘ] (proj₁ (unwrap [F′₀] ⊢Δ [σ′]))
                                             [F′ₘ≡F′₀] [σ′z′]))
-  in  transEqTerm [σFₙ] eq₁
-                  (transEqTerm [σFₙ] [σz≡σ′z′]
-                               (convEqTerm₂ [σFₙ] [σ′F′ₘ] [σFₙ≡σ′F′ₘ]
-                                            (symEqTerm [σ′F′ₘ] eq₂)))
+    in irrelevanceEqTerm [σFₙ] ⊩F[⇑σ][n] $
+       transEqTerm [σFₙ] eq₁
+         (transEqTerm [σFₙ] [σz≡σ′z′]
+            (convEqTerm₂ [σFₙ] [σ′F′ₘ] [σFₙ≡σ′F′ₘ]
+               (symEqTerm [σ′F′ₘ] eq₂)))
 
-natrec-congTerm {k} {Γ = Γ} {k′} {Δ = Δ} {p = p} {q} {r}
-                {F = F} {F′} {z} {z′} {s} {s′} {n} {m} {σ} {σ′} {l}
-                [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                (ℕₜ n′ d n≡n (ne (neNfₜ neN′ ⊢n′ n≡n₁)))
-                (ℕₜ m′ d′ m≡m (ne (neNfₜ neM′ ⊢m′ m≡m₁)))
-                (ℕₜ₌ n″ m″ d₁ d₁′ t≡u (ne (neNfₜ₌ x₂ x₃ prop₂))) =
-  let n″≡n′ = whrDet*Term (redₜ d₁ , ne x₂) (redₜ d , ne neN′)
+  natrec-congTerm
+    {k} {k′} {p} {q} {r} {Γ} {Δ}
+    {F} {F′} {z} {z′} {s} {s′} {n} {m} {σ} {σ′} {l}
+    [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
+    [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
+    (ℕₜ n′ d n≡n (ne (neNfₜ neN′ ⊢n′ n≡n₁)))
+    (ℕₜ m′ d′ m≡m (ne (neNfₜ neM′ ⊢m′ m≡m₁)))
+    (ℕₜ₌ n″ m″ d₁ d₁′ t≡u (ne (neNfₜ₌ x₂ x₃ prop₂)))
+    ⊩F[⇑σ][n] =
+    let
+      n″≡n′ = whrDet*Term (redₜ d₁ , ne x₂) (redₜ d , ne neN′)
       m″≡m′ = whrDet*Term (redₜ d₁′ , ne x₃) (redₜ d′ , ne neM′)
       [ℕ] = ℕᵛ {l = l} [Γ]
       [σℕ] = proj₁ (unwrap [ℕ] ⊢Δ [σ])
@@ -798,94 +836,89 @@ natrec-congTerm {k} {Γ = Γ} {k′} {Δ = Δ} {p = p} {q} {r}
                                  (convTerm₂ [σFₙ] [σFₙ′] [Fₙ≡Fₙ′] natrecN))
       eq₂ = proj₂ (redSubst*Term reduction₂ [σ′F′ₘ]
                                  (convTerm₂ [σ′F′ₘ] [σ′F′ₘ′] [F′ₘ≡F′ₘ′] natrecM))
-  in  transEqTerm [σFₙ] eq₁
-                 (transEqTerm [σFₙ] natrecN≡M
-                              (convEqTerm₂ [σFₙ] [σ′F′ₘ] [σFₙ≡σ′F′ₘ] (symEqTerm [σ′F′ₘ] eq₂)))
+    in irrelevanceEqTerm [σFₙ] ⊩F[⇑σ][n] $
+       transEqTerm [σFₙ] eq₁
+         (transEqTerm [σFₙ] natrecN≡M
+            (convEqTerm₂ [σFₙ] [σ′F′ₘ] [σFₙ≡σ′F′ₘ]
+               (symEqTerm [σ′F′ₘ] eq₂)))
 
--- Refuting cases
-natrec-congTerm [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                [σn] (ℕₜ _ d₁ _ zeroᵣ)
-                (ℕₜ₌ _ _ d₂ d′ t≡u (sucᵣ prop₂))
-  with whrDet*Term (redₜ d₁ , zeroₙ) (redₜ d′ , sucₙ)
-... | ()
-natrec-congTerm [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                [σn] (ℕₜ n d₁ _ (ne (neNfₜ neK ⊢k k≡k)))
-                (ℕₜ₌ _ _ d₂ d′ t≡u (sucᵣ prop₂)) =
-  ⊥-elim (suc≢ne neK (whrDet*Term (redₜ d′ , sucₙ) (redₜ d₁ , ne neK)))
-natrec-congTerm [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                (ℕₜ _ d _ zeroᵣ) [σm]
-                (ℕₜ₌ _ _ d₁ d′ t≡u (sucᵣ prop₂))
-  with whrDet*Term (redₜ d , zeroₙ) (redₜ d₁ , sucₙ)
-... | ()
-natrec-congTerm [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                (ℕₜ n d _ (ne (neNfₜ neK ⊢k k≡k))) [σm]
-                (ℕₜ₌ _ _ d₁ d′ t≡u (sucᵣ prop₂)) =
-  ⊥-elim (suc≢ne neK (whrDet*Term (redₜ d₁ , sucₙ) (redₜ d , ne neK)))
+  -- Refuting cases
+  natrec-congTerm
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (ℕₜ _ d₁ _ zeroᵣ) (ℕₜ₌ _ _ _ d₂ _ (sucᵣ _))
+    with whrDet*Term (redₜ d₁ , zeroₙ) (redₜ d₂ , sucₙ)
+  ... | ()
+  natrec-congTerm
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (ℕₜ _ d₁ _ (ne (neNfₜ n _ _))) (ℕₜ₌ _ _ _ d₂ _ (sucᵣ _)) =
+    ⊥-elim $
+    suc≢ne n (whrDet*Term (redₜ d₂ , sucₙ) (redₜ d₁ , ne n))
+  natrec-congTerm
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (ℕₜ _ d₁ _ zeroᵣ) _ (ℕₜ₌ _ _ d₂ _ _ (sucᵣ _))
+    with whrDet*Term (redₜ d₁ , zeroₙ) (redₜ d₂ , sucₙ)
+  ... | ()
+  natrec-congTerm
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (ℕₜ _ d₁ _ (ne (neNfₜ n _ _))) _ (ℕₜ₌ _ _ d₂ _ _ (sucᵣ _)) =
+    ⊥-elim $
+    suc≢ne n (whrDet*Term (redₜ d₂ , sucₙ) (redₜ d₁ , ne n))
+  natrec-congTerm
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (ℕₜ _ d₁ _ (sucᵣ _)) _ (ℕₜ₌ _ _ d₂ _ _ zeroᵣ)
+    with whrDet*Term (redₜ d₂ , zeroₙ) (redₜ d₁ , sucₙ)
+  ... | ()
+  natrec-congTerm
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (ℕₜ _ d₁ _ (sucᵣ _)) (ℕₜ₌ _ _ _ d₂ _ zeroᵣ)
+    with whrDet*Term (redₜ d₂ , zeroₙ) (redₜ d₁ , sucₙ)
+  ... | ()
+  natrec-congTerm
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (ℕₜ _ d₁ _ (ne (neNfₜ n _ _))) (ℕₜ₌ _ _ _ d₂ _ zeroᵣ) =
+    ⊥-elim $ zero≢ne n (whrDet*Term (redₜ d₂ , zeroₙ) (redₜ d₁ , ne n))
+  natrec-congTerm
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (ℕₜ _ d₁ _ (ne (neNfₜ n _ _))) _ (ℕₜ₌ _ _ d₂ _ _ zeroᵣ) =
+    ⊥-elim $ zero≢ne n (whrDet*Term (redₜ d₂ , zeroₙ) (redₜ d₁ , ne n))
+  natrec-congTerm
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (ℕₜ _ d₁ _ (sucᵣ _)) _ (ℕₜ₌ _ _ d₂ _ _ (ne (neNfₜ₌ n _ _))) =
+    ⊥-elim $ suc≢ne n (whrDet*Term (redₜ d₁ , sucₙ) (redₜ d₂ , ne n))
+  natrec-congTerm
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (ℕₜ _ d₁ _ zeroᵣ) _ (ℕₜ₌ _ _ d₂ _ _ (ne (neNfₜ₌ n _ _))) =
+    ⊥-elim $ zero≢ne n (whrDet*Term (redₜ d₁ , zeroₙ) (redₜ d₂ , ne n))
+  natrec-congTerm
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (ℕₜ _ d₁ _ (sucᵣ _)) (ℕₜ₌ _ _ _ d₂ _ (ne (neNfₜ₌ _ n _))) =
+    ⊥-elim $ suc≢ne n (whrDet*Term (redₜ d₁ , sucₙ) (redₜ d₂ , ne n))
+  natrec-congTerm
+    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+    (ℕₜ _ d₁ _ zeroᵣ) (ℕₜ₌ _ _ _ d₂ _ (ne (neNfₜ₌ _ n _))) =
+    ⊥-elim $ zero≢ne n (whrDet*Term (redₜ d₁ , zeroₙ) (redₜ d₂ , ne n))
 
-natrec-congTerm [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                (ℕₜ _ d _ (sucᵣ prop)) [σm]
-                (ℕₜ₌ _ _ d₂ d′ t≡u zeroᵣ)
-  with whrDet*Term (redₜ d₂ , zeroₙ) (redₜ d , sucₙ)
-... | ()
-natrec-congTerm [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                [σn] (ℕₜ _ d₁ _ (sucᵣ prop₁))
-                (ℕₜ₌ _ _ d₂ d′ t≡u zeroᵣ)
-  with whrDet*Term (redₜ d′ , zeroₙ) (redₜ d₁ , sucₙ)
-... | ()
-natrec-congTerm [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                [σn] (ℕₜ n d₁ _ (ne (neNfₜ neK ⊢k k≡k)))
-                (ℕₜ₌ _ _ d₂ d′ t≡u zeroᵣ) =
-  ⊥-elim (zero≢ne neK (whrDet*Term (redₜ d′ , zeroₙ) (redₜ d₁ , ne neK)))
-natrec-congTerm [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                (ℕₜ n d _ (ne (neNfₜ neK ⊢k k≡k))) [σm]
-                (ℕₜ₌ _ _ d₂ d′ t≡u zeroᵣ) =
-  ⊥-elim (zero≢ne neK (whrDet*Term (redₜ d₂ , zeroₙ) (redₜ d , ne neK)))
+opaque
+  unfolding ℕᵛ
 
-natrec-congTerm [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                (ℕₜ _ d _ (sucᵣ prop)) [σm]
-                (ℕₜ₌ n₁ n′ d₂ d′ t≡u (ne (neNfₜ₌ x x₁ prop₂))) =
-  ⊥-elim (suc≢ne x (whrDet*Term (redₜ d , sucₙ) (redₜ d₂ , ne x)))
-natrec-congTerm [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                (ℕₜ _ d _ zeroᵣ) [σm]
-                (ℕₜ₌ n₁ n′ d₂ d′ t≡u (ne (neNfₜ₌ x x₁ prop₂))) =
-  ⊥-elim (zero≢ne x (whrDet*Term (redₜ d , zeroₙ) (redₜ d₂ , ne x)))
-natrec-congTerm [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                [σn] (ℕₜ _ d₁ _ (sucᵣ prop₁))
-                (ℕₜ₌ n₁ n′ d₂ d′ t≡u (ne (neNfₜ₌ x₁ x₂ prop₂))) =
-  ⊥-elim (suc≢ne x₂ (whrDet*Term (redₜ d₁ , sucₙ) (redₜ d′ , ne x₂)))
-natrec-congTerm [Γ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-                [z] [z′] [z≡z′] [s] [s′] [s≡s′] ⊢Δ [σ] [σ′] [σ≡σ′]
-                [σn] (ℕₜ _ d₁ _ zeroᵣ)
-                (ℕₜ₌ n₁ n′ d₂ d′ t≡u (ne (neNfₜ₌ x₁ x₂ prop₂))) =
-  ⊥-elim (zero≢ne x₂ (whrDet*Term (redₜ d₁ , zeroₙ) (redₜ d′ , ne x₂)))
-
-
--- Validity of natural recursion.
-natrecᵛ : ∀ {F z s n l} ([Γ] : ⊩ᵛ Γ)
-          ([ℕ]  : Γ ⊩ᵛ⟨ l ⟩ ℕ / [Γ])
-          ([F]  : Γ ∙ ℕ ⊩ᵛ⟨ l ⟩ F / [Γ] ∙ [ℕ])
-          ([F₀] : Γ ⊩ᵛ⟨ l ⟩ F [ zero ]₀ / [Γ])
-          ([F₊] : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ F [ suc (var x1) ]↑² / [Γ] ∙ [ℕ] ∙ [F])
-          ([Fₙ] : Γ ⊩ᵛ⟨ l ⟩ F [ n ]₀ / [Γ])
-        → Γ ⊩ᵛ⟨ l ⟩ z ∷ F [ zero ]₀ / [Γ] / [F₀]
-        → Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ s ∷ F [ suc (var x1) ]↑² / [Γ] ∙ [ℕ] ∙ [F] / [F₊]
-        → ([n] : Γ ⊩ᵛ⟨ l ⟩ n ∷ ℕ / [Γ] / [ℕ])
-        → Γ ⊩ᵛ⟨ l ⟩ natrec p q r F z s n ∷ F [ n ]₀ / [Γ] / [Fₙ]
-natrecᵛ {F = F} {z = z} {s = s} {n = n} {l = l}
-        [Γ] [ℕ] [F] [F₀] [F₊] [Fₙ] [z] [s] [n]
-        {Δ = Δ} {σ = σ} ⊢Δ [σ] =
-  let [F]′ = S.irrelevance {A = F} (_∙_ {A = ℕ} [Γ] [ℕ])
+  -- Validity of natural recursion.
+  natrecᵛ :
+    ∀ {F z s n l} ([Γ] : ⊩ᵛ Γ)
+    ([ℕ]  : Γ ⊩ᵛ⟨ l ⟩ ℕ / [Γ])
+    ([F]  : Γ ∙ ℕ ⊩ᵛ⟨ l ⟩ F / [Γ] ∙ [ℕ])
+    ([F₀] : Γ ⊩ᵛ⟨ l ⟩ F [ zero ]₀ / [Γ])
+    ([F₊] : Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ F [ suc (var x1) ]↑² / [Γ] ∙ [ℕ] ∙ [F])
+    ([Fₙ] : Γ ⊩ᵛ⟨ l ⟩ F [ n ]₀ / [Γ]) →
+    Γ ⊩ᵛ⟨ l ⟩ z ∷ F [ zero ]₀ / [Γ] / [F₀] →
+    Γ ∙ ℕ ∙ F ⊩ᵛ⟨ l ⟩ s ∷ F [ suc (var x1) ]↑² / [Γ] ∙ [ℕ] ∙ [F] /
+      [F₊] →
+    ([n] : Γ ⊩ᵛ⟨ l ⟩ n ∷ ℕ / [Γ] / [ℕ]) →
+    Γ ⊩ᵛ⟨ l ⟩ natrec p q r F z s n ∷ F [ n ]₀ / [Γ] / [Fₙ]
+  natrecᵛ {F = F} {z = z} {s = s} {n = n} {l = l}
+          [Γ] [ℕ] [F] [F₀] [F₊] [Fₙ] [z] [s] [n]
+          {Δ = Δ} {σ = σ} ⊢Δ [σ] =
+    let
+      [F]′ = S.irrelevance {A = F} (_∙_ {A = ℕ} [Γ] [ℕ])
                            (_∙_ {l = l} [Γ] (ℕᵛ [Γ])) [F]
       [σn]′ = irrelevanceTerm {l′ = l} (proj₁ (unwrap [ℕ] ⊢Δ [σ]))
                               (ℕᵣ (idRed:*: (ℕⱼ ⊢Δ))) (proj₁ ([n] ⊢Δ [σ]))
@@ -901,15 +934,16 @@ natrecᵛ {F = F} {z = z} {s = s} {n = n} {l = l}
                                ((_∙_ {A = F} {l = l} (_∙_ {A = ℕ} {l = l} [Γ] [ℕ]) [F]))
                                (_∙_ {l = l} (_∙_ {l = l} [Γ] [ℕ]′) [F]′)
                                [F₊] [F₊]′ [s]
-  in  irrelevanceTerm′ eqPrf (irrelevance′ (PE.sym (singleSubstComp n′ σ F))
-                                           (proj₁ (unwrap [F]′ ⊢Δ ([σ] , [σn]′))))
-                        (proj₁ (unwrap [Fₙ] ⊢Δ [σ]))
-                   (natrecTerm {F = F} {z} {s} {n′} {σ = σ} [Γ]
-                               [F]′
-                               [F₀] [F₊]′ [z] [s]′ ⊢Δ [σ]
-                               [σn]′)
- ,   (λ {σ′} [σ′] [σ≡σ′] →
-        let [σ′n]′ = irrelevanceTerm {l′ = l} (proj₁ (unwrap [ℕ] ⊢Δ [σ′]))
+      ⊩F[⇑σ][n′] =
+        irrelevance′ (PE.sym (singleSubstComp n′ σ F))
+          (proj₁ (unwrap [F]′ ⊢Δ ([σ] , [σn]′)))
+    in
+      irrelevanceTerm′ eqPrf ⊩F[⇑σ][n′] (proj₁ (unwrap [Fₙ] ⊢Δ [σ]))
+        (natrecTerm {z = z} {s = s}
+           [Γ] [F]′ [F₀] [F₊]′ [z] [s]′ ⊢Δ [σ] [σn]′ ⊩F[⇑σ][n′])
+    , (λ {σ′} [σ′] [σ≡σ′] →
+         let
+            [σ′n]′ = irrelevanceTerm {l′ = l} (proj₁ (unwrap [ℕ] ⊢Δ [σ′]))
                                      (ℕᵣ (idRed:*: (ℕⱼ ⊢Δ)))
                                      (proj₁ ([n] ⊢Δ [σ′]))
             [σn≡σ′n] = irrelevanceEqTerm {l′ = l} (proj₁ (unwrap [ℕ] ⊢Δ [σ]))
@@ -923,9 +957,8 @@ natrecᵛ {F = F} {z = z} {s = s} {n = n} {l = l}
                                      ((_∙_ {A = F} {l = l} (_∙_ {A = ℕ} {l = l} [Γ] [ℕ]) [F]))
                                      (_∙_ {l = l} (_∙_ {l = l} [Γ] [ℕ]′) [F]′)
                                      [F₊] [F₊]′ [s]
-        in  irrelevanceEqTerm′ eqPrf
-              (irrelevance′ (PE.sym (singleSubstComp n′ σ F))
-                            (proj₁ (unwrap [F]′ ⊢Δ ([σ] , [σn]′))))
+         in irrelevanceEqTerm′ eqPrf
+              ⊩F[⇑σ][n′]
               (proj₁ (unwrap [Fₙ] ⊢Δ [σ]))
               (natrec-congTerm {F = F} {F} {z} {z} {s} {s} {n′} {n [ σ′ ]} {σ = σ}
                                [Γ] [F]′ [F]′ (reflᵛ {A = F} (_∙_ {A = ℕ} {l = l}
@@ -937,10 +970,15 @@ natrecᵛ {F = F} {z = z} {s = s} {n = n} {l = l}
                                [s]′ [s]′
                                (reflᵗᵛ {A = F [ suc (var x1) ]↑²} {s}
                                        (_∙_ {A = F} {l = l} (_∙_ {A = ℕ} {l = l} [Γ] [ℕ]′) [F]′) [F₊]′ [s]′)
-                               ⊢Δ [σ] [σ′] [σ≡σ′] [σn]′ [σ′n]′ [σn≡σ′n]))
+                               ⊢Δ [σ] [σ′] [σ≡σ′] [σn]′ [σ′n]′ [σn≡σ′n]
+                               ⊩F[⇑σ][n′]))
 
--- Validity of natural recursion congruence.
-natrec-congᵛ : ∀ {F F′ z z′ s s′ n n′ l} ([Γ] : ⊩ᵛ Γ)
+opaque
+  unfolding ℕᵛ
+
+  -- Validity of natural recursion congruence.
+  natrec-congᵛ :
+          ∀ {F F′ z z′ s s′ n n′ l} ([Γ] : ⊩ᵛ Γ)
           ([ℕ]  : Γ ⊩ᵛ⟨ l ⟩ ℕ / [Γ])
           ([F]  : Γ ∙ ℕ ⊩ᵛ⟨ l ⟩ F / [Γ] ∙ [ℕ])
           ([F′]  : Γ ∙ ℕ ⊩ᵛ⟨ l ⟩ F′ / [Γ] ∙ [ℕ])
@@ -966,12 +1004,13 @@ natrec-congᵛ : ∀ {F F′ z z′ s s′ n n′ l} ([Γ] : ⊩ᵛ Γ)
           ([n′] : Γ ⊩ᵛ⟨ l ⟩ n′ ∷ ℕ / [Γ] / [ℕ])
           ([n≡n′] : Γ ⊩ᵛ⟨ l ⟩ n ≡ n′ ∷ ℕ / [Γ] / [ℕ])
         → Γ ⊩ᵛ⟨ l ⟩ natrec p q r F z s n ≡ natrec p q r F′ z′ s′ n′ ∷ F [ n ]₀ / [Γ] / [Fₙ]
-natrec-congᵛ {p = p} {q = q} {r = r} {F = F} {F′ = F′} {z = z} {z′ = z′}
-             {s = s} {s′ = s′} {n = n} {n′ = n′} {l = l}
-             [Γ] [ℕ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
-             [Fₙ] [z] [z′] [z≡z′] [s] [s′] [s≡s′] [n] [n′]
-             [n≡n′] {Δ = Δ} {σ = σ} ⊢Δ [σ] =
-  let [ℕ]′ = ℕᵛ [Γ]
+  natrec-congᵛ {p = p} {q = q} {r = r} {F = F} {F′ = F′} {z = z} {z′ = z′}
+               {s = s} {s′ = s′} {n = n} {n′ = n′} {l = l}
+               [Γ] [ℕ] [F] [F′] [F≡F′] [F₀] [F′₀] [F₀≡F′₀] [F₊] [F′₊] [F₊≡F′₊]
+               [Fₙ] [z] [z′] [z≡z′] [s] [s′] [s≡s′] [n] [n′]
+               [n≡n′] {Δ = Δ} {σ = σ} ⊢Δ [σ] =
+    let
+      [ℕ]′ = ℕᵛ [Γ]
       [F]′ = S.irrelevance {A = F} (_∙_ {A = ℕ} [Γ] [ℕ])
                            (_∙_ {l = l} [Γ] (ℕᵛ [Γ])) [F]
       [F′]′ = S.irrelevance {A = F′} (_∙_ {A = ℕ} [Γ] [ℕ])
@@ -1009,14 +1048,15 @@ natrec-congᵛ {p = p} {q = q} {r = r} {F = F} {F′ = F′} {z = z} {z′ = z�
                                     (((_∙_ {A = F} {l = l} (_∙_ {A = ℕ} {l = l} [Γ] [ℕ]) [F])))
                                     ((_∙_ {l = l} (_∙_ {l = l} [Γ] [ℕ]′) [F]′))
                                     [F₊] [F₊]′ [s≡s′]
-  in irrelevanceEqTerm′ (PE.sym (singleSubstLift F n))
-                        [Fₙ]′ (proj₁ (unwrap [Fₙ] ⊢Δ [σ]))
-                        (natrec-congTerm {p = p} {q = q} {r = r} {F = F} {F′ = F′} {z = z} {z′ = z′}
-                               {s = s} {s′ = s′} {n = n [ σ ]} {m = n′ [ σ ]}
-                               [Γ] [F]′ [F′]′ [F≡F′]′
-                               [F₀] [F′₀] [F₀≡F′₀]
-                               [F₊]′ [F′₊]′ [F₊≡F′₊]′
-                               [z] [z′] [z≡z′]
-                               [s]′ [s′]′ [s≡s′]′ ⊢Δ
-                               [σ] [σ] (reflSubst [Γ] ⊢Δ [σ])
-                               [σn]′ [σn′]′ [σn≡σn′]′)
+    in irrelevanceEqTerm′
+         (PE.sym (singleSubstLift F n))
+         [Fₙ]′ (proj₁ (unwrap [Fₙ] ⊢Δ [σ]))
+         (natrec-congTerm {z = z} {z′ = z′} {s = s} {s′ = s′}
+            [Γ] [F]′ [F′]′ [F≡F′]′
+            [F₀] [F′₀] [F₀≡F′₀]
+            [F₊]′ [F′₊]′ [F₊≡F′₊]′
+            [z] [z′] [z≡z′]
+            [s]′ [s′]′ [s≡s′]′ ⊢Δ
+            [σ] [σ] (reflSubst [Γ] ⊢Δ [σ])
+            [σn]′ [σn′]′ [σn≡σn′]′
+            [Fₙ]′)

--- a/Definition/LogicalRelation/Substitution/Introductions/SingleSubst.agda
+++ b/Definition/LogicalRelation/Substitution/Introductions/SingleSubst.agda
@@ -58,23 +58,26 @@ substS {F = F} {G} {t} [Γ] [F] [G] [t] = wrap λ {_} {_} {σ} ⊢Δ [σ] →
                                      ([σ′] , proj₁ ([t] ⊢Δ [σ′]))
                                      (([σ≡σ′] , (proj₂ ([t] ⊢Δ [σ]) [σ′] [σ≡σ′])))))
 
+opaque
+  unfolding substS
 
--- Validity of substitution of single variable in type equality.
-substSEq : ∀ {F F′ G G′ t t′ l} ([Γ] : ⊩ᵛ Γ)
-           ([F] : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
-           ([F′] : Γ ⊩ᵛ⟨ l ⟩ F′ / [Γ])
-           ([F≡F′] : Γ ⊩ᵛ⟨ l ⟩ F ≡ F′ / [Γ] / [F])
-           ([G] : Γ ∙ F ⊩ᵛ⟨ l ⟩ G / [Γ] ∙ [F])
-           ([G′] : Γ ∙ F′ ⊩ᵛ⟨ l ⟩ G′ / [Γ] ∙ [F′])
-           ([G≡G′] : Γ ∙ F ⊩ᵛ⟨ l ⟩ G ≡ G′ / [Γ] ∙ [F] / [G])
-           ([t] : Γ ⊩ᵛ⟨ l ⟩ t ∷ F / [Γ] / [F])
-           ([t′] : Γ ⊩ᵛ⟨ l ⟩ t′ ∷ F′ / [Γ] / [F′])
-           ([t≡t′] : Γ ⊩ᵛ⟨ l ⟩ t ≡ t′ ∷ F / [Γ] / [F])
-         → Γ ⊩ᵛ⟨ l ⟩ G [ t ]₀ ≡ G′ [ t′ ]₀ / [Γ]
-                   / substS {F = F} {G} {t} [Γ] [F] [G] [t]
-substSEq {F = F} {F′} {G} {G′} {t} {t′}
-         [Γ] [F] [F′] [F≡F′] [G] [G′] [G≡G′] [t] [t′] [t≡t′] {σ = σ} ⊢Δ [σ] =
-  let Geq = substConsId G
+  -- Validity of substitution of single variable in type equality.
+  substSEq : ∀ {F F′ G G′ t t′ l} ([Γ] : ⊩ᵛ Γ)
+             ([F] : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
+             ([F′] : Γ ⊩ᵛ⟨ l ⟩ F′ / [Γ])
+             ([F≡F′] : Γ ⊩ᵛ⟨ l ⟩ F ≡ F′ / [Γ] / [F])
+             ([G] : Γ ∙ F ⊩ᵛ⟨ l ⟩ G / [Γ] ∙ [F])
+             ([G′] : Γ ∙ F′ ⊩ᵛ⟨ l ⟩ G′ / [Γ] ∙ [F′])
+             ([G≡G′] : Γ ∙ F ⊩ᵛ⟨ l ⟩ G ≡ G′ / [Γ] ∙ [F] / [G])
+             ([t] : Γ ⊩ᵛ⟨ l ⟩ t ∷ F / [Γ] / [F])
+             ([t′] : Γ ⊩ᵛ⟨ l ⟩ t′ ∷ F′ / [Γ] / [F′])
+             ([t≡t′] : Γ ⊩ᵛ⟨ l ⟩ t ≡ t′ ∷ F / [Γ] / [F])
+           → Γ ⊩ᵛ⟨ l ⟩ G [ t ]₀ ≡ G′ [ t′ ]₀ / [Γ]
+                     / substS {F = F} {G} {t} [Γ] [F] [G] [t]
+  substSEq {F = F} {F′} {G} {G′} {t} {t′}
+           [Γ] [F] [F′] [F≡F′] [G] [G′] [G≡G′] [t] [t′] [t≡t′] {σ = σ} ⊢Δ [σ] =
+    let
+      Geq = substConsId G
       G′eq = substConsId G′
       G[t] = (proj₁ (unwrap [G] ⊢Δ ([σ] , (proj₁ ([t] ⊢Δ [σ])))))
       G[t]′ = irrelevance′ Geq G[t]
@@ -90,25 +93,30 @@ substSEq {F = F} {F′} {G} {G′} {t} {t′}
                                         [Γ] [F] [F′] [F≡F′] [t≡t′] ⊢Δ [σ]))
       G′[t′] = (proj₁ (unwrap [G′] ⊢Δ ([σ] , proj₁ ([t′] ⊢Δ [σ]))))
       G′[t′]′ = irrelevance′ G′eq G′[t′]
-  in  transEq G[t]′ G′[t] G′[t′]′ G[t]≡G′[t] G′[t]≡G′[t′]
+    in transEq G[t]′ G′[t] G′[t′]′ G[t]≡G′[t] G′[t]≡G′[t′]
 
--- Validity of substitution of single variable in terms.
-substSTerm : ∀ {F G t f l} ([Γ] : ⊩ᵛ Γ)
-             ([F] : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
-             ([G] : Γ ∙ F ⊩ᵛ⟨ l ⟩ G / [Γ] ∙ [F])
-             ([f] : Γ ∙ F ⊩ᵛ⟨ l ⟩ f ∷ G / [Γ] ∙ [F] / [G])
-             ([t] : Γ ⊩ᵛ⟨ l ⟩ t ∷ F / [Γ] / [F])
-           → Γ ⊩ᵛ⟨ l ⟩ f [ t ]₀ ∷ G [ t ]₀ / [Γ]
-                      / substS {F = F} {G} {t} [Γ] [F] [G] [t]
-substSTerm {F = F} {G} {t} {f} [Γ] [F] [G] [f] [t] {σ = σ} ⊢Δ [σ] =
-  let prfG = substConsId G
+opaque
+  unfolding substS
+
+  -- Validity of substitution of single variable in terms.
+  substSTerm : ∀ {F G t f l} ([Γ] : ⊩ᵛ Γ)
+               ([F] : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
+               ([G] : Γ ∙ F ⊩ᵛ⟨ l ⟩ G / [Γ] ∙ [F])
+               ([f] : Γ ∙ F ⊩ᵛ⟨ l ⟩ f ∷ G / [Γ] ∙ [F] / [G])
+               ([t] : Γ ⊩ᵛ⟨ l ⟩ t ∷ F / [Γ] / [F])
+             → Γ ⊩ᵛ⟨ l ⟩ f [ t ]₀ ∷ G [ t ]₀ / [Γ]
+                        / substS {F = F} {G} {t} [Γ] [F] [G] [t]
+  substSTerm {F = F} {G} {t} {f} [Γ] [F] [G] [f] [t] {σ = σ} ⊢Δ [σ] =
+    let
+      prfG = substConsId G
       prff = substConsId f
       G[t] = proj₁ (unwrap [G] ⊢Δ ([σ] , proj₁ ([t] ⊢Δ [σ])))
       G[t]′ = irrelevance′ prfG G[t]
       f[t] = proj₁ ([f] ⊢Δ ([σ] , proj₁ ([t] ⊢Δ [σ])))
       f[t]′ = irrelevanceTerm″ prfG prff G[t] G[t]′ f[t]
-  in  f[t]′
-  ,   (λ {σ′} [σ′] [σ≡σ′] →
+    in
+      f[t]′
+    , (λ {σ′} [σ′] [σ≡σ′] →
          irrelevanceEqTerm″
            prff
            (substConsId f)
@@ -146,23 +154,28 @@ subst↑S {F = F} {G} {t} [Γ] [F] [G] [t] = wrap λ {_} {_} {σ} ⊢Δ [σ] →
          in irrelevanceEq″ (substConsTailId {σ = σ} {G} {t} ) (substConsTailId {σ = σ′} {G} {t})
                             G[t] G[t]′ [σG[t]≡σ′G[t]])
 
--- Validity of substitution of single lifted variable in type equality.
-subst↑SEq : ∀ {F G G′ t t′ l} ([Γ] : ⊩ᵛ Γ)
-            ([F] : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
-            ([G] : Γ ∙ F ⊩ᵛ⟨ l ⟩ G / [Γ] ∙ [F])
-            ([G′] : Γ ∙ F ⊩ᵛ⟨ l ⟩ G′ / [Γ] ∙ [F])
-            ([G≡G′] : Γ ∙ F ⊩ᵛ⟨ l ⟩ G ≡ G′ / [Γ] ∙ [F] / [G])
-            ([t] : Γ ∙ F ⊩ᵛ⟨ l ⟩ t ∷ wk1 F / [Γ] ∙ [F]
-                                / wk1ᵛ {A = F} {F} [Γ] [F] [F])
-            ([t′] : Γ ∙ F ⊩ᵛ⟨ l ⟩ t′ ∷ wk1 F / [Γ] ∙ [F]
-                                 / wk1ᵛ {A = F} {F} [Γ] [F] [F])
-            ([t≡t′] : Γ ∙ F ⊩ᵛ⟨ l ⟩ t ≡ t′ ∷ wk1 F / [Γ] ∙ [F]
+opaque
+  unfolding subst↑S
+
+  -- Validity of substitution of single lifted variable in type
+  -- equality.
+  subst↑SEq : ∀ {F G G′ t t′ l} ([Γ] : ⊩ᵛ Γ)
+              ([F] : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
+              ([G] : Γ ∙ F ⊩ᵛ⟨ l ⟩ G / [Γ] ∙ [F])
+              ([G′] : Γ ∙ F ⊩ᵛ⟨ l ⟩ G′ / [Γ] ∙ [F])
+              ([G≡G′] : Γ ∙ F ⊩ᵛ⟨ l ⟩ G ≡ G′ / [Γ] ∙ [F] / [G])
+              ([t] : Γ ∙ F ⊩ᵛ⟨ l ⟩ t ∷ wk1 F / [Γ] ∙ [F]
+                                  / wk1ᵛ {A = F} {F} [Γ] [F] [F])
+              ([t′] : Γ ∙ F ⊩ᵛ⟨ l ⟩ t′ ∷ wk1 F / [Γ] ∙ [F]
                                    / wk1ᵛ {A = F} {F} [Γ] [F] [F])
-          → Γ ∙ F ⊩ᵛ⟨ l ⟩ G [ t ]↑ ≡ G′ [ t′ ]↑ / [Γ] ∙ [F]
-                        / subst↑S {F = F} {G} {t} [Γ] [F] [G] [t]
-subst↑SEq {F = F} {G} {G′} {t} {t′}
-          [Γ] [F] [G] [G′] [G≡G′] [t] [t′] [t≡t′] {σ = σ} ⊢Δ [σ] =
-  let [wk1F] = wk1ᵛ {A = F} {F} [Γ] [F] [F]
+              ([t≡t′] : Γ ∙ F ⊩ᵛ⟨ l ⟩ t ≡ t′ ∷ wk1 F / [Γ] ∙ [F]
+                                     / wk1ᵛ {A = F} {F} [Γ] [F] [F])
+            → Γ ∙ F ⊩ᵛ⟨ l ⟩ G [ t ]↑ ≡ G′ [ t′ ]↑ / [Γ] ∙ [F]
+                          / subst↑S {F = F} {G} {t} [Γ] [F] [G] [t]
+  subst↑SEq {F = F} {G} {G′} {t} {t′}
+            [Γ] [F] [G] [G′] [G≡G′] [t] [t′] [t≡t′] {σ = σ} ⊢Δ [σ] =
+    let
+      [wk1F] = wk1ᵛ {A = F} {F} [Γ] [F] [F]
       [σwk1F] = proj₁ (unwrap [wk1F] {σ = σ} ⊢Δ [σ])
       [σwk1F]′ = proj₁ (unwrap [F] {σ = tail σ} ⊢Δ (proj₁ [σ]))
       [t]′ = irrelevanceTerm′ (subst-wk F) [σwk1F] [σwk1F]′ (proj₁ ([t] ⊢Δ [σ]))
@@ -182,7 +195,7 @@ subst↑SEq {F = F} {G} {G′} {t} {t′}
                                      (proj₂ (unwrap [G′] ⊢Δ (proj₁ [σ] , [t]′))
                                             (proj₁ [σ] , [t′]′)
                                             (reflSubst [Γ] ⊢Δ (proj₁ [σ]) , [t≡t′]′))
-  in  transEq G[t]′ G′[t]′ G′[t′]′ G[t]≡G′[t] G′[t]≡G′[t′]
+    in transEq G[t]′ G′[t]′ G′[t′]′ G[t]≡G′[t] G′[t]≡G′[t′]
 
 -- Helper function for reducible substitution of Π-types with specific typing derivations.
 substSΠ₁′ : ∀ {F G t l l′} W
@@ -208,22 +221,29 @@ substSΠ₁ : ∀ {F G t l l′} W
          → Γ ⊩⟨ l ⟩ G [ t ]₀
 substSΠ₁ W [ΠFG] [F] [t] = substSΠ₁′ W (B-elim W [ΠFG]) [F] [t]
 
--- Helper function for reducible substitution of Π-congruence with specific typing derivations.
-substSΠ₂′ : ∀ {F F′ G G′ t t′ l l′ l″ l‴} W
-           ([ΠFG] : Γ ⊩⟨ l ⟩B⟨ W ⟩ ⟦ W ⟧ F ▹ G)
-           ([ΠFG≡ΠF′G′] : Γ ⊩⟨ l ⟩ ⟦ W ⟧ F ▹ G ≡ ⟦ W ⟧ F′ ▹ G′ / B-intr W [ΠFG])
-           ([F] : Γ ⊩⟨ l′ ⟩ F)
-           ([F′] : Γ ⊩⟨ l′ ⟩ F′)
-           ([t] : Γ ⊩⟨ l′ ⟩ t ∷ F / [F])
-           ([t′] : Γ ⊩⟨ l′ ⟩ t′ ∷ F′ / [F′])
-           ([t≡t′] : Γ ⊩⟨ l′ ⟩ t ≡ t′ ∷ F / [F])
-           ([G[t]] : Γ ⊩⟨ l″ ⟩ G [ t ]₀)
-           ([G′[t′]] : Γ ⊩⟨ l‴ ⟩ G′ [ t′ ]₀)
-         → Γ ⊩⟨ l″ ⟩ G [ t ]₀ ≡ G′ [ t′ ]₀ / [G[t]]
-substSΠ₂′ W (noemb (Bᵣ F G D ⊢F ⊢G A≡A [F] [G] G-ext _))
-          (B₌ F″ G″ D′ A≡B [F≡F′] [G≡G′])
-          [F]₁ [F′] [t] [t′] [t≡t′] [G[t]] [G′[t′]] =
-  let F≡F′  , G≡G′  , _ = B-PE-injectivity W W (whnfRed* (red D) (⟦ W ⟧ₙ))
+opaque
+  unfolding B-intr
+
+  -- Helper function for reducible substitution of Π-congruence with
+  -- specific typing derivations.
+  substSΠ₂′ :
+    ∀ {F F′ G G′ t t′ l l′ l″ l‴} W
+    ([ΠFG] : Γ ⊩⟨ l ⟩B⟨ W ⟩ ⟦ W ⟧ F ▹ G)
+    ([ΠFG≡ΠF′G′] :
+       Γ ⊩⟨ l ⟩ ⟦ W ⟧ F ▹ G ≡ ⟦ W ⟧ F′ ▹ G′ / B-intr W [ΠFG])
+    ([F] : Γ ⊩⟨ l′ ⟩ F)
+    ([F′] : Γ ⊩⟨ l′ ⟩ F′)
+    ([t] : Γ ⊩⟨ l′ ⟩ t ∷ F / [F])
+    ([t′] : Γ ⊩⟨ l′ ⟩ t′ ∷ F′ / [F′])
+    ([t≡t′] : Γ ⊩⟨ l′ ⟩ t ≡ t′ ∷ F / [F])
+    ([G[t]] : Γ ⊩⟨ l″ ⟩ G [ t ]₀)
+    ([G′[t′]] : Γ ⊩⟨ l‴ ⟩ G′ [ t′ ]₀) →
+    Γ ⊩⟨ l″ ⟩ G [ t ]₀ ≡ G′ [ t′ ]₀ / [G[t]]
+  substSΠ₂′ W (noemb (Bᵣ F G D ⊢F ⊢G A≡A [F] [G] G-ext _))
+            (B₌ F″ G″ D′ A≡B [F≡F′] [G≡G′])
+            [F]₁ [F′] [t] [t′] [t≡t′] [G[t]] [G′[t′]] =
+    let
+      F≡F′  , G≡G′  , _ = B-PE-injectivity W W (whnfRed* (red D) (⟦ W ⟧ₙ))
       F′≡F″ , G′≡G″ , _ = B-PE-injectivity W W (whnfRed* D′ ⟦ W ⟧ₙ)
       Feq = PE.trans F≡F′ (PE.sym (wk-id _))
       F′eq = PE.trans F′≡F″ (PE.sym (wk-id _))
@@ -235,10 +255,10 @@ substSΠ₂′ W (noemb (Bᵣ F G D ⊢F ⊢G A≡A [F] [G] G-ext _))
       [t≡t′]′ = irrelevanceEqTerm′ Feq [F]₁ ([F] id ⊢Γ) [t≡t′]
       [Gt≡Gt′] = G-ext id ⊢Γ [t]′ [t′]′ [t≡t′]′
       [Gt′≡G′t′] = [G≡G′] id ⊢Γ [t′]′
-  in  irrelevanceEq′ Geq ([G] id ⊢Γ [t]′) [G[t]]
-        (transEq′ PE.refl Geq′ ([G] id ⊢Γ [t]′) ([G] id ⊢Γ [t′]′)
-                  [G′[t′]] [Gt≡Gt′] [Gt′≡G′t′])
-substSΠ₂′ W (emb 0<1 x) = substSΠ₂′ W x
+    in irrelevanceEq′ Geq ([G] id ⊢Γ [t]′) [G[t]]
+         (transEq′ PE.refl Geq′ ([G] id ⊢Γ [t]′) ([G] id ⊢Γ [t′]′)
+            [G′[t′]] [Gt≡Gt′] [Gt′≡G′t′])
+  substSΠ₂′ W (emb 0<1 x) = substSΠ₂′ W x
 
 -- Reducible substitution of Π-congruence.
 substSΠ₂ : ∀ {F F′ G G′ t t′ l l′ l″ l‴} W

--- a/Definition/LogicalRelation/Substitution/Introductions/Unit.agda
+++ b/Definition/LogicalRelation/Substitution/Introductions/Unit.agda
@@ -42,31 +42,37 @@ Unitᵛ _ ok =
     Unitᵣ (Unitₜ (idRed:*: (Unitⱼ ⊢Δ ok)) ok)
   , λ _ _ → id (Unitⱼ ⊢Δ ok)
 
--- Validity of the Unit type as a term.
-Unitᵗᵛ :
-  ([Γ] : ⊩ᵛ Γ) →
-  Unit-allowed →
-  Γ ⊩ᵛ⟨ ¹ ⟩ Unit ∷ U / [Γ] / Uᵛ [Γ]
-Unitᵗᵛ _ ok ⊢Δ _ =
-    Uₜ Unit (idRedTerm:*: ⊢Unit) Unitₙ Unit≅Unit [Unit]
-  , (λ _ _ →
-       Uₜ₌ Unit Unit (idRedTerm:*: ⊢Unit) (idRedTerm:*: ⊢Unit)
-         Unitₙ Unitₙ Unit≅Unit [Unit] [Unit] (id ⊢Unit′))
-  where
-  ⊢Unit     = Unitⱼ ⊢Δ ok
-  ⊢Unit′    = univ ⊢Unit
-  Unit≅Unit = ≅ₜ-Unitrefl ⊢Δ ok
-  [Unit]    = Unitᵣ (Unitₜ (idRed:*: ⊢Unit′) ok)
+opaque
+  unfolding Uᵛ
 
--- Validity of star.
-starᵛ :
-  ∀ {l} ([Γ] : ⊩ᵛ Γ) (ok : Unit-allowed) →
-  Γ ⊩ᵛ⟨ l ⟩ star ∷ Unit / [Γ] / Unitᵛ [Γ] ok
-starᵛ [Γ] ok ⊢Δ _ =
-    Unitₜ star (idRedTerm:*: ⊢star) starₙ
-  , (λ _ _ → Unitₜ₌ ⊢star ⊢star)
-  where
-  ⊢star = starⱼ ⊢Δ ok
+  -- Validity of the Unit type as a term.
+  Unitᵗᵛ :
+    ([Γ] : ⊩ᵛ Γ) →
+    Unit-allowed →
+    Γ ⊩ᵛ⟨ ¹ ⟩ Unit ∷ U / [Γ] / Uᵛ [Γ]
+  Unitᵗᵛ _ ok ⊢Δ _ =
+    let
+      ⊢Unit     = Unitⱼ ⊢Δ ok
+      ⊢Unit′    = univ ⊢Unit
+      Unit≅Unit = ≅ₜ-Unitrefl ⊢Δ ok
+      [Unit]    = Unitᵣ (Unitₜ (idRed:*: ⊢Unit′) ok)
+    in
+      Uₜ Unit (idRedTerm:*: ⊢Unit) Unitₙ Unit≅Unit [Unit]
+    , (λ _ _ →
+         Uₜ₌ Unit Unit (idRedTerm:*: ⊢Unit) (idRedTerm:*: ⊢Unit)
+           Unitₙ Unitₙ Unit≅Unit [Unit] [Unit] (id ⊢Unit′))
+
+opaque
+  unfolding Unitᵛ
+
+  -- Validity of star.
+  starᵛ :
+    ∀ {l} ([Γ] : ⊩ᵛ Γ) (ok : Unit-allowed) →
+    Γ ⊩ᵛ⟨ l ⟩ star ∷ Unit / [Γ] / Unitᵛ [Γ] ok
+  starᵛ [Γ] ok ⊢Δ _ =
+    let ⊢star = starⱼ ⊢Δ ok in
+      Unitₜ star (idRedTerm:*: ⊢star) starₙ
+    , (λ _ _ → Unitₜ₌ ⊢star ⊢star)
 
 -- Validity of η-unit.
 η-unitᵛ : ∀ {l e e'} ([Γ] : ⊩ᵛ Γ)

--- a/Definition/LogicalRelation/Substitution/Irrelevance.agda
+++ b/Definition/LogicalRelation/Substitution/Irrelevance.agda
@@ -204,34 +204,39 @@ irrelevanceTerm′ : ∀ {l l′ A A′ t}
 irrelevanceTerm′ {A = A} {t = t} PE.refl [Γ] [Γ]′ [A] [A]′ [t] =
   irrelevanceTerm {A = A} {t = t} [Γ] [Γ]′ [A] [A]′ [t]
 
--- Irrelevance of valid terms with different derivations of
--- contexts and types with a lifting of equal types
-irrelevanceTermLift : ∀ {l A F H t}
-              ([Γ] : ⊩ᵛ Γ)
-              ([F] : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
-              ([H] : Γ ⊩ᵛ⟨ l ⟩ H / [Γ])
-              ([F≡H] : Γ ⊩ᵛ⟨ l ⟩ F ≡ H / [Γ] / [F])
-              ([A] : Γ ∙ F ⊩ᵛ⟨ l ⟩ A / [Γ] ∙ [F])
-            → Γ ∙ F ⊩ᵛ⟨ l ⟩ t ∷ A / [Γ] ∙ [F] / [A]
-            → Γ ∙ H ⊩ᵛ⟨ l ⟩ t ∷ A / [Γ] ∙ [H]
-                           / irrelevanceLift {A = A} {F = F} {H = H}
-                                             [Γ] [F] [H] [F≡H] [A]
-irrelevanceTermLift [Γ] [F] [H] [F≡H] [A] [t] ⊢Δ ([tailσ] , [headσ]) =
-  let [σ]′ = [tailσ] , convTerm₂ (proj₁ (unwrap [F] ⊢Δ [tailσ]))
-                                 (proj₁ (unwrap [H] ⊢Δ [tailσ]))
-                                 ([F≡H] ⊢Δ [tailσ]) [headσ]
-  in  proj₁ ([t] ⊢Δ [σ]′)
-  , (λ [σ′] x →
-       let [σ′]′ = proj₁ [σ′] , convTerm₂ (proj₁ (unwrap [F] ⊢Δ (proj₁ [σ′])))
-                                          (proj₁ (unwrap [H] ⊢Δ (proj₁ [σ′])))
-                                          ([F≡H] ⊢Δ (proj₁ [σ′]))
-                                          (proj₂ [σ′])
-           [tailσ′] = proj₁ [σ′]
-       in  proj₂ ([t] ⊢Δ [σ]′) [σ′]′
-                 (proj₁ x , convEqTerm₂ (proj₁ (unwrap [F] ⊢Δ [tailσ]))
-                                        (proj₁ (unwrap [H] ⊢Δ [tailσ]))
-                                        ([F≡H] ⊢Δ [tailσ])
-                                        (proj₂ x)))
+opaque
+  unfolding irrelevanceLift
+
+  -- Irrelevance of valid terms with different derivations of
+  -- contexts and types with a lifting of equal types
+  irrelevanceTermLift : ∀ {l A F H t}
+                ([Γ] : ⊩ᵛ Γ)
+                ([F] : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
+                ([H] : Γ ⊩ᵛ⟨ l ⟩ H / [Γ])
+                ([F≡H] : Γ ⊩ᵛ⟨ l ⟩ F ≡ H / [Γ] / [F])
+                ([A] : Γ ∙ F ⊩ᵛ⟨ l ⟩ A / [Γ] ∙ [F])
+              → Γ ∙ F ⊩ᵛ⟨ l ⟩ t ∷ A / [Γ] ∙ [F] / [A]
+              → Γ ∙ H ⊩ᵛ⟨ l ⟩ t ∷ A / [Γ] ∙ [H]
+                             / irrelevanceLift {A = A} {F = F} {H = H}
+                                               [Γ] [F] [H] [F≡H] [A]
+  irrelevanceTermLift [Γ] [F] [H] [F≡H] [A] [t] ⊢Δ ([tailσ] , [headσ]) =
+    let [σ]′ = [tailσ] , convTerm₂ (proj₁ (unwrap [F] ⊢Δ [tailσ]))
+                                   (proj₁ (unwrap [H] ⊢Δ [tailσ]))
+                                   ([F≡H] ⊢Δ [tailσ]) [headσ]
+    in  proj₁ ([t] ⊢Δ [σ]′)
+    , (λ [σ′] x →
+         let [σ′]′ =
+               proj₁ [σ′] ,
+               convTerm₂ (proj₁ (unwrap [F] ⊢Δ (proj₁ [σ′])))
+                         (proj₁ (unwrap [H] ⊢Δ (proj₁ [σ′])))
+                         ([F≡H] ⊢Δ (proj₁ [σ′]))
+                         (proj₂ [σ′])
+             [tailσ′] = proj₁ [σ′]
+         in  proj₂ ([t] ⊢Δ [σ]′) [σ′]′
+               (proj₁ x , convEqTerm₂ (proj₁ (unwrap [F] ⊢Δ [tailσ]))
+                                      (proj₁ (unwrap [H] ⊢Δ [tailσ]))
+                                      ([F≡H] ⊢Δ [tailσ])
+                                      (proj₂ x)))
 
 -- Irrelevance of valid term equality with different derivations of
 -- contexts and types

--- a/Definition/LogicalRelation/Substitution/Properties.agda
+++ b/Definition/LogicalRelation/Substitution/Properties.agda
@@ -91,16 +91,19 @@ consSubstS : ∀ {l t A Γ Δ} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
          → Δ ⊩ˢ consSubst σ t ∷ Γ ∙ A / [Γ] ∙ [A] / ⊢Δ
 consSubstS [Γ] ⊢Δ [σ] [A] [t] = [σ] , [t]
 
--- Extend a valid substitution equality with a term
-consSubstSEq : ∀ {l t A Γ Δ} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
-             ([σ]    : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
-             ([σ≡σ′] : Δ ⊩ˢ σ ≡ σ′ ∷ Γ / [Γ] / ⊢Δ / [σ])
-             ([A] : Γ ⊩ᵛ⟨ l ⟩ A / [Γ])
-             ([t] : Δ ⊩⟨ l ⟩ t ∷ A [ σ ] / proj₁ (unwrap [A] ⊢Δ [σ]))
-           → Δ ⊩ˢ consSubst σ t ≡ consSubst σ′ t ∷ Γ ∙ A / [Γ] ∙ [A] / ⊢Δ
-               / consSubstS {t = t} {A = A} [Γ] ⊢Δ [σ] [A] [t]
-consSubstSEq [Γ] ⊢Δ [σ] [σ≡σ′] [A] [t] =
-  [σ≡σ′] , reflEqTerm (proj₁ (unwrap [A] ⊢Δ [σ])) [t]
+opaque
+  unfolding consSubstS
+
+  -- Extend a valid substitution equality with a term
+  consSubstSEq : ∀ {l t A Γ Δ} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
+               ([σ]    : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
+               ([σ≡σ′] : Δ ⊩ˢ σ ≡ σ′ ∷ Γ / [Γ] / ⊢Δ / [σ])
+               ([A] : Γ ⊩ᵛ⟨ l ⟩ A / [Γ])
+               ([t] : Δ ⊩⟨ l ⟩ t ∷ A [ σ ] / proj₁ (unwrap [A] ⊢Δ [σ]))
+             → Δ ⊩ˢ consSubst σ t ≡ consSubst σ′ t ∷ Γ ∙ A / [Γ] ∙ [A] /
+                 ⊢Δ / consSubstS {t = t} {A = A} [Γ] ⊢Δ [σ] [A] [t]
+  consSubstSEq [Γ] ⊢Δ [σ] [σ≡σ′] [A] [t] =
+    [σ≡σ′] , reflEqTerm (proj₁ (unwrap [A] ⊢Δ [σ])) [t]
 
 -- Weakening of valid substitutions
 wkSubstS : ∀ {Γ Δ Δ′} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ) (⊢Δ′ : ⊢ Δ′)
@@ -116,19 +119,24 @@ wkSubstS {σ = σ} {Γ = Γ ∙ A} ([Γ] ∙ x) ⊢Δ ⊢Δ′ ρ [σ] =
         (proj₁ (unwrap x ⊢Δ′ [tailσ]))
         (LR.wkTerm ρ ⊢Δ′ (proj₁ (unwrap x ⊢Δ (proj₁ [σ]))) (proj₂ [σ]))
 
--- Weakening of valid substitution equality
-wkSubstSEq : ∀ {Γ Δ Δ′} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ) (⊢Δ′ : ⊢ Δ′)
-             ([ρ] : ρ ∷ Δ′ ⊇ Δ)
-             ([σ] : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
-             ([σ≡σ′] : Δ ⊩ˢ σ ≡ σ′ ∷ Γ / [Γ] / ⊢Δ / [σ])
-           → Δ′ ⊩ˢ ρ •ₛ σ ≡ ρ •ₛ σ′ ∷ Γ / [Γ]
-                / ⊢Δ′ / wkSubstS [Γ] ⊢Δ ⊢Δ′ [ρ] [σ]
-wkSubstSEq ε ⊢Δ ⊢Δ′ ρ [σ] [σ≡σ′] = lift tt
-wkSubstSEq {Γ = Γ ∙ A} ([Γ] ∙ x) ⊢Δ ⊢Δ′ ρ [σ] [σ≡σ′] =
-  wkSubstSEq [Γ] ⊢Δ ⊢Δ′ ρ (proj₁ [σ]) (proj₁ [σ≡σ′])
-  , irrelevanceEqTerm′ (wk-subst A) (LR.wk ρ ⊢Δ′ (proj₁ (unwrap x ⊢Δ (proj₁ [σ]))))
-                            (proj₁ (unwrap x ⊢Δ′ (wkSubstS [Γ] ⊢Δ ⊢Δ′ ρ (proj₁ [σ]))))
-                            (LR.wkEqTerm ρ ⊢Δ′ (proj₁ (unwrap x ⊢Δ (proj₁ [σ]))) (proj₂ [σ≡σ′]))
+opaque
+  unfolding wkSubstS
+
+  -- Weakening of valid substitution equality
+  wkSubstSEq : ∀ {Γ Δ Δ′} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ) (⊢Δ′ : ⊢ Δ′)
+               ([ρ] : ρ ∷ Δ′ ⊇ Δ)
+               ([σ] : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
+               ([σ≡σ′] : Δ ⊩ˢ σ ≡ σ′ ∷ Γ / [Γ] / ⊢Δ / [σ])
+             → Δ′ ⊩ˢ ρ •ₛ σ ≡ ρ •ₛ σ′ ∷ Γ / [Γ]
+                  / ⊢Δ′ / wkSubstS [Γ] ⊢Δ ⊢Δ′ [ρ] [σ]
+  wkSubstSEq ε ⊢Δ ⊢Δ′ ρ [σ] [σ≡σ′] = lift tt
+  wkSubstSEq {Γ = Γ ∙ A} ([Γ] ∙ x) ⊢Δ ⊢Δ′ ρ [σ] [σ≡σ′] =
+    wkSubstSEq [Γ] ⊢Δ ⊢Δ′ ρ (proj₁ [σ]) (proj₁ [σ≡σ′])
+    , irrelevanceEqTerm′ (wk-subst A)
+        (LR.wk ρ ⊢Δ′ (proj₁ (unwrap x ⊢Δ (proj₁ [σ]))))
+        (proj₁ (unwrap x ⊢Δ′ (wkSubstS [Γ] ⊢Δ ⊢Δ′ ρ (proj₁ [σ]))))
+        (LR.wkEqTerm ρ ⊢Δ′ (proj₁ (unwrap x ⊢Δ (proj₁ [σ])))
+           (proj₂ [σ≡σ′]))
 
 -- Weaken a valid substitution by one type
 wk1SubstS : ∀ {F Γ Δ} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
@@ -139,15 +147,18 @@ wk1SubstS : ∀ {F Γ Δ} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
 wk1SubstS [Γ] ⊢Δ ⊢F [σ] =
   wkSubstS [Γ] ⊢Δ (⊢Δ ∙ ⊢F) (step id) [σ]
 
--- Weaken a valid substitution equality by one type
-wk1SubstSEq : ∀ {F Γ Δ} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
-              (⊢F : Δ ⊢ F)
-              ([σ] : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
-              ([σ≡σ′] : Δ ⊩ˢ σ ≡ σ′ ∷ Γ / [Γ] / ⊢Δ / [σ])
-            → (Δ ∙ F) ⊩ˢ wk1Subst σ ≡ wk1Subst σ′ ∷ Γ / [Γ]
-                            / (⊢Δ ∙ ⊢F) / wk1SubstS [Γ] ⊢Δ ⊢F [σ]
-wk1SubstSEq [Γ] ⊢Δ ⊢F [σ] [σ≡σ′] =
-  wkSubstSEq [Γ] ⊢Δ (⊢Δ ∙ ⊢F) (step id) [σ] [σ≡σ′]
+opaque
+  unfolding wk1SubstS
+
+  -- Weaken a valid substitution equality by one type
+  wk1SubstSEq : ∀ {F Γ Δ} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
+                (⊢F : Δ ⊢ F)
+                ([σ] : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
+                ([σ≡σ′] : Δ ⊩ˢ σ ≡ σ′ ∷ Γ / [Γ] / ⊢Δ / [σ])
+              → (Δ ∙ F) ⊩ˢ wk1Subst σ ≡ wk1Subst σ′ ∷ Γ / [Γ]
+                              / (⊢Δ ∙ ⊢F) / wk1SubstS [Γ] ⊢Δ ⊢F [σ]
+  wk1SubstSEq [Γ] ⊢Δ ⊢F [σ] [σ≡σ′] =
+    wkSubstSEq [Γ] ⊢Δ (⊢Δ ∙ ⊢F) (step id) [σ] [σ≡σ′]
 
 -- Lift a valid substitution
 liftSubstS : ∀ {l F Γ Δ} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
@@ -193,21 +204,30 @@ opaque
         ⊢0
         (~-var ⊢0) }}
 
--- Lift a valid substitution equality
-liftSubstSEq : ∀ {l F Γ Δ} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
-             ([F] : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
-             ([σ] : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
-             ([σ≡σ′] : Δ ⊩ˢ σ ≡ σ′ ∷ Γ / [Γ] / ⊢Δ / [σ])
-           → (Δ ∙ F [ σ ]) ⊩ˢ liftSubst σ ≡ liftSubst σ′ ∷ Γ ∙ F / [Γ] ∙ [F]
-                             / (⊢Δ ∙ escape (proj₁ (unwrap [F] ⊢Δ [σ])))
-                             / liftSubstS {F = F} [Γ] ⊢Δ [F] [σ]
-liftSubstSEq {σ = σ} {σ′ = σ′} {F = F} {Δ = Δ} [Γ] ⊢Δ [F] [σ] [σ≡σ′] =
-  let ⊢F = escape (proj₁ (unwrap [F] ⊢Δ [σ]))
-      [tailσ] = wk1SubstS {F = F [ σ ]} [Γ] ⊢Δ (escape (proj₁ (unwrap [F] ⊢Δ [σ]))) [σ]
-      [tailσ≡σ′] = wk1SubstSEq [Γ] ⊢Δ (escape (proj₁ (unwrap [F] ⊢Δ [σ]))) [σ] [σ≡σ′]
-      var0 = var (⊢Δ ∙ ⊢F) (PE.subst (λ x → x0 ∷ x ∈ (Δ ∙ F [ σ ])) (wk-subst F) here)
-  in  [tailσ≡σ′] , neuEqTerm (proj₁ (unwrap [F] (⊢Δ ∙ ⊢F) [tailσ])) (var x0) (var x0)
-                         var0 var0 (~-var var0)
+opaque
+  unfolding liftSubstS
+
+  -- Lift a valid substitution equality
+  liftSubstSEq :
+    ∀ {l F Γ Δ} ([Γ] : ⊩ᵛ Γ) (⊢Δ : ⊢ Δ)
+    ([F] : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
+    ([σ] : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
+    ([σ≡σ′] : Δ ⊩ˢ σ ≡ σ′ ∷ Γ / [Γ] / ⊢Δ / [σ]) →
+    Δ ∙ F [ σ ] ⊩ˢ liftSubst σ ≡ liftSubst σ′ ∷ Γ ∙ F / [Γ] ∙ [F] /
+      ⊢Δ ∙ escape (proj₁ (unwrap [F] ⊢Δ [σ])) /
+      liftSubstS {F = F} [Γ] ⊢Δ [F] [σ]
+  liftSubstSEq {σ = σ} {σ′ = σ′} {F = F} {Δ = Δ} [Γ] ⊢Δ [F] [σ] [σ≡σ′] =
+    let ⊢F = escape (proj₁ (unwrap [F] ⊢Δ [σ]))
+        [tailσ] = wk1SubstS {F = F [ σ ]} [Γ] ⊢Δ
+                    (escape (proj₁ (unwrap [F] ⊢Δ [σ]))) [σ]
+        [tailσ≡σ′] = wk1SubstSEq [Γ] ⊢Δ
+                       (escape (proj₁ (unwrap [F] ⊢Δ [σ]))) [σ] [σ≡σ′]
+        var0 = var (⊢Δ ∙ ⊢F)
+                 (PE.subst (λ x → x0 ∷ x ∈ (Δ ∙ F [ σ ])) (wk-subst F)
+                    here)
+    in  [tailσ≡σ′] ,
+        neuEqTerm (proj₁ (unwrap [F] (⊢Δ ∙ ⊢F) [tailσ])) (var x0)
+          (var x0) var0 var0 (~-var var0)
 
 opaque
 

--- a/Definition/Typed.agda
+++ b/Definition/Typed.agda
@@ -2,6 +2,8 @@
 -- Typing and reduction relations
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 open import Definition.Typed.Restrictions
 open import Graded.Modality
 
@@ -545,26 +547,30 @@ data _⊢ˢ_≡_∷_ {k} (Δ : Con Term k) :
       → Δ ⊢  head σ ≡ head σ′ ∷ A [ tail σ ]
       → Δ ⊢ˢ      σ ≡ σ′      ∷ Γ ∙ A
 
--- Note that we cannot use the well-formed substitutions.
--- For that, we need to prove the fundamental theorem for substitutions.
+opaque
 
-⟦_⟧ⱼ : (W : BindingType) → ∀ {F G}
-     → Γ     ⊢ F
-     → Γ ∙ F ⊢ G
-     → BindingType-allowed W
-     → Γ     ⊢ ⟦ W ⟧ F ▹ G
-⟦ BΠ _ _   ⟧ⱼ = ΠΣⱼ
-⟦ BΣ _ _ _ ⟧ⱼ = ΠΣⱼ
+  -- Note that we cannot use the well-formed substitutions.
+  -- For that, we need to prove the fundamental theorem for
+  -- substitutions.
 
-⟦_⟧ⱼᵤ : (W : BindingType) → ∀ {F G}
-     → Γ     ⊢ F ∷ U
-     → Γ ∙ F ⊢ G ∷ U
-     → BindingType-allowed W
-     → Γ     ⊢ ⟦ W ⟧ F ▹ G ∷ U
-⟦ BΠ _ _   ⟧ⱼᵤ = ΠΣⱼ
-⟦ BΣ _ _ _ ⟧ⱼᵤ = ΠΣⱼ
+  ⟦_⟧ⱼ : (W : BindingType) → ∀ {F G}
+       → Γ     ⊢ F
+       → Γ ∙ F ⊢ G
+       → BindingType-allowed W
+       → Γ     ⊢ ⟦ W ⟧ F ▹ G
+  ⟦ BΠ _ _   ⟧ⱼ = ΠΣⱼ
+  ⟦ BΣ _ _ _ ⟧ⱼ = ΠΣⱼ
 
--- A context Γ is consistent if the empty type is not inhabited in Γ.
+  ⟦_⟧ⱼᵤ : (W : BindingType) → ∀ {F G}
+       → Γ     ⊢ F ∷ U
+       → Γ ∙ F ⊢ G ∷ U
+       → BindingType-allowed W
+       → Γ     ⊢ ⟦ W ⟧ F ▹ G ∷ U
+  ⟦ BΠ _ _   ⟧ⱼᵤ = ΠΣⱼ
+  ⟦ BΣ _ _ _ ⟧ⱼᵤ = ΠΣⱼ
+
+-- A context Γ is consistent if the empty type is not inhabited
+-- in Γ.
 
 Consistent : Con Term n → Set ℓ
 Consistent Γ = ∀ t → ¬ Γ ⊢ t ∷ Empty

--- a/Definition/Typed/EqRelInstance.agda
+++ b/Definition/Typed/EqRelInstance.agda
@@ -3,6 +3,8 @@
 -- equality relations.
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 open import Definition.Typed.Restrictions
 open import Graded.Modality
 

--- a/Definition/Typed/Reasoning/Term.agda
+++ b/Definition/Typed/Reasoning/Term.agda
@@ -2,6 +2,8 @@
 -- Equational reasoning combinators for definitional equality of terms
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 open import Definition.Typed.Restrictions
 open import Graded.Modality
 

--- a/Definition/Typed/Reasoning/Type.agda
+++ b/Definition/Typed/Reasoning/Type.agda
@@ -2,6 +2,8 @@
 -- Equational reasoning combinators for definitional equality of types
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 open import Definition.Typed.Restrictions
 open import Graded.Modality
 

--- a/Definition/Typed/Restrictions.agda
+++ b/Definition/Typed/Restrictions.agda
@@ -2,6 +2,8 @@
 -- Restrictions on typing derivations
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 open import Graded.Modality
 
 module Definition.Typed.Restrictions

--- a/Definition/Untyped.agda
+++ b/Definition/Untyped.agda
@@ -2,6 +2,8 @@
 -- Raw terms, weakening (renaming) and substitution.
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 module Definition.Untyped {a} (M : Set a) where
 
 open import Tools.Fin

--- a/Definition/Untyped/NotParametrised.agda
+++ b/Definition/Untyped/NotParametrised.agda
@@ -3,6 +3,8 @@
 -- do not depend on that module's module parameter
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 module Definition.Untyped.NotParametrised where
 
 open import Tools.Fin

--- a/Definition/Untyped/Properties.agda
+++ b/Definition/Untyped/Properties.agda
@@ -768,7 +768,9 @@ subst-β-prodrec {n = n} A σ = begin
      ≡˘⟨ substCompEq A ⟩
    A [ liftSubst σ ] [ t₂ ]↑² ∎
    where
+   t₁ : Term (2 + n)
    t₁ = prod! (var (x0 +1)) (var x0)
+   t₂ : Term (2 + m)
    t₂ = prod! (var (x0 +1)) (var x0)
    varEq :
      (x : Fin (1+ n)) →
@@ -806,7 +808,7 @@ substCompProdrec :
   ∀ {s} (A : Term (1+ n)) (t u : Term m) (σ : Subst m n) →
   A [ liftSubst σ ] [ prod s p t u ]₀ ≡
   A [ prod s p (var x1) (var x0) ]↑² [ consSubst (consSubst σ t) u ]
-substCompProdrec {n = n} A t u σ = begin
+substCompProdrec {n} {p} {s} A t u σ = begin
    A [ liftSubst σ ] [ prod! t u ]₀
      ≡⟨ substCompEq A ⟩
    A [ sgSubst (prod! t u) ₛ•ₛ liftSubst σ ]
@@ -815,9 +817,10 @@ substCompProdrec {n = n} A t u σ = begin
      ≡˘⟨ substCompEq A ⟩
    A [ px ]↑² [ consSubst (consSubst σ t) u ] ∎
    where
+   px : Term (2 + n)
    px = prod! (var (x0 +1)) (var x0)
    varEq : (x : Fin (1+ n))
-         → (sgSubst (prod! t u) ₛ•ₛ liftSubst σ) x
+         → (sgSubst (prod s p t u) ₛ•ₛ liftSubst σ) x
          ≡ (consSubst (consSubst σ t) u ₛ•ₛ consSubst (wk1Subst (wk1Subst idSubst)) px) x
    varEq x0 = refl
    varEq (x +1) = trans (wk1-tail (σ x)) (subst-id (σ x))

--- a/Graded/Context.agda
+++ b/Graded/Context.agda
@@ -2,6 +2,8 @@
 -- Modality (grade) contexts.
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 import Graded.Modality
 
 module Graded.Context

--- a/Graded/Derived/Erased/Typed/Primitive.agda
+++ b/Graded/Derived/Erased/Typed/Primitive.agda
@@ -67,9 +67,7 @@ Erased-cong-U ⊢A A≡B =
   Γ ⊢ t ∷ A →
   Γ ⊢ [ t ] ∷ Erased A
 []ⱼ ⊢A ⊢t =
-  prodⱼ ⊢A (Unitⱼ (⊢Γ ∙ ⊢A) Unit-ok) ⊢t (starⱼ ⊢Γ Unit-ok) Σₚ-ok
-  where
-  ⊢Γ = wf ⊢A
+  prodⱼ ⊢A (Unitⱼ (wf ⊢A ∙ ⊢A) Unit-ok) ⊢t (starⱼ (wf ⊢A) Unit-ok) Σₚ-ok
 
 -- A corresponding congruence rule.
 
@@ -104,9 +102,8 @@ Erased-β :
   Γ ⊢ t ∷ A →
   Γ ⊢ erased [ t ] ≡ t ∷ A
 Erased-β ⊢A ⊢t =
-  Σ-β₁ ⊢A (Unitⱼ (⊢Γ ∙ ⊢A) Unit-ok) ⊢t (starⱼ ⊢Γ Unit-ok) PE.refl Σₚ-ok
-  where
-  ⊢Γ = wf ⊢A
+  Σ-β₁ ⊢A (Unitⱼ (wf ⊢A ∙ ⊢A) Unit-ok) ⊢t (starⱼ (wf ⊢A) Unit-ok)
+    PE.refl Σₚ-ok
 
 -- An η-rule for Erased.
 
@@ -116,11 +113,11 @@ Erased-η :
   Γ ⊢ u ∷ Erased A →
   Γ ⊢ erased t ≡ erased u ∷ A →
   Γ ⊢ t ≡ u ∷ Erased A
-Erased-η ⊢A ⊢t ⊢u t≡u = Σ-η
-  ⊢A Γ∙A⊢Unit ⊢t ⊢u t≡u
-  (η-unit (sndⱼ ⊢A Γ∙A⊢Unit ⊢t) (sndⱼ ⊢A Γ∙A⊢Unit ⊢u))
-  where
-  Γ∙A⊢Unit = Unitⱼ (wf ⊢A ∙ ⊢A) Unit-ok
+Erased-η ⊢A ⊢t ⊢u t≡u =
+  case Unitⱼ (wf ⊢A ∙ ⊢A) Unit-ok of λ {
+    Γ∙A⊢Unit →
+  Σ-η ⊢A Γ∙A⊢Unit ⊢t ⊢u t≡u
+    (η-unit (sndⱼ ⊢A Γ∙A⊢Unit ⊢t) (sndⱼ ⊢A Γ∙A⊢Unit ⊢u)) }
 
 -- An instance of the η-rule.
 

--- a/Graded/Derived/Erased/Untyped.agda
+++ b/Graded/Derived/Erased/Untyped.agda
@@ -2,6 +2,8 @@
 -- The type constructor Erased
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 open import Graded.Modality
 
 module Graded.Derived.Erased.Untyped

--- a/Graded/Modality.agda
+++ b/Graded/Modality.agda
@@ -57,13 +57,15 @@ record Semiring-with-meet : Set a where
     -- by 𝟙, so it is fine to let ω be 𝟙.
     ω≤𝟙 : ω ≤ 𝟙
 
-  -- A semiring with meet is said to be trivial if 𝟙 ≡ 𝟘.
-  --
-  -- This implies that all values of type M are equal, see
-  -- Graded.Modality.Properties.Equivalence.≡-trivial.
+  transparent
 
-  Trivial : Set a
-  Trivial = 𝟙 ≡ 𝟘
+    -- A semiring with meet is said to be trivial if 𝟙 ≡ 𝟘.
+    --
+    -- This implies that all values of type M are equal, see
+    -- Graded.Modality.Properties.Equivalence.≡-trivial.
+
+    Trivial : Set a
+    Trivial = 𝟙 ≡ 𝟘
 
   ·-distribˡ-∧ : _·_ DistributesOverˡ _∧_
   ·-distribˡ-∧ = proj₁ ·-distrib-∧
@@ -77,16 +79,18 @@ record Semiring-with-meet : Set a where
   +-distribʳ-∧ : _+_ DistributesOverʳ _∧_
   +-distribʳ-∧ = proj₂ +-distrib-∧
 
-  +-·-Semiring′ : Semiring a a
-  +-·-Semiring′ = record
-    { Carrier = M
-    ; _≈_ = _≡_
-    ; _+_ = _+_
-    ; _*_ = _·_
-    ; 0# = 𝟘
-    ; 1# = 𝟙
-    ; isSemiring = +-·-Semiring
-    }
+  transparent
+
+    +-·-Semiring′ : Semiring a a
+    +-·-Semiring′ = record
+      { Carrier = M
+      ; _≈_ = _≡_
+      ; _+_ = _+_
+      ; _*_ = _·_
+      ; 0# = 𝟘
+      ; 1# = 𝟙
+      ; isSemiring = +-·-Semiring
+      }
 
   open IsSemiring +-·-Semiring public
     using (

--- a/Graded/Modality/Properties/Division.agda
+++ b/Graded/Modality/Properties/Division.agda
@@ -2,6 +2,8 @@
 -- Division
 ------------------------------------------------------------------------
 
+{-# OPTIONS --hidden-argument-puns #-}
+
 import Graded.Modality
 
 module Graded.Modality.Properties.Division
@@ -31,27 +33,29 @@ private variable
 ------------------------------------------------------------------------
 -- The relation _/_≡_
 
--- Least-such-that P p means that p is the least value which
--- satisfies P.
+transparent
 
-Least-such-that : (M → Set a) → M → Set a
-Least-such-that P p = P p × (∀ q → P q → p ≤ q)
+  -- Least-such-that P p means that p is the least value which
+  -- satisfies P.
 
--- The relation p / q ≤ r is inhabited if "p divided by q" is bounded
--- by r.
+  Least-such-that : (M → Set a) → M → Set a
+  Least-such-that P p = P p × (∀ q → P q → p ≤ q)
 
-infix 4 _/_≤_
+  -- The relation p / q ≤ r is inhabited if "p divided by q" is
+  -- bounded by r.
 
-_/_≤_ : M → M → M → Set a
-p / q ≤ r = p ≤ q · r
+  infix 4 _/_≤_
 
--- The relation p / q ≡ r is inhabited if r is the least value for
--- which p / q ≤_ is inhabited.
+  _/_≤_ : M → M → M → Set a
+  p / q ≤ r = p ≤ q · r
 
-infix 4 _/_≡_
+  -- The relation p / q ≡ r is inhabited if r is the least value for
+  -- which p / q ≤_ is inhabited.
 
-_/_≡_ : M → M → M → Set a
-p / q ≡ r = Least-such-that (p / q ≤_) r
+  infix 4 _/_≡_
+
+  _/_≡_ : M → M → M → Set a
+  p / q ≡ r = Least-such-that (p / q ≤_) r
 
 -- The relation _/_≤_ is total if 𝟘 is the greatest value.
 
@@ -63,32 +67,35 @@ p / q ≡ r = Least-such-that (p / q ≤_) r
      p ≤ q · 𝟘  →⟨ idᶠ ⟩
      p / q ≤ 𝟘  □)
 
--- The relation _/_≡_ is total if equality is decidable, 𝟘 is the
--- greatest value, and all "decidable subsets" that contain 𝟘 and are
--- closed under _∧_ have a least value.
+opaque
+  unfolding /≤-total
 
-/≡-total :
-  Decidable (_≡_ {A = M}) →
-  (∀ p → p ≤ 𝟘) →
-  ((P : M → Set a) → (∀ p → Dec (P p)) →
-   P 𝟘 → (∀ p q → P p → P q → P (p ∧ q)) →
-   ∃ (Least-such-that P)) →
-  ∃ (p / q ≡_)
-/≡-total {p = p} {q = q} dec ≤𝟘 limit =
-  limit (p / q ≤_) p/q≤? (/≤-total ≤𝟘 .proj₂) lemma
-  where
-  p/q≤? : ∀ r → Dec (p / q ≤ r)
-  p/q≤? _ = ≡-decidable→≤-decidable dec _ _
+  -- The relation _/_≡_ is total if equality is decidable, 𝟘 is the
+  -- greatest value, and all "decidable subsets" that contain 𝟘 and
+  -- are closed under _∧_ have a least value.
 
-  lemma :
-    (r₁ r₂ : M) →
-    p / q ≤ r₁ → p / q ≤ r₂ → p / q ≤ r₁ ∧ r₂
-  lemma r₁ r₂ p/q≤r₁ p/q≤r₂ = begin
-    p                ≤⟨ ∧-greatest-lower-bound p/q≤r₁ p/q≤r₂ ⟩
-    q · r₁ ∧ q · r₂  ≡˘⟨ ·-distribˡ-∧ _ _ _ ⟩
-    q · (r₁ ∧ r₂)    ∎
+  /≡-total :
+    Decidable (_≡_ {A = M}) →
+    (∀ p → p ≤ 𝟘) →
+    ((P : M → Set a) → (∀ p → Dec (P p)) →
+     P 𝟘 → (∀ p q → P p → P q → P (p ∧ q)) →
+     ∃ (Least-such-that P)) →
+    ∃ (p / q ≡_)
+  /≡-total {p = p} {q = q} dec ≤𝟘 limit =
+    limit (p / q ≤_) p/q≤? (/≤-total ≤𝟘 .proj₂) lemma
     where
-    open Tools.Reasoning.PartialOrder ≤-poset
+    p/q≤? : ∀ r → Dec (p / q ≤ r)
+    p/q≤? _ = ≡-decidable→≤-decidable dec _ _
+
+    lemma :
+      (r₁ r₂ : M) →
+      p / q ≤ r₁ → p / q ≤ r₂ → p / q ≤ r₁ ∧ r₂
+    lemma r₁ r₂ p/q≤r₁ p/q≤r₂ = begin
+      p                ≤⟨ ∧-greatest-lower-bound p/q≤r₁ p/q≤r₂ ⟩
+      q · r₁ ∧ q · r₂  ≡˘⟨ ·-distribˡ-∧ _ _ _ ⟩
+      q · (r₁ ∧ r₂)    ∎
+      where
+      open Tools.Reasoning.PartialOrder ≤-poset
 
 -- The relation _/_≡_ is functional.
 
@@ -165,6 +172,7 @@ p / q ≡ r = Least-such-that (p / q ≤_) r
   where
   open Tools.Reasoning.PartialOrder ≤-poset
 
+  r′ : M
   r′ = surj .proj₁
 
   p≡qr′ : p ≡ q · r′
@@ -246,16 +254,18 @@ p / q ≡ r = Least-such-that (p / q ≤_) r
 ------------------------------------------------------------------------
 -- The predicate Supports-division-by
 
--- The property of supporting division by a given value.
+transparent
 
-Supports-division-by : M → Set a
-Supports-division-by q =
-  ∃ λ (_/q : M → M) → ∀ p r → (p /q) ≤ r ⇔ p ≤ q · r
+  -- The property of supporting division by a given value.
 
--- The property of supporting division.
+  Supports-division-by : M → Set a
+  Supports-division-by q =
+    ∃ λ (_/q : M → M) → ∀ p r → (p /q) ≤ r ⇔ p ≤ q · r
 
-Supports-division : Set a
-Supports-division = ∀ p → Supports-division-by p
+  -- The property of supporting division.
+
+  Supports-division : Set a
+  Supports-division = ∀ p → Supports-division-by p
 
 -- "𝕄 supports division by q" is logically equivalent to "for all p
 -- there is an r such that p / q ≡ r".
@@ -282,15 +292,16 @@ Supports-division-by⇔ {q = q} =
   where
   open Tools.Reasoning.PartialOrder ≤-poset
 
--- If 𝕄 supports division by q, then "p / q" is the least r such that
--- p ≤ q · r.
+opaque
+  unfolding Supports-division-by⇔
 
-/-least-≤· :
-  ((_/q , _) : Supports-division-by q) →
-  Least-such-that (λ r → p ≤ q · r) (p /q)
-/-least-≤· s = div _ .proj₂
-  where
-  div = Supports-division-by⇔ .proj₁ s
+  -- If 𝕄 supports division by q, then "p / q" is the least r such
+  -- that p ≤ q · r.
+
+  /-least-≤· :
+    ((_/q , _) : Supports-division-by q) →
+    Least-such-that (λ r → p ≤ q · r) (p /q)
+  /-least-≤· s = Supports-division-by⇔ .proj₁ s _ .proj₂
 
 -- If 𝕄 supports division by q, then p / q ≡ r is logically equivalent
 -- to "p / q is equal to r".
@@ -302,32 +313,43 @@ Supports-division-by⇔ {q = q} =
     /≡-functional (/-least-≤· s)
   , (λ { refl → /-least-≤· s })
 
--- If 𝕄 supports division by q, then the associated division operation
--- is monotone.
+opaque
+  unfolding Supports-division-by⇔
 
-/-monotoneˡ′ :
-  ((_/q , _) : Supports-division-by q) →
-  ∀ p₁ p₂ → p₁ ≤ p₂ → (p₁ /q) ≤ (p₂ /q)
-/-monotoneˡ′ s p₁ p₂ = /-monotoneˡ (div p₁ .proj₂) (div p₂ .proj₂)
-  where
-  div = Supports-division-by⇔ .proj₁ s
+  -- If 𝕄 supports division by q, then the associated division
+  -- operation is monotone.
 
--- Division by 𝟙 is supported, and the value of p divided by 𝟙 is p.
+  /-monotoneˡ′ :
+    ((_/q , _) : Supports-division-by q) →
+    ∀ p₁ p₂ → p₁ ≤ p₂ → (p₁ /q) ≤ (p₂ /q)
+  /-monotoneˡ′ {q} s p₁ p₂ =
+    /-monotoneˡ (div p₁ .proj₂) (div p₂ .proj₂)
+    where
+    div : ∀ p → ∃ λ r → p / q ≡ r
+    div = Supports-division-by⇔ .proj₁ s
 
-/𝟙≡′ : ∃ λ ((_/𝟙 , _) : Supports-division-by 𝟙) → (p /𝟙) ≡ p
-/𝟙≡′ =
-    Supports-division-by⇔ .proj₂ (λ _ → _ , /𝟙≡)
-  , refl
+opaque
+  unfolding Supports-division-by⇔
 
--- If 𝟙 is the least value and 𝟘 the greatest one, then division by 𝟘
--- is supported and the value of p divided by 𝟘 is 𝟙.
+  -- Division by 𝟙 is supported, and the value of p divided by 𝟙 is p.
 
-/𝟘≡𝟙′ :
-  (∀ p → 𝟙 ≤ p) → (∀ p → p ≤ 𝟘) →
-  (∃ λ ((_/𝟘 , _) : Supports-division-by 𝟘) → (p /𝟘) ≡ 𝟙)
-/𝟘≡𝟙′ 𝟙≤ ≤𝟘 =
-    Supports-division-by⇔ .proj₂ (λ _ → _ , /𝟘≡𝟙 𝟙≤ (≤𝟘 _))
-  , refl
+  /𝟙≡′ : ∃ λ ((_/𝟙 , _) : Supports-division-by 𝟙) → (p /𝟙) ≡ p
+  /𝟙≡′ =
+      Supports-division-by⇔ .proj₂ (λ _ → _ , /𝟙≡)
+    , refl
+
+opaque
+  unfolding Supports-division-by⇔
+
+  -- If 𝟙 is the least value and 𝟘 the greatest one, then division by
+  -- 𝟘 is supported and the value of p divided by 𝟘 is 𝟙.
+
+  /𝟘≡𝟙′ :
+    (∀ p → 𝟙 ≤ p) → (∀ p → p ≤ 𝟘) →
+    (∃ λ ((_/𝟘 , _) : Supports-division-by 𝟘) → (p /𝟘) ≡ 𝟙)
+  /𝟘≡𝟙′ 𝟙≤ ≤𝟘 =
+      Supports-division-by⇔ .proj₂ (λ _ → _ , /𝟘≡𝟙 𝟙≤ (≤𝟘 _))
+    , refl
 
 -- If 𝟙 is the least value and division by p is supported, then the
 -- value of p divided by p is 𝟙.

--- a/Graded/Modality/Properties/PartialOrder.agda
+++ b/Graded/Modality/Properties/PartialOrder.agda
@@ -60,15 +60,17 @@ private
   ; antisym    = ≤-antisym
   }
 
--- (M, ≤) is a poset
+transparent
 
-≤-poset : Poset _ _ _
-≤-poset = record
-  { Carrier        = M
-  ; _≈_            = _≡_
-  ; _≤_            = _≤_
-  ; isPartialOrder = ≤-partial
-  }
+  -- (M, ≤) is a poset
+
+  ≤-poset : Poset a a a
+  ≤-poset = record
+    { Carrier        = M
+    ; _≈_            = _≡_
+    ; _≤_            = _≤_
+    ; isPartialOrder = ≤-partial
+    }
 
 -- If _≡_ is decidable (for M), then _≤_ is decidable.
 

--- a/Graded/Modality/Properties/Star.agda
+++ b/Graded/Modality/Properties/Star.agda
@@ -68,32 +68,23 @@ private
 -- The operator _⊛_▷ r is idempotent on 𝟘.
 
 ⊛-idem-𝟘 : (r : M) → (_⊛_▷ r) IdempotentOn 𝟘
-⊛-idem-𝟘 r = ≤-antisym (⊛-ineq₂ 𝟘 𝟘 r) 𝟘≤𝟘⊛𝟘
+⊛-idem-𝟘 r =
+  ≤-antisym (⊛-ineq₂ 𝟘 𝟘 r) $ begin
+    𝟘                      ≈˘⟨ ·-zeroʳ (𝟘 ⊛ 𝟘 ▷ r) ⟩
+    (𝟘 ⊛ 𝟘 ▷ r) · 𝟘        ≤⟨ ·-sub-distribʳ-⊛ r 𝟘 𝟘 𝟘 ⟩
+    (𝟘 · 𝟘) ⊛ (𝟘 · 𝟘) ▷ r  ≈⟨ ⊛ᵣ-cong (·-zeroˡ 𝟘) (·-zeroˡ 𝟘) ⟩
+    𝟘 ⊛ 𝟘 ▷ r              ∎
   where
   open import Tools.Reasoning.PartialOrder ≤-poset
-  𝟘≤𝟘⊛𝟘 = begin
-    𝟘                     ≈˘⟨ ·-zeroʳ (𝟘 ⊛ 𝟘 ▷ r) ⟩
-    (𝟘 ⊛ 𝟘 ▷ r) · 𝟘       ≤⟨ ·-sub-distribʳ-⊛ r 𝟘 𝟘 𝟘 ⟩
-    (𝟘 · 𝟘) ⊛ (𝟘 · 𝟘) ▷ r ≈⟨ ⊛ᵣ-cong (·-zeroˡ 𝟘) (·-zeroˡ 𝟘) ⟩
-    𝟘 ⊛ 𝟘 ▷ r ∎
 
--- If a "semiring with meet" has a natrec-star operator, then it has
--- an nr function.
+-- Some definitions used to implement has-nr.
 
-has-nr : Has-nr 𝕄
-has-nr = record
-  { nr          = nr′
-  ; nr-monotone = nr′-monotone
-  ; nr-·        = nr′-·
-  ; nr-+        = nr′-+
-  ; nr-𝟘        = nr′-𝟘
-  ; nr-positive = nr′-positive
-  ; nr-zero     = nr′-zero
-  ; nr-suc      = nr′-suc
-  }
-  where
-  nr′ : M → M → M → M → M → M
-  nr′ p r z s n = (z ∧ n) ⊛ s + p · n ▷ r
+private module Has-nr-lemmas where
+
+  transparent
+
+    nr′ : M → M → M → M → M → M
+    nr′ p r z s n = (z ∧ n) ⊛ s + p · n ▷ r
 
   nr′-monotone :
     z₁ ≤ z₂ → s₁ ≤ s₂ → n₁ ≤ n₂ →
@@ -129,6 +120,7 @@ has-nr = record
     where
     open Tools.Reasoning.PartialOrder ≤-poset
 
+    lemma : (s₁ + p · n₁) + (s₂ + p · n₂) ≤ (s₁ + s₂) + p · (n₁ + n₂)
     lemma = begin
       (s₁ + p · n₁) + (s₂ + p · n₂)  ≡⟨ +-assoc _ _ _ ⟩
       s₁ + (p · n₁ + (s₂ + p · n₂))  ≡˘⟨ cong (_ +_) (+-assoc _ _ _) ⟩
@@ -173,6 +165,25 @@ has-nr = record
     s + p · n + r · ((z ∧ n) ⊛ s + p · n ▷ r)    ∎
     where
     open Tools.Reasoning.PartialOrder ≤-poset
+
+transparent
+
+  -- If a "semiring with meet" has a natrec-star operator, then it has
+  -- an nr function.
+
+  has-nr : Has-nr 𝕄
+  has-nr = record
+    { nr          = nr′
+    ; nr-monotone = nr′-monotone
+    ; nr-·        = nr′-·
+    ; nr-+        = nr′-+
+    ; nr-𝟘        = nr′-𝟘
+    ; nr-positive = nr′-positive
+    ; nr-zero     = nr′-zero
+    ; nr-suc      = nr′-suc
+    }
+    where
+    open Has-nr-lemmas
 
 -- The function Has-nr.nr has-nr p r z s is decreasing.
 

--- a/Graded/Modality/Variant.agda
+++ b/Graded/Modality/Variant.agda
@@ -2,6 +2,8 @@
 -- Modality variants
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 open import Tools.Level
 
 module Graded.Modality.Variant (a : Level) where

--- a/Graded/Mode.agda
+++ b/Graded/Mode.agda
@@ -54,6 +54,8 @@ private variable
 ------------------------------------------------------------------------
 -- Some eliminators or similar principles
 
+-- transparent
+
 private
 
   -- A lemma used in the implementation of 𝟘ᵐ-allowed-elim.
@@ -66,16 +68,19 @@ private
   𝟘ᵐ-allowed-elim-helper true  t f = t _
   𝟘ᵐ-allowed-elim-helper false t f = f (λ ())
 
--- One can prove that a predicate holds for 𝟘ᵐ-allowed by proving that
--- it holds given that T 𝟘ᵐ-allowed is inhabited, and that it holds
--- given that T 𝟘ᵐ-allowed is not inhabited.
+opaque
+  unfolding 𝟘ᵐ-allowed-elim-helper
 
-𝟘ᵐ-allowed-elim :
-  ∀ {p} {P : Set p} →
-  (T 𝟘ᵐ-allowed → P) →
-  ((not-ok : ¬ T 𝟘ᵐ-allowed) → P) →
-  P
-𝟘ᵐ-allowed-elim = 𝟘ᵐ-allowed-elim-helper 𝟘ᵐ-allowed
+  -- One can prove that a predicate holds for 𝟘ᵐ-allowed by proving
+  -- that it holds given that T 𝟘ᵐ-allowed is inhabited, and that it
+  -- holds given that T 𝟘ᵐ-allowed is not inhabited.
+
+  𝟘ᵐ-allowed-elim :
+    ∀ {p} {P : Set p} →
+    (T 𝟘ᵐ-allowed → P) →
+    ((not-ok : ¬ T 𝟘ᵐ-allowed) → P) →
+    P
+  𝟘ᵐ-allowed-elim = 𝟘ᵐ-allowed-elim-helper 𝟘ᵐ-allowed
 
 -- An eliminator for modes.
 
@@ -91,42 +96,55 @@ Mode-elim _ z o = λ where
 ------------------------------------------------------------------------
 -- 𝟘ᵐ? and 𝟙ᵐ′
 
--- A mode that is 𝟘ᵐ[ something ] if 𝟘ᵐ-allowed is true, and otherwise
--- 𝟙ᵐ.
+opaque
+  unfolding 𝟘ᵐ-allowed-elim
 
-𝟘ᵐ? : Mode
-𝟘ᵐ? = 𝟘ᵐ-allowed-elim 𝟘ᵐ[_] (λ _ → 𝟙ᵐ)
+  -- A mode that is 𝟘ᵐ[ something ] if 𝟘ᵐ-allowed is true, and otherwise
+  -- 𝟙ᵐ.
 
--- One can prove that a predicate holds for 𝟘ᵐ? by proving that it
--- holds for 𝟘ᵐ[ ok ] (for any ok) and that it holds for 𝟙ᵐ (under the
--- assumption that T 𝟘ᵐ-allowed is not inhabited).
+  𝟘ᵐ? : Mode
+  𝟘ᵐ? = 𝟘ᵐ-allowed-elim 𝟘ᵐ[_] (λ _ → 𝟙ᵐ)
 
-𝟘ᵐ?-elim :
-  ∀ {p} (P : Mode → Set p) →
-  (⦃ ok : T 𝟘ᵐ-allowed ⦄ → P 𝟘ᵐ) →
-  (¬ T 𝟘ᵐ-allowed → P 𝟙ᵐ) →
-  P 𝟘ᵐ?
-𝟘ᵐ?-elim P = lemma _ refl
-  where
-  lemma :
-    ∀ b (eq : b ≡ 𝟘ᵐ-allowed)
-    (z : ⦃ ok : T b ⦄ → P 𝟘ᵐ[ subst T eq ok ])
-    (o : ¬ T b → P 𝟙ᵐ) →
-    P (𝟘ᵐ-allowed-elim-helper b (λ ok → 𝟘ᵐ[ subst T eq ok ]) (λ _ → 𝟙ᵐ))
-  lemma true  _ z _ = z ⦃ ok = _ ⦄
-  lemma false _ _ o = o (λ ())
+opaque
+  unfolding 𝟘ᵐ?
 
--- A variant of 𝟙ᵐ.
+  -- One can prove that a predicate holds for 𝟘ᵐ? by proving that it
+  -- holds for 𝟘ᵐ[ ok ] (for any ok) and that it holds for 𝟙ᵐ (under
+  -- the assumption that T 𝟘ᵐ-allowed is not inhabited).
 
-𝟙ᵐ′ : Mode
-𝟙ᵐ′ = 𝟘ᵐ-allowed-elim (λ _ → 𝟙ᵐ) (λ _ → 𝟙ᵐ)
+  𝟘ᵐ?-elim :
+    ∀ {p} (P : Mode → Set p) →
+    (⦃ ok : T 𝟘ᵐ-allowed ⦄ → P 𝟘ᵐ) →
+    (¬ T 𝟘ᵐ-allowed → P 𝟙ᵐ) →
+    P 𝟘ᵐ?
+  𝟘ᵐ?-elim P = lemma _ refl
+    where
+    lemma :
+      ∀ b (eq : b ≡ 𝟘ᵐ-allowed)
+      (z : ⦃ ok : T b ⦄ → P 𝟘ᵐ[ subst T eq ok ])
+      (o : ¬ T b → P 𝟙ᵐ) →
+      P (𝟘ᵐ-allowed-elim-helper
+           b (λ ok → 𝟘ᵐ[ subst T eq ok ]) (λ _ → 𝟙ᵐ))
+    lemma true  _ z _ = z ⦃ ok = _ ⦄
+    lemma false _ _ o = o (λ ())
 
--- 𝟙ᵐ′ is equal to 𝟙ᵐ.
+opaque
+  unfolding 𝟘ᵐ-allowed-elim
 
-𝟙ᵐ′≡𝟙ᵐ : 𝟙ᵐ′ ≡ 𝟙ᵐ
-𝟙ᵐ′≡𝟙ᵐ with 𝟘ᵐ-allowed
-… | true  = refl
-… | false = refl
+  -- A variant of 𝟙ᵐ.
+
+  𝟙ᵐ′ : Mode
+  𝟙ᵐ′ = 𝟘ᵐ-allowed-elim (λ _ → 𝟙ᵐ) (λ _ → 𝟙ᵐ)
+
+opaque
+  unfolding 𝟙ᵐ′
+
+  -- 𝟙ᵐ′ is equal to 𝟙ᵐ.
+
+  𝟙ᵐ′≡𝟙ᵐ : 𝟙ᵐ′ ≡ 𝟙ᵐ
+  𝟙ᵐ′≡𝟙ᵐ with 𝟘ᵐ-allowed
+  … | true  = refl
+  … | false = refl
 
 -- 𝟙ᵐ′ is not equal to 𝟘ᵐ[ ok ].
 
@@ -143,27 +161,29 @@ Mode-elim _ z o = λ where
 ------------------------------------------------------------------------
 -- Some basic definitions
 
--- The join of two modes.
+transparent
 
-infixr 40 _∨ᵐ_
+  -- The join of two modes.
 
-_∨ᵐ_ : Mode → Mode → Mode
-𝟘ᵐ ∨ᵐ m = m
-𝟙ᵐ ∨ᵐ m = 𝟙ᵐ
+  infixr 40 _∨ᵐ_
 
--- Multiplication of modes.
+  _∨ᵐ_ : Mode → Mode → Mode
+  𝟘ᵐ ∨ᵐ m = m
+  𝟙ᵐ ∨ᵐ m = 𝟙ᵐ
 
-infixr 45 _·ᵐ_
+  -- Multiplication of modes.
 
-_·ᵐ_ : Mode → Mode → Mode
-𝟘ᵐ ·ᵐ _ = 𝟘ᵐ
-𝟙ᵐ ·ᵐ m = m
+  infixr 45 _·ᵐ_
 
--- Modes can be translated to quantities.
+  _·ᵐ_ : Mode → Mode → Mode
+  𝟘ᵐ ·ᵐ _ = 𝟘ᵐ
+  𝟙ᵐ ·ᵐ m = m
 
-⌜_⌝ : Mode → M
-⌜ 𝟘ᵐ ⌝ = 𝟘
-⌜ 𝟙ᵐ ⌝ = 𝟙
+  -- Modes can be translated to quantities.
+
+  ⌜_⌝ : Mode → M
+  ⌜ 𝟘ᵐ ⌝ = 𝟘
+  ⌜ 𝟙ᵐ ⌝ = 𝟙
 
 private
 
@@ -174,69 +194,78 @@ private
     (yes _) → 𝟘ᵐ[ ok ]
     (no _)  → 𝟙ᵐ
 
--- Quantities can be translated to modes (in a potentially lossy way).
+opaque
+  unfolding 𝟘ᵐ-allowed-elim ⌞_⌟′
 
-⌞_⌟ : M → Mode
-⌞ p ⌟ = 𝟘ᵐ-allowed-elim ⌞ p ⌟′ (λ _ → 𝟙ᵐ)
+  -- Quantities can be translated to modes (in a potentially lossy
+  -- way).
 
--- Modes can be scaled by quantities.
---
--- This definition is based on the typing rule for application in
--- Robert Atkey's "Syntax and Semantics of Quantitative Type Theory".
+  ⌞_⌟ : M → Mode
+  ⌞ p ⌟ = 𝟘ᵐ-allowed-elim ⌞ p ⌟′ (λ _ → 𝟙ᵐ)
 
-infixr 45 _ᵐ·_
+transparent
 
-_ᵐ·_ : Mode → M → Mode
-𝟘ᵐ ᵐ· _ = 𝟘ᵐ
-𝟙ᵐ ᵐ· p = ⌞ p ⌟
+  -- Modes can be scaled by quantities.
+  --
+  -- This definition is based on the typing rule for application in
+  -- Robert Atkey's "Syntax and Semantics of Quantitative Type
+  -- Theory".
+
+  infixr 45 _ᵐ·_
+
+  _ᵐ·_ : Mode → M → Mode
+  𝟘ᵐ ᵐ· _ = 𝟘ᵐ
+  𝟙ᵐ ᵐ· p = ⌞ p ⌟
 
 ------------------------------------------------------------------------
 -- Mode vectors
 
--- Mode vectors of the given length.
+transparent
 
-Mode-vector : Nat → Set
-Mode-vector n = Fin n → Mode
+  -- Mode vectors of the given length.
 
-private variable
-  ms : Mode-vector n
+  Mode-vector : Nat → Set
+  Mode-vector n = Fin n → Mode
 
--- An empty mode vector.
+  private variable
+    ms : Mode-vector n
 
-nilᵐ : Mode-vector 0
-nilᵐ ()
+  -- An empty mode vector.
 
--- Adds an element to the mode vector.
+  nilᵐ : Mode-vector 0
+  nilᵐ ()
 
-consᵐ : Mode → Mode-vector n → Mode-vector (1+ n)
-consᵐ m ρ x0     = m
-consᵐ m ρ (x +1) = ρ x
+  -- Adds an element to the mode vector.
 
--- The head of the mode vector.
+  consᵐ : Mode → Mode-vector n → Mode-vector (1+ n)
+  consᵐ m ρ x0     = m
+  consᵐ m ρ (x +1) = ρ x
 
-headᵐ : Mode-vector (1+ n) → Mode
-headᵐ ρ = ρ x0
+  -- The head of the mode vector.
 
--- The tail of the mode vector.
+  headᵐ : Mode-vector (1+ n) → Mode
+  headᵐ ρ = ρ x0
 
-tailᵐ : Mode-vector (1+ n) → Mode-vector n
-tailᵐ ρ x = ρ (x +1)
+  -- The tail of the mode vector.
 
--- A constant vector.
+  tailᵐ : Mode-vector (1+ n) → Mode-vector n
+  tailᵐ ρ x = ρ (x +1)
 
-replicateᵐ : Mode → Mode-vector n
-replicateᵐ m _ = m
+  -- A constant vector.
 
--- Converts usage contexts to mode vectors.
+  replicateᵐ : Mode → Mode-vector n
+  replicateᵐ m _ = m
 
-⌞_⌟ᶜ : Conₘ n → Mode-vector n
-⌞ γ ⌟ᶜ x = ⌞ γ ⟨ x ⟩ ⌟
+  -- Converts usage contexts to mode vectors.
 
--- Converts mode vectors to usage contexts.
+  ⌞_⌟ᶜ : Conₘ n → Mode-vector n
+  ⌞ γ ⌟ᶜ x = ⌞ γ ⟨ x ⟩ ⌟
 
-⌜_⌝ᶜ : Mode-vector n → Conₘ n
-⌜_⌝ᶜ {n = 0}    _ = ε
-⌜_⌝ᶜ {n = 1+ _} ρ = ⌜ tailᵐ ρ ⌝ᶜ ∙ ⌜ headᵐ ρ ⌝
+  -- Converts mode vectors to usage contexts.
+
+  ⌜_⌝ᶜ : Mode-vector n → Conₘ n
+  ⌜_⌝ᶜ {n = 0}    _ = ε
+  ⌜_⌝ᶜ {n = 1+ _} ρ = ⌜ tailᵐ ρ ⌝ᶜ ∙ ⌜ headᵐ ρ ⌝
 
 ------------------------------------------------------------------------
 -- Properties related to 𝟘ᵐ-allowed
@@ -566,20 +595,23 @@ open IsCommutativeSemiring Mode ∨ᵐ-·ᵐ-is-commutative-semiring
   x0     → ⌞⌟-cong p≡q
   (x +1) → ⌞⌟ᶜ-cong γ≈ᶜδ x
 
--- ⌞ 𝟘 ⌟ is equal to 𝟘ᵐ[ ok ].
+opaque
+  unfolding ⌞_⌟
 
-⌞𝟘⌟ : ⌞ 𝟘 ⌟ ≡ 𝟘ᵐ[ ok ]
-⌞𝟘⌟ = lemma _ refl
-  where
-  lemma :
-    ∀ b (eq : b ≡ 𝟘ᵐ-allowed) {ok : T b} →
-    𝟘ᵐ-allowed-elim-helper b
-      (λ ok → ⌞ 𝟘 ⌟′ (subst T eq ok))
-      (λ _ → 𝟙ᵐ) ≡
-    𝟘ᵐ[ subst T eq ok ]
-  lemma true refl with 𝟘ᵐ.is-𝟘? tt 𝟘
-  … | yes _  = refl
-  … | no 𝟘≢𝟘 = ⊥-elim (𝟘≢𝟘 refl)
+  -- ⌞ 𝟘 ⌟ is equal to 𝟘ᵐ[ ok ].
+
+  ⌞𝟘⌟ : ⌞ 𝟘 ⌟ ≡ 𝟘ᵐ[ ok ]
+  ⌞𝟘⌟ = lemma _ refl
+    where
+    lemma :
+      ∀ b (eq : b ≡ 𝟘ᵐ-allowed) {ok : T b} →
+      𝟘ᵐ-allowed-elim-helper b
+        (λ ok → ⌞ 𝟘 ⌟′ (subst T eq ok))
+        (λ _ → 𝟙ᵐ) ≡
+      𝟘ᵐ[ subst T eq ok ]
+    lemma true refl with 𝟘ᵐ.is-𝟘? tt 𝟘
+    … | yes _  = refl
+    … | no 𝟘≢𝟘 = ⊥-elim (𝟘≢𝟘 refl)
 
 
 -- If p is equal to 𝟘, then ⌞ p ⌟ is equal to 𝟘ᵐ[ ok ].
@@ -600,55 +632,64 @@ open IsCommutativeSemiring Mode ∨ᵐ-·ᵐ-is-commutative-semiring
 ≡𝟘→⌞⌟≡𝟘ᵐ? : p ≡ 𝟘 → ⌞ p ⌟ ≡ 𝟘ᵐ?
 ≡𝟘→⌞⌟≡𝟘ᵐ? refl = ⌞𝟘⌟≡𝟘ᵐ?
 
--- If ⌞ p ⌟ is equal to 𝟘ᵐ[ ok ], then p is equal to 𝟘.
+opaque
+  unfolding ⌞_⌟
 
-⌞⌟≡𝟘ᵐ→≡𝟘 : ⌞ p ⌟ ≡ 𝟘ᵐ[ ok ] → p ≡ 𝟘
-⌞⌟≡𝟘ᵐ→≡𝟘 {p = p} = lemma _ refl
-  where
-  lemma :
-    ∀ b (eq : b ≡ 𝟘ᵐ-allowed) →
-    𝟘ᵐ-allowed-elim-helper b
-      (λ ok → ⌞ p ⌟′ (subst T eq ok))
-      (λ _ → 𝟙ᵐ) ≡
-    𝟘ᵐ[ ok ] →
-    p ≡ 𝟘
-  lemma true refl with 𝟘ᵐ.is-𝟘? tt p
-  … | yes p≡𝟘 = λ _ → p≡𝟘
-  … | no _    = λ ()
+  -- If ⌞ p ⌟ is equal to 𝟘ᵐ[ ok ], then p is equal to 𝟘.
 
--- If p is not equal to 𝟘, then ⌞ p ⌟ is equal to 𝟙ᵐ.
+  ⌞⌟≡𝟘ᵐ→≡𝟘 : ⌞ p ⌟ ≡ 𝟘ᵐ[ ok ] → p ≡ 𝟘
+  ⌞⌟≡𝟘ᵐ→≡𝟘 {p = p} = lemma _ refl
+    where
+    lemma :
+      ∀ b (eq : b ≡ 𝟘ᵐ-allowed) →
+      𝟘ᵐ-allowed-elim-helper b
+        (λ ok → ⌞ p ⌟′ (subst T eq ok))
+        (λ _ → 𝟙ᵐ) ≡
+      𝟘ᵐ[ ok ] →
+      p ≡ 𝟘
+    lemma true refl with 𝟘ᵐ.is-𝟘? tt p
+    … | yes p≡𝟘 = λ _ → p≡𝟘
+    … | no _    = λ ()
 
-≢𝟘→⌞⌟≡𝟙ᵐ : p ≢ 𝟘 → ⌞ p ⌟ ≡ 𝟙ᵐ
-≢𝟘→⌞⌟≡𝟙ᵐ {p = p} p≢𝟘 = lemma _ refl
-  where
-  lemma :
-    ∀ b (eq : b ≡ 𝟘ᵐ-allowed) →
-    𝟘ᵐ-allowed-elim-helper b
-      (λ ok → ⌞ p ⌟′ (subst T eq ok))
-      (λ _ → 𝟙ᵐ) ≡
-    𝟙ᵐ
-  lemma false refl = refl
-  lemma true  refl with 𝟘ᵐ.is-𝟘? tt p
-  … | no _    = refl
-  … | yes p≡𝟘 = ⊥-elim (p≢𝟘 p≡𝟘)
+opaque
+  unfolding ⌞_⌟
 
--- If 𝟘ᵐ is allowed and ⌞ p ⌟ is equal to 𝟙ᵐ, then p is not equal to
--- 𝟘.
+  -- If p is not equal to 𝟘, then ⌞ p ⌟ is equal to 𝟙ᵐ.
 
-⌞⌟≡𝟙ᵐ→≢𝟘 : T 𝟘ᵐ-allowed → ⌞ p ⌟ ≡ 𝟙ᵐ → p ≢ 𝟘
-⌞⌟≡𝟙ᵐ→≢𝟘 {p = p} ok = lemma _ refl
-  where
-  lemma :
-    ∀ b (eq : b ≡ 𝟘ᵐ-allowed) →
-    𝟘ᵐ-allowed-elim-helper b
-      (λ ok → ⌞ p ⌟′ (subst T eq ok))
-      (λ _ → 𝟙ᵐ) ≡
-    𝟙ᵐ →
-    p ≢ 𝟘
-  lemma false refl = ⊥-elim ok
-  lemma true  refl with 𝟘ᵐ.is-𝟘? tt p
-  … | yes _  = λ ()
-  … | no p≢𝟘 = λ _ → p≢𝟘
+  ≢𝟘→⌞⌟≡𝟙ᵐ : p ≢ 𝟘 → ⌞ p ⌟ ≡ 𝟙ᵐ
+  ≢𝟘→⌞⌟≡𝟙ᵐ {p = p} p≢𝟘 = lemma _ refl
+    where
+    lemma :
+      ∀ b (eq : b ≡ 𝟘ᵐ-allowed) →
+      𝟘ᵐ-allowed-elim-helper b
+        (λ ok → ⌞ p ⌟′ (subst T eq ok))
+        (λ _ → 𝟙ᵐ) ≡
+      𝟙ᵐ
+    lemma false refl = refl
+    lemma true  refl with 𝟘ᵐ.is-𝟘? tt p
+    … | no _    = refl
+    … | yes p≡𝟘 = ⊥-elim (p≢𝟘 p≡𝟘)
+
+opaque
+  unfolding ⌞_⌟
+
+  -- If 𝟘ᵐ is allowed and ⌞ p ⌟ is equal to 𝟙ᵐ, then p is not equal to
+  -- 𝟘.
+
+  ⌞⌟≡𝟙ᵐ→≢𝟘 : T 𝟘ᵐ-allowed → ⌞ p ⌟ ≡ 𝟙ᵐ → p ≢ 𝟘
+  ⌞⌟≡𝟙ᵐ→≢𝟘 {p = p} ok = lemma _ refl
+    where
+    lemma :
+      ∀ b (eq : b ≡ 𝟘ᵐ-allowed) →
+      𝟘ᵐ-allowed-elim-helper b
+        (λ ok → ⌞ p ⌟′ (subst T eq ok))
+        (λ _ → 𝟙ᵐ) ≡
+      𝟙ᵐ →
+      p ≢ 𝟘
+    lemma false refl = ⊥-elim ok
+    lemma true  refl with 𝟘ᵐ.is-𝟘? tt p
+    … | yes _  = λ ()
+    … | no p≢𝟘 = λ _ → p≢𝟘
 
 -- ⌞ 𝟙 ⌟ is equal to 𝟙ᵐ.
 

--- a/Tools/Algebra.agda
+++ b/Tools/Algebra.agda
@@ -2,6 +2,8 @@
 -- Algebraic structures and properties
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 open import Tools.Relation
 
 module Tools.Algebra {a} (A : Set a) where

--- a/Tools/Fin.agda
+++ b/Tools/Fin.agda
@@ -2,6 +2,8 @@
 -- Finite sets
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 module Tools.Fin where
 
 open import Data.Fin.Properties using () renaming (_≟_ to _≟ⱽ_) public

--- a/Tools/Function.agda
+++ b/Tools/Function.agda
@@ -2,6 +2,8 @@
 -- Function combinators
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 module Tools.Function where
 
 open import Function.Base
@@ -235,35 +237,41 @@ Function-extensionality a p =
     ∃ λ (f⁻¹-f : ∀ x → f⁻¹ (f x) ≡ x) →
     ∀ x → cong f (f⁻¹-f x) ≡ f-f⁻¹ (f x)
 
--- If function extensionality holds, then pointwise equal functions
--- are equal.
+opaque
 
-ext :
-  {A : Set a} {P : A → Set p} {f g : (x : A) → P x} →
-  Function-extensionality a p →
-  (∀ x → f x ≡ g x) → f ≡ g
-ext fe = fe .proj₁
+  -- If function extensionality holds, then pointwise equal functions
+  -- are equal.
 
--- Is-proposition is closed under Π A (assuming function
--- extensionality).
+  ext :
+    {A : Set a} {P : A → Set p} {f g : (x : A) → P x} →
+    Function-extensionality a p →
+    (∀ x → f x ≡ g x) → f ≡ g
+  ext fe = fe .proj₁
 
-Is-proposition-Π :
-  {A : Set a} {P : A → Set p} →
-  Function-extensionality a p →
-  (∀ x → Is-proposition (P x)) →
-  Is-proposition (∀ x → P x)
-Is-proposition-Π fe prop = ext fe λ _ → prop _
+opaque
 
--- If A is a proposition, then Dec A is a proposition, assuming
--- function extensionality.
+  -- Is-proposition is closed under Π A (assuming function
+  -- extensionality).
 
-Is-proposition-Dec :
-  {A : Set a} →
-  Function-extensionality a lzero →
-  Is-proposition A → Is-proposition (Dec A)
-Is-proposition-Dec = λ where
-  _  prop {x = yes x} {y = yes y} → cong yes prop
-  _  _    {x = yes x} {y = no y}  → ⊥-elim (y x)
-  _  _    {x = no x}  {y = yes y} → ⊥-elim (x y)
-  fe _    {x = no x}  {y = no y}  →
-    cong no (Is-proposition-Π fe λ _ → ⊥-propositional)
+  Is-proposition-Π :
+    {A : Set a} {P : A → Set p} →
+    Function-extensionality a p →
+    (∀ x → Is-proposition (P x)) →
+    Is-proposition (∀ x → P x)
+  Is-proposition-Π fe prop = ext fe λ _ → prop _
+
+opaque
+
+  -- If A is a proposition, then Dec A is a proposition, assuming
+  -- function extensionality.
+
+  Is-proposition-Dec :
+    {A : Set a} →
+    Function-extensionality a lzero →
+    Is-proposition A → Is-proposition (Dec A)
+  Is-proposition-Dec = λ where
+    _  prop {x = yes x} {y = yes y} → cong yes prop
+    _  _    {x = yes x} {y = no y}  → ⊥-elim (y x)
+    _  _    {x = no x}  {y = yes y} → ⊥-elim (x y)
+    fe _    {x = no x}  {y = no y}  →
+      cong no (Is-proposition-Π fe λ _ → ⊥-propositional)

--- a/Tools/Level.agda
+++ b/Tools/Level.agda
@@ -2,6 +2,8 @@
 -- Universe levels
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 module Tools.Level where
 
 open import Agda.Primitive using (lzero; lsuc; Level; _⊔_) public

--- a/Tools/Nat.agda
+++ b/Tools/Nat.agda
@@ -189,97 +189,109 @@ T-== = ≡ᵇ⇒≡ _ _ , ≡⇒≡ᵇ _ _
 ∃< 0      p = false
 ∃< (1+ n) p = p n ∨ ∃< n p
 
--- ∃< is correctly defined.
+opaque
+  unfolding ∃<
 
-∃<⇔ : T (∃< n p) ⇔ (∃ λ m → m < n × T (p m))
-∃<⇔ {n = 0} {p = p} =
-  ⊥                          ⇔⟨ (⊥-elim , λ { (_ , () , _) }) ⟩
-  (∃ λ m → m < 0 × T (p m))  □⇔
-∃<⇔ {n = 1+ n} {p = p} =
-  T (p n ∨ ∃< n p)                     ⇔⟨ T-∨ ⟩
-  T (p n) ⊎ T (∃< n p)                 ⇔⟨ id⇔ ⊎-cong-⇔ ∃<⇔ ⟩
-  T (p n) ⊎ (∃ λ m → m < n × T (p m))  ⇔⟨ (λ where
-                                             (inj₁ p-n)             → n , ≤-refl , p-n
-                                             (inj₂ (m , m<n , p-m)) → m , ≤-trans m<n (n≤1+n _) , p-m)
-                                        , (λ (m , m<1+n , p-m) →
-                                             case <-cmp m n of λ where
-                                               (tri< m<n _    _)   → inj₂ (m , m<n , p-m)
-                                               (tri≈ _   refl _)   → inj₁ p-m
-                                               (tri> _   _    m>n) → ⊥-elim (m+n≮n _ _ (≤-trans m<1+n m>n)))
-                                        ⟩
-  (∃ λ m → m < 1+ n × T (p m))         □⇔
+  -- ∃< is correctly defined.
+
+  ∃<⇔ : T (∃< n p) ⇔ (∃ λ m → m < n × T (p m))
+  ∃<⇔ {n = 0} {p = p} =
+    ⊥                          ⇔⟨ (⊥-elim , λ { (_ , () , _) }) ⟩
+    (∃ λ m → m < 0 × T (p m))  □⇔
+  ∃<⇔ {n = 1+ n} {p = p} =
+    T (p n ∨ ∃< n p)                     ⇔⟨ T-∨ ⟩
+    T (p n) ⊎ T (∃< n p)                 ⇔⟨ id⇔ ⊎-cong-⇔ ∃<⇔ ⟩
+    T (p n) ⊎ (∃ λ m → m < n × T (p m))  ⇔⟨ (λ where
+                                               (inj₁ p-n)             → n , ≤-refl , p-n
+                                               (inj₂ (m , m<n , p-m)) → m , ≤-trans m<n (n≤1+n _) , p-m)
+                                          , (λ (m , m<1+n , p-m) →
+                                               case <-cmp m n of λ where
+                                                 (tri< m<n _    _)   → inj₂ (m , m<n , p-m)
+                                                 (tri≈ _   refl _)   → inj₁ p-m
+                                                 (tri> _   _    m>n) → ⊥-elim (m+n≮n _ _ (≤-trans m<1+n m>n)))
+                                          ⟩
+    (∃ λ m → m < 1+ n × T (p m))         □⇔
 
 -- ∃≤ n p is true if there is some m ≤ n such that p m holds.
 
 ∃≤ : Nat → (Nat → Bool) → Bool
 ∃≤ n = ∃< (1+ n)
 
--- ∃≤ is correctly defined.
+opaque
+  unfolding ∃≤
 
-∃≤⇔ : T (∃≤ n p) ⇔ (∃ λ m → m ≤ n × T (p m))
-∃≤⇔ {n = n} {p = p} =
-  T (∃≤ n p)                    ⇔⟨ id⇔ ⟩
-  T (∃< (1+ n) p)               ⇔⟨ ∃<⇔ ⟩
-  (∃ λ m → m < 1+ n × T (p m))  ⇔⟨ (Σ-cong-⇔ λ _ → ((λ { (s≤s m≤n) → m≤n }) , s≤s) ×-cong-⇔ id⇔) ⟩
-  (∃ λ m → m ≤ n × T (p m))     □⇔
+  -- ∃≤ is correctly defined.
+
+  ∃≤⇔ : T (∃≤ n p) ⇔ (∃ λ m → m ≤ n × T (p m))
+  ∃≤⇔ {n = n} {p = p} =
+    T (∃≤ n p)                    ⇔⟨ id⇔ ⟩
+    T (∃< (1+ n) p)               ⇔⟨ ∃<⇔ ⟩
+    (∃ λ m → m < 1+ n × T (p m))  ⇔⟨ (Σ-cong-⇔ λ _ → ((λ { (s≤s m≤n) → m≤n }) , s≤s) ×-cong-⇔ id⇔) ⟩
+    (∃ λ m → m ≤ n × T (p m))     □⇔
 
 -- ∃-least P means that there is a least number n for which P n holds.
 
 ∃-least : (ℕ → Set a) → Set a
 ∃-least P = ∃ λ n → P n × ∀ m → m < n → ¬ P m
 
--- A decidable predicate holds for some number if and only if there is
--- a least number for which it holds.
+opaque
+  unfolding ∃-least
 
-∃⇔∃-least : (∃ λ n → T (p n)) ⇔ ∃-least (λ n → T (p n))
-∃⇔∃-least = (uncurry λ _ → ∃→∃-least) , Σ.map idᶠ proj₁
-  where
-  ∃→∃-least : T (p n) → ∃-least (λ n → T (p n))
-  ∃→∃-least {n = 0} ok =
-    0 , ok , λ _ ()
-  ∃→∃-least {p = p} {n = 1+ n} ok = lemma _ refl
+  -- A decidable predicate holds for some number if and only if there
+  -- is a least number for which it holds.
+
+  ∃⇔∃-least : (∃ λ n → T (p n)) ⇔ ∃-least (λ n → T (p n))
+  ∃⇔∃-least = (uncurry λ _ → ∃→∃-least) , Σ.map idᶠ proj₁
     where
-    lemma :
-      ∀ b → b ≡ p 0 →
-      ∃ λ n → T (p n) × ∀ m → m < n → ¬ T (p m)
-    lemma true  eq = 0 , subst T eq _ , λ _ ()
-    lemma false eq =
-      case ∃→∃-least {p = p ∘→ 1+} ok of λ {
-        (n , ok , least) →
-        1+ n
-      , ok
-      , (λ where
-           0 _ →
-             T (p 0)  →⟨ subst T (sym eq) ⟩
-             ⊥        □
-           (1+ m) 1+m<1+n →
-             T (p (1+ m))  →⟨ least m (+-cancelˡ-< 1 1+m<1+n) ⟩
-             ⊥             □) }
+    ∃→∃-least : T (p n) → ∃-least (λ n → T (p n))
+    ∃→∃-least {n = 0} ok =
+      0 , ok , λ _ ()
+    ∃→∃-least {p = p} {n = 1+ n} ok = lemma _ refl
+      where
+      lemma :
+        ∀ b → b ≡ p 0 →
+        ∃ λ n → T (p n) × ∀ m → m < n → ¬ T (p m)
+      lemma true  eq = 0 , subst T eq _ , λ _ ()
+      lemma false eq =
+        case ∃→∃-least {p = p ∘→ 1+} ok of λ {
+          (n , ok , least) →
+          1+ n
+        , ok
+        , (λ where
+             0 _ →
+               T (p 0)  →⟨ subst T (sym eq) ⟩
+               ⊥        □
+             (1+ m) 1+m<1+n →
+               T (p (1+ m))  →⟨ least m (+-cancelˡ-< 1 1+m<1+n) ⟩
+               ⊥             □) }
 
--- Is-proposition is closed under ∃-least (assuming function
--- extensionality).
+opaque
+  unfolding ∃-least
 
-∃-least-propositional :
-  ∀ {p} {P : ℕ → Set p} →
-  Function-extensionality lzero p →
-  Function-extensionality p lzero →
-  (∀ n → Is-proposition (P n)) →
-  Is-proposition (∃-least P)
-∃-least-propositional
-  fe₁ fe₂ P-prop
-  {x = n₁ , p₁ , least₁}
-  {y = n₂ , p₂ , least₂} =
-  case n₁≡n₂ of λ {
-    refl →
-  cong₂ (λ p least → _ , p , least)
-    (P-prop _)
-    (Is-proposition-Π fe₁ λ _ →
-     Is-proposition-Π fe₁ λ _ →
-     Is-proposition-Π fe₂ λ _ →
-     ⊥-propositional) }
-  where
-  n₁≡n₂ : n₁ ≡ n₂
-  n₁≡n₂ = case <-cmp n₁ n₂ of λ where
-    (tri< n₁<n₂ _     _)     → ⊥-elim (least₂ _ n₁<n₂ p₁)
-    (tri≈ _     n₁≡n₂ _)     → n₁≡n₂
-    (tri> _     _     n₁>n₂) → ⊥-elim (least₁ _ n₁>n₂ p₂)
+  -- Is-proposition is closed under ∃-least (assuming function
+  -- extensionality).
+
+  ∃-least-propositional :
+    ∀ {p} {P : ℕ → Set p} →
+    Function-extensionality lzero p →
+    Function-extensionality p lzero →
+    (∀ n → Is-proposition (P n)) →
+    Is-proposition (∃-least P)
+  ∃-least-propositional
+    fe₁ fe₂ P-prop
+    {x = n₁ , p₁ , least₁}
+    {y = n₂ , p₂ , least₂} =
+    case n₁≡n₂ of λ {
+      refl →
+    cong₂ (λ p least → _ , p , least)
+      (P-prop _)
+      (Is-proposition-Π fe₁ λ _ →
+       Is-proposition-Π fe₁ λ _ →
+       Is-proposition-Π fe₂ λ _ →
+       ⊥-propositional) }
+    where
+    n₁≡n₂ : n₁ ≡ n₂
+    n₁≡n₂ = case <-cmp n₁ n₂ of λ where
+      (tri< n₁<n₂ _     _)     → ⊥-elim (least₂ _ n₁<n₂ p₁)
+      (tri≈ _     n₁≡n₂ _)     → n₁≡n₂
+      (tri> _     _     n₁>n₂) → ⊥-elim (least₁ _ n₁>n₂ p₂)

--- a/Tools/Product.agda
+++ b/Tools/Product.agda
@@ -3,6 +3,8 @@
 -- cartesian product (also used as conjunction).
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 module Tools.Product where
 
 open import Level

--- a/Tools/PropositionalEquality.agda
+++ b/Tools/PropositionalEquality.agda
@@ -3,6 +3,8 @@
 -- (we do not assume uniqueness of identity proofs).
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 module Tools.PropositionalEquality where
 
 -- We reexport Agda's builtin equality type.

--- a/Tools/Reasoning/Equivalence.agda
+++ b/Tools/Reasoning/Equivalence.agda
@@ -2,6 +2,8 @@
 -- Equational resoning for equivalences
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-opaque #-}
+
 open import Tools.Relation
 
 -- Reasoning for equivalence relations using preorder relation syntax

--- a/graded-type-theory.agda-lib
+++ b/graded-type-theory.agda-lib
@@ -5,3 +5,4 @@ flags:
   --without-K
   --safe
   -WnoUnsupportedIndexedMatch
+  --opaque


### PR DESCRIPTION
This pull request is related to issue #5.

The change is currently incomplete: there is presumably code that does not type-check. Furthermore the new code makes use of Agda features that have (at the time of writing) not yet been released (`--opaque`, `--no-opaque`, `transparent`).

I made a number of definitions opaque and type-checked `Definition.LogicalRelation.Substitution.Introductions.Natrec` from scratch (with the standard library modules already type-checked). This made Agda a little faster:
* With fewer opaque definitions:
  ```
  Total                                                          180,865ms
  Miscellaneous                                                    4,326ms
  Definition.LogicalRelation.Properties.Conversion                29,130ms
  Definition.LogicalRelation.Substitution.Introductions.Natrec    26,261ms
  Definition.Typed.Properties                                     23,667ms
  Definition.LogicalRelation.Irrelevance                          20,256ms
  Definition.LogicalRelation.Weakening                            11,195ms
  Definition.LogicalRelation.ShapeView                            10,163ms
  Definition.LogicalRelation.Properties.Transitivity               8,846ms
  Definition.Typed.Weakening                                       8,376ms
  Definition.LogicalRelation.Substitution.Properties               7,538ms
  Definition.LogicalRelation.Properties.Neutral                    4,709ms
  Definition.Typed.EqualityRelation                                4,011ms
  Definition.LogicalRelation                                       3,167ms
  Definition.LogicalRelation.Properties.Symmetry                   2,861ms
  Definition.LogicalRelation.Properties.Escape                     1,945ms
  Definition.Untyped.Properties                                    1,927ms
  Definition.LogicalRelation.Substitution.Irrelevance              1,689ms
  Definition.Typed                                                 1,596ms
  Definition.LogicalRelation.Properties.Reduction                  1,523ms
  Definition.Untyped                                               1,258ms
  Definition.LogicalRelation.Properties.Reflexivity                  814ms
  Definition.Typed.Properties.Well-formed                            668ms
  Definition.LogicalRelation.Properties.Successor                    628ms
  Definition.LogicalRelation.Substitution                            509ms
  Definition.LogicalRelation.Substitution.Introductions.Nat          502ms
  Graded.Modality                                                    404ms
  Tools.Nat                                                          368ms
  Definition.LogicalRelation.Properties.Universe                     367ms
  Definition.Typed.RedSteps                                          360ms
  Definition.LogicalRelation.Substitution.Introductions.Universe     351ms
  Graded.Derived.Erased.Typed.Primitive                              345ms
  Definition.LogicalRelation.Properties.MaybeEmb                     271ms
  Tools.Function                                                     165ms
  Tools.Algebra                                                      130ms
  Definition.LogicalRelation.Substitution.Reflexivity                122ms
  Tools.PropositionalEquality                                         75ms
  Definition.Typed.Restrictions                                       72ms
  Definition.LogicalRelation.Properties                               57ms
  Graded.Derived.Erased.Untyped                                       53ms
  Tools.Bool                                                          44ms
  Definition.Untyped.NotParametrised                                  42ms
  Tools.Fin                                                           16ms
  Tools.Relation                                                      15ms
  Tools.Product                                                       11ms
  Graded.Modality.Variant                                             11ms
   516,320,266,456 bytes allocated in the heap
    54,888,558,944 bytes copied during GC
     1,498,651,472 bytes maximum residency (73 sample(s))
         3,294,384 bytes maximum slop
              2906 MiB total memory in use (0 MiB lost due to fragmentation)

                                       Tot time (elapsed)  Avg pause  Max pause
    Gen  0     123152 colls,     0 par   36.241s  36.283s     0.0003s    0.0093s
    Gen  1        73 colls,     0 par    9.578s   9.579s     0.1312s    0.8651s

    TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

    SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

    INIT    time    0.001s  (  0.000s elapsed)
    MUT     time  135.460s  (135.017s elapsed)
    GC      time   45.819s  ( 45.862s elapsed)
    EXIT    time    0.001s  (  0.000s elapsed)
    Total   time  181.281s  (180.880s elapsed)

    Alloc rate    3,811,611,485 bytes per MUT second

    Productivity  74.7% of total user, 74.6% of total elapsed


  real	3m0,985s
  user	2m59,734s
  sys	0m1,652s
  ```
* With many opaque definitions:
  ```
  Total                                                          171,407ms
  Miscellaneous                                                    4,372ms
  Definition.LogicalRelation.Properties.Conversion                26,166ms
  Definition.LogicalRelation.Substitution.Introductions.Natrec    23,817ms
  Definition.Typed.Properties                                     23,599ms
  Definition.LogicalRelation.Irrelevance                          19,667ms
  Definition.LogicalRelation.Weakening                            10,198ms
  Definition.LogicalRelation.ShapeView                            10,135ms
  Definition.Typed.Weakening                                       8,477ms
  Definition.LogicalRelation.Properties.Transitivity               8,070ms
  Definition.LogicalRelation.Substitution.Properties               6,927ms
  Definition.LogicalRelation.Properties.Neutral                    4,229ms
  Definition.Typed.EqualityRelation                                4,049ms
  Definition.LogicalRelation                                       3,075ms
  Definition.LogicalRelation.Properties.Symmetry                   2,675ms
  Definition.Untyped.Properties                                    1,946ms
  Definition.LogicalRelation.Properties.Escape                     1,864ms
  Definition.Typed                                                 1,636ms
  Definition.LogicalRelation.Substitution.Irrelevance              1,618ms
  Definition.LogicalRelation.Properties.Reduction                  1,389ms
  Definition.Untyped                                               1,291ms
  Definition.LogicalRelation.Properties.Reflexivity                  848ms
  Definition.Typed.Properties.Well-formed                            670ms
  Definition.LogicalRelation.Properties.Successor                    554ms
  Definition.LogicalRelation.Substitution                            459ms
  Definition.LogicalRelation.Substitution.Introductions.Nat          447ms
  Graded.Modality                                                    397ms
  Tools.Nat                                                          370ms
  Definition.LogicalRelation.Properties.Universe                     364ms
  Definition.Typed.RedSteps                                          362ms
  Graded.Derived.Erased.Typed.Primitive                              360ms
  Definition.LogicalRelation.Substitution.Introductions.Universe     310ms
  Definition.LogicalRelation.Properties.MaybeEmb                     246ms
  Tools.Function                                                     166ms
  Tools.Algebra                                                      137ms
  Definition.LogicalRelation.Substitution.Reflexivity                108ms
  Tools.PropositionalEquality                                         76ms
  Definition.Typed.Restrictions                                       72ms
  Graded.Derived.Erased.Untyped                                       54ms
  Definition.LogicalRelation.Properties                               46ms
  Tools.Bool                                                          45ms
  Definition.Untyped.NotParametrised                                  41ms
  Tools.Fin                                                           16ms
  Tools.Relation                                                      15ms
  Tools.Product                                                       12ms
  Graded.Modality.Variant                                             11ms
   524,117,285,408 bytes allocated in the heap
    53,603,796,392 bytes copied during GC
     1,242,359,384 bytes maximum residency (72 sample(s))
         2,632,104 bytes maximum slop
              2657 MiB total memory in use (0 MiB lost due to fragmentation)

                                       Tot time (elapsed)  Avg pause  Max pause
    Gen  0     124982 colls,     0 par   34.307s  34.342s     0.0003s    0.0092s
    Gen  1        72 colls,     0 par    8.239s   8.241s     0.1145s    0.5867s

    TASKS: 4 (1 bound, 3 peak workers (3 total), using -N1)

    SPARKS: 0 (0 converted, 0 overflowed, 0 dud, 0 GC'd, 0 fizzled)

    INIT    time    0.001s  (  0.001s elapsed)
    MUT     time  128.970s  (128.583s elapsed)
    GC      time   42.546s  ( 42.583s elapsed)
    EXIT    time    0.001s  (  0.003s elapsed)
    Total   time  171.517s  (171.170s elapsed)

    Alloc rate    4,063,856,808 bytes per MUT second

    Productivity  75.2% of total user, 75.1% of total elapsed


  real	2m51,266s
  user	2m50,189s
  sys	0m1,423s
  ```