### PR TITLE
Changed the logical relation for reducibility

### DIFF
--- a/Definition/LogicalRelation.agda
+++ b/Definition/LogicalRelation.agda
@@ -51,7 +51,7 @@ record _⊩ne_ {ℓ : Nat} (Γ : Con Term ℓ) (A : Term ℓ) : Set a where
     K   : Term ℓ
     D   : Γ ⊢ A :⇒*: K
     neK : Neutral K
-    K≡K : Γ ⊢ K ~ K ∷ U
+    K≡K : Γ ⊢ K ≅ K
 
 -- Neutral type equality
 record _⊩ne_≡_/_ (Γ : Con Term ℓ) (A B : Term ℓ) ([A] : Γ ⊩ne A) : Set a where
@@ -61,7 +61,7 @@ record _⊩ne_≡_/_ (Γ : Con Term ℓ) (A B : Term ℓ) ([A] : Γ ⊩ne A) : S
     M   : Term ℓ
     D′  : Γ ⊢ B :⇒*: M
     neM : Neutral M
-    K≡M : Γ ⊢ K ~ M ∷ U
+    K≡M : Γ ⊢ K ≅ M
 
 -- Neutral term in WHNF
 record _⊩neNf_∷_ (Γ : Con Term ℓ) (k A : Term ℓ) : Set a where

--- a/Definition/LogicalRelation/Properties/Conversion.agda
+++ b/Definition/LogicalRelation/Properties/Conversion.agda
@@ -54,7 +54,7 @@ mutual
              (neₜ k d (neNfₜ neK₂ ⊢k k≡k)) =
     let K≡K₁ = PE.subst (λ x → _ ⊢ _ ≡ x)
                         (whrDet* (red D′ , ne neM) (red D₁ , ne neK₁))
-                        (≅-eq (~-to-≅ K≡M))
+                        (≅-eq K≡M)
     in  neₜ k (convRed:*: d K≡K₁)
             (neNfₜ neK₂ (conv ⊢k K≡K₁) (~-conv k≡k K≡K₁))
   convTermT₁
@@ -177,7 +177,7 @@ mutual
              (neₜ k d (neNfₜ neK₂ ⊢k k≡k)) =
     let K₁≡K = PE.subst (λ x → _ ⊢ x ≡ _)
                         (whrDet* (red D′ , ne neM) (red D₁ , ne neK₁))
-                        (sym (≅-eq (~-to-≅ K≡M)))
+                        (sym (≅-eq K≡M))
     in  neₜ k (convRed:*: d K₁≡K)
             (neNfₜ neK₂ (conv ⊢k K₁≡K) (~-conv k≡k K₁≡K))
   convTermT₂
@@ -329,7 +329,7 @@ mutual
                (neₜ₌ k m d d′ (neNfₜ₌ neK₂ neM₁ k≡m)) =
     let K≡K₁ = PE.subst (λ x → _ ⊢ _ ≡ x)
                         (whrDet* (red D′ , ne neM) (red D₁ , ne neK₁))
-                        (≅-eq (~-to-≅ K≡M))
+                        (≅-eq K≡M)
     in  neₜ₌ k m (convRed:*: d K≡K₁)
                  (convRed:*: d′ K≡K₁)
                  (neNfₜ₌ neK₂ neM₁ (~-conv k≡m K≡K₁))
@@ -479,7 +479,7 @@ mutual
                (neₜ₌ k m d d′ (neNfₜ₌ neK₂ neM₁ k≡m)) =
     let K₁≡K = PE.subst (λ x → _ ⊢ x ≡ _)
                         (whrDet* (red D′ , ne neM) (red D₁ , ne neK₁))
-                        (sym (≅-eq (~-to-≅ K≡M)))
+                        (sym (≅-eq K≡M))
     in  neₜ₌ k m (convRed:*: d K₁≡K) (convRed:*: d′ K₁≡K)
                  (neNfₜ₌ neK₂ neM₁ (~-conv k≡m K₁≡K))
   convEqTermT₂

--- a/Definition/LogicalRelation/Properties/Escape.agda
+++ b/Definition/LogicalRelation/Properties/Escape.agda
@@ -107,7 +107,7 @@ escapeEq (Emptyᵣ [ ⊢A , ⊢B , D ]) D′ =
 escapeEq (Unitᵣ (Unitₜ [ ⊢A , ⊢B , D ] ok)) D′ =
   ≅-red D D′ Unitₙ Unitₙ (≅-Unitrefl (wf ⊢A) ok)
 escapeEq (ne′ K D neK K≡K) (ne₌ M D′ neM K≡M) =
-  ≅-red (red D) (red D′) (ne neK) (ne neM) (~-to-≅ K≡M)
+  ≅-red (red D) (red D′) (ne neK) (ne neM) K≡M
 escapeEq (Bᵣ′ W _ _ D _ _ _ _ _ _ _) (B₌ _ _ D′ A≡B _ _) =
   ≅-red (red D) D′ ⟦ W ⟧ₙ ⟦ W ⟧ₙ A≡B
 escapeEq (Idᵣ ⊩A) A≡B =

--- a/Definition/LogicalRelation/Properties/Neutral.agda
+++ b/Definition/LogicalRelation/Properties/Neutral.agda
@@ -40,7 +40,7 @@ private
 -- Neutral reflexive types are reducible.
 neu : ∀ {l A} (neA : Neutral A)
     → Γ ⊢ A
-    → Γ ⊢ A ~ A ∷ U
+    → Γ ⊢ A ≅ A
     → Γ ⊩⟨ l ⟩ A
 neu neA A A~A = ne′ _ (idRed:*: A) neA A~A
 
@@ -49,11 +49,11 @@ neuEq′ : ∀ {l A B} ([A] : Γ ⊩⟨ l ⟩ne A)
          (neA : Neutral A)
          (neB : Neutral B)
        → Γ ⊢ A → Γ ⊢ B
-       → Γ ⊢ A ~ B ∷ U
+       → Γ ⊢ A ≅ B
        → Γ ⊩⟨ l ⟩ A ≡ B / ne-intr [A]
 neuEq′ (noemb (ne K [ ⊢A , ⊢B , D ] neK K≡K)) neA neB A B A~B =
   let A≡K = whnfRed* D (ne neA)
-  in  ne₌ _ (idRed:*: B) neB (PE.subst (λ x → _ ⊢ x ~ _ ∷ _) A≡K A~B)
+  in  ne₌ _ (idRed:*: B) neB (PE.subst (λ x → _ ⊢ x ≅ _) A≡K A~B)
 neuEq′ (emb 0<1 x) neB A:≡:B = neuEq′ x neB A:≡:B
 
 -- Neutrally equal types are of reducible equality.
@@ -61,7 +61,7 @@ neuEq : ∀ {l A B} ([A] : Γ ⊩⟨ l ⟩ A)
         (neA : Neutral A)
         (neB : Neutral B)
       → Γ ⊢ A → Γ ⊢ B
-      → Γ ⊢ A ~ B ∷ U
+      → Γ ⊢ A ≅ B
       → Γ ⊩⟨ l ⟩ A ≡ B / [A]
 neuEq [A] neA neB A B A~B =
   irrelevanceEq (ne-intr (ne-elim neA [A]))
@@ -75,7 +75,8 @@ mutual
           → Γ ⊢ n ~ n ∷ A
           → Γ ⊩⟨ l ⟩ n ∷ A / [A]
   neuTerm (Uᵣ′ .⁰ 0<1 ⊢Γ) neN n n~n =
-    Uₜ _ (idRedTerm:*: n) (ne neN) (~-to-≅ₜ n~n) (neu neN (univ n) n~n)
+    Uₜ _ (idRedTerm:*: n) (ne neN) (~-to-≅ₜ n~n)
+      (neu neN (univ n) (~-to-≅ n~n))
   neuTerm (ℕᵣ [ ⊢A , ⊢B , D ]) neN n n~n =
     let A≡ℕ  = subset* D
         n~n′ = ~-conv n~n A≡ℕ
@@ -192,10 +193,11 @@ mutual
             → Γ ⊢ n ~ n′ ∷ A
             → Γ ⊩⟨ l ⟩ n ≡ n′ ∷ A / [A]
   neuEqTerm (Uᵣ′ .⁰ 0<1 ⊢Γ) neN neN′ n n′ n~n′ =
-    let [n]  = neu neN  (univ n) (~-trans n~n′ (~-sym n~n′))
-        [n′] = neu neN′ (univ n′) (~-trans (~-sym n~n′) n~n′)
+    let [n]  = neu neN  (univ n) (~-to-≅ (~-trans n~n′ (~-sym n~n′)))
+        [n′] = neu neN′ (univ n′) (~-to-≅ (~-trans (~-sym n~n′) n~n′))
     in  Uₜ₌ _ _ (idRedTerm:*: n) (idRedTerm:*: n′) (ne neN) (ne neN′)
-            (~-to-≅ₜ n~n′) [n] [n′] (neuEq [n] neN neN′ (univ n) (univ n′) n~n′)
+            (~-to-≅ₜ n~n′) [n] [n′]
+            (neuEq [n] neN neN′ (univ n) (univ n′) (~-to-≅ n~n′))
   neuEqTerm (ℕᵣ [ ⊢A , ⊢B , D ]) neN neN′ n n′ n~n′ =
     let A≡ℕ = subset* D
         n~n′₁ = ~-conv n~n′ A≡ℕ

--- a/Definition/LogicalRelation/Properties/Symmetry.agda
+++ b/Definition/LogicalRelation/Properties/Symmetry.agda
@@ -84,7 +84,7 @@ symEqT (Unitᵥ (Unitₜ D _) D′) A≡B = red D
 symEqT (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
        rewrite whrDet* (red D′ , ne neM) (red D₁ , ne neK₁) =
   ne₌ _ D neK
-      (~-sym K≡M)
+      (≅-sym K≡M)
 symEqT
   {n} {Γ = Γ} {l′ = l′}
   (Bᵥ W (Bᵣ F G D ⊢F ⊢G A≡A [F] [G] G-ext _)

--- a/Definition/LogicalRelation/Properties/Transitivity.agda
+++ b/Definition/LogicalRelation/Properties/Transitivity.agda
@@ -186,7 +186,7 @@ transEqT (ne (ne K [ ⊢A , ⊢B , D ] neK K≡K) (ne K₁ D₁ neK₁ _)
          rewrite whrDet* (red D₁ , ne neK₁) (red D′ , ne neM)
                | whrDet* (red D₂ , ne neK₂) (red D″ , ne neM₁) =
   ne₌ M₁ D″ neM₁
-      (~-trans K≡M K≡M₁)
+      (≅-trans K≡M K≡M₁)
 transEqT {n = n} {Γ = Γ} {l = l} {l′ = l′} {l″ = l″}
          (Bᵥ W W′ W″ (Bᵣ F G D ⊢F ⊢G A≡A [F] [G] G-ext _)
                (Bᵣ F₁ G₁ D₁ ⊢F₁ ⊢G₁ A≡A₁ [F]₁ [G]₁ G-ext₁ _)

--- a/Definition/LogicalRelation/Weakening.agda
+++ b/Definition/LogicalRelation/Weakening.agda
@@ -160,7 +160,7 @@ wk ρ ⊢Δ (Emptyᵣ D) = Emptyᵣ (wkRed:*: ρ ⊢Δ D)
 wk ρ ⊢Δ (Unitᵣ (Unitₜ D ok)) =
   Unitᵣ (Unitₜ (wkRed:*: ρ ⊢Δ D) ok)
 wk {ρ = ρ} [ρ] ⊢Δ (ne′ K D neK K≡K) =
-  ne′ (U.wk ρ K) (wkRed:*: [ρ] ⊢Δ D) (wkNeutral ρ neK) (~-wk [ρ] ⊢Δ K≡K)
+  ne′ (U.wk ρ K) (wkRed:*: [ρ] ⊢Δ D) (wkNeutral ρ neK) (≅-wk [ρ] ⊢Δ K≡K)
 wk
   {m = m} {Δ = Δ} {Γ = Γ} {l = l} {A = A} {ρ = ρ} [ρ] ⊢Δ
   (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext ok) =
@@ -259,7 +259,7 @@ wkEq ρ ⊢Δ (Emptyᵣ D) A≡B = wkRed* ρ ⊢Δ A≡B
 wkEq ρ ⊢Δ (Unitᵣ (Unitₜ D _)) A≡B = wkRed* ρ ⊢Δ A≡B
 wkEq {ρ = ρ} [ρ] ⊢Δ (ne′ _ _ _ _) (ne₌ M D′ neM K≡M) =
   ne₌ (U.wk ρ M) (wkRed:*: [ρ] ⊢Δ D′)
-      (wkNeutral ρ neM) (~-wk [ρ] ⊢Δ K≡M)
+      (wkNeutral ρ neM) (≅-wk [ρ] ⊢Δ K≡M)
 wkEq {ρ = ρ} [ρ] ⊢Δ (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext _)
                 (B₌ F′ G′ D′ A≡B [F≡F′] [G≡G′]) =
   B₌ (U.wk ρ F′)


### PR DESCRIPTION
Some instances of "_ ⊢ _ ~ _ ∷ U" were replaced by "_ ⊢ _ ≅ _".