### PR TITLE
Modified the proofs of the two fundamental lemmas for Empty

### DIFF
--- a/Definition/LogicalRelation/Fundamental.agda
+++ b/Definition/LogicalRelation/Fundamental.agda
@@ -69,7 +69,7 @@ opaque
   fundamental : ∀ {A} (⊢A : Γ ⊢ A) → Σ (⊩ᵛ Γ) (λ [Γ] → Γ ⊩ᵛ⟨ ¹ ⟩ A / [Γ])
   fundamental (ℕⱼ ⊢Γ) =
     ℕᵛ (valid ⊢Γ)
-  fundamental (Emptyⱼ x) = valid x , Emptyᵛ (valid x)
+  fundamental (Emptyⱼ x) = Emptyᵛ (valid x)
   fundamental (Unitⱼ ⊢Γ ok) =
     Unitᵛ (valid ⊢Γ) ok
   fundamental (Uⱼ ⊢Γ) =
@@ -132,7 +132,8 @@ opaque
     → Γ ⊩ᵛ⟨ ¹ ⟩ t ∷ A / [Γ] / [A]
   fundamentalTerm (ℕⱼ ⊢Γ) =
     ℕᵗᵛ (valid ⊢Γ)
-  fundamentalTerm (Emptyⱼ x) = valid x , Uᵛ (valid x) , Emptyᵗᵛ (valid x)
+  fundamentalTerm (Emptyⱼ x) =
+    Emptyᵗᵛ (valid x)
   fundamentalTerm (Unitⱼ ⊢Γ ok) =
     Unitᵗᵛ (valid ⊢Γ) ok
   fundamentalTerm (ΠΣⱼ {F = F} {G} {b = BMΠ} ⊢F ⊢G ok)
@@ -211,11 +212,8 @@ opaque
   fundamentalTerm (natrecⱼ {z = t} {s = u} ⊢A ⊢t ⊢u ⊢v) =
     natrecᵛ {t = t} {u = u} (fundamental ⊢A) (fundamentalTerm ⊢t)
       (fundamentalTerm ⊢u) (fundamentalTerm ⊢v)
-  fundamentalTerm (emptyrecⱼ {A} {t = n} ⊢A ⊢n)
-    with fundamental ⊢A | fundamentalTerm ⊢n
-  ... | [Γ] , [A] | [Γ]′ , [Empty] , [n] =
-    let [A]′ = S.irrelevance {A = A} [Γ] [Γ]′ [A]
-    in [Γ]′ , [A]′ , emptyrecᵛ {F = A} {n} [Γ]′ [Empty] [A]′ [n]
+  fundamentalTerm (emptyrecⱼ {t = t} ⊢A ⊢t) =
+    emptyrecᵛ {t = t} (fundamental ⊢A) (fundamentalTerm ⊢t)
   fundamentalTerm (starⱼ ⊢Γ ok) =
     starᵛ (valid ⊢Γ) ok
   fundamentalTerm (conv {t} ⊢t A≡B) =
@@ -410,25 +408,10 @@ opaque
   fundamentalTermEq (natrec-suc ⊢A ⊢t ⊢u ⊢v) =
     natrec-sucᵛ (fundamental ⊢A) (fundamentalTerm ⊢t)
       (fundamentalTerm ⊢u) (fundamentalTerm ⊢v)
-  fundamentalTermEq (emptyrec-cong F≡F′ n≡n′)
-    with fundamentalEq F≡F′ |
-         fundamentalTermEq n≡n′
-  fundamentalTermEq (emptyrec-cong {A = F} {B = F′} {t = n} {u = n′}
-                                 F≡F′ n≡n′) |
-    [Γ]  , [F] , [F′] , [F≡F′] |
-    [Γ]′ , modelsTermEq [Empty] [n] [n′] [n≡n′] =
-    let [F]′ = S.irrelevance {A = F} [Γ] [Γ]′ [F]
-        [F′]′ = S.irrelevance {A = F′} [Γ] [Γ]′ [F′]
-        [F≡F′]′ = S.irrelevanceEq {A = F} {B = F′} [Γ] [Γ]′ [F] [F]′ [F≡F′]
-    in [Γ]′
-      , modelsTermEq [F]′ (emptyrecᵛ {F = F} {n} [Γ]′ [Empty] [F]′ [n])
-                     (conv₂ᵛ {t = emptyrec _ F′ n′} {F} {F′} [Γ]′ [F]′ [F′]′ [F≡F′]′
-                       (emptyrecᵛ {F = F′} {n′} [Γ]′ [Empty] [F′]′ [n′]))
-                     (emptyrec-congᵛ {F = F} {F′} {n} {n′}
-                       [Γ]′ [Empty] [F]′ [F′]′ [F≡F′]′
-                       [n] [n′] [n≡n′])
+  fundamentalTermEq (emptyrec-cong F≡F′ n≡n′) =
+    emptyrec-congᵛ (fundamentalEq F≡F′) (fundamentalTermEq n≡n′)
   fundamentalTermEq (η-unit ⊢t ⊢u η) =
-    η-unitᵛ (fundamentalTerm ⊢t) (fundamentalTerm ⊢u) η
+    η-unitᵛ (fundamentalTerm ⊢t) (fundamentalTerm ⊢u)
   fundamentalTermEq (fst-cong {F = F} {G} {t = t} {t′} ⊢F ⊢G t≡t′)
     with fundamentalTermEq t≡t′ | fundamental ⊢F | fundamental ⊢G
   ... | [Γ] , modelsTermEq [ΣFG] [t] [t′] [t≡t′] | [Γ]₁ , [F]₁ | [Γ]₂ , [G]₂ =

--- a/Definition/LogicalRelation/Fundamental.agda
+++ b/Definition/LogicalRelation/Fundamental.agda
@@ -411,7 +411,7 @@ opaque
   fundamentalTermEq (emptyrec-cong F≡F′ n≡n′) =
     emptyrec-congᵛ (fundamentalEq F≡F′) (fundamentalTermEq n≡n′)
   fundamentalTermEq (η-unit ⊢t ⊢u η) =
-    η-unitᵛ (fundamentalTerm ⊢t) (fundamentalTerm ⊢u)
+    η-unitᵛ (fundamentalTerm ⊢t) (fundamentalTerm ⊢u) η
   fundamentalTermEq (fst-cong {F = F} {G} {t = t} {t′} ⊢F ⊢G t≡t′)
     with fundamentalTermEq t≡t′ | fundamental ⊢F | fundamental ⊢G
   ... | [Γ] , modelsTermEq [ΣFG] [t] [t′] [t≡t′] | [Γ]₁ , [F]₁ | [Γ]₂ , [G]₂ =

--- a/Definition/LogicalRelation/Substitution/Introductions/Empty.agda
+++ b/Definition/LogicalRelation/Substitution/Introductions/Empty.agda
@@ -21,27 +21,134 @@ open import Definition.Untyped.Neutral M type-variant
 open import Definition.Typed R
 open import Definition.Typed.Properties R
 open import Definition.LogicalRelation R
+open import Definition.LogicalRelation.Hidden R
+open import Definition.LogicalRelation.Irrelevance R
+open import Definition.LogicalRelation.ShapeView R
 open import Definition.LogicalRelation.Substitution R
 open import Definition.LogicalRelation.Substitution.Introductions.Universe R
 
-open import Tools.Nat using (Nat)
+open import Tools.Function
 open import Tools.Product
 
-private
-  variable
-    n : Nat
-    Γ : Con Term n
+private variable
+  Γ Δ : Con Term _
+  t u : Term _
+  l : TypeLevel
 
+------------------------------------------------------------------------
+-- Characterisation lemmas
 
--- Validity of the Empty type.
-Emptyᵛ : ∀ {l} ([Γ] : ⊩ᵛ Γ) → Γ ⊩ᵛ⟨ l ⟩ Empty / [Γ]
-Emptyᵛ [Γ] = wrap λ ⊢Δ [σ] → Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)) , λ _ x₂ → id (Emptyⱼ ⊢Δ)
+opaque
 
--- Validity of the Empty type as a term.
-Emptyᵗᵛ : ([Γ] : ⊩ᵛ Γ)
-    → Γ ⊩ᵛ⟨ ¹ ⟩ Empty ∷ U / [Γ] / Uᵛ [Γ]
-Emptyᵗᵛ [Γ] ⊢Δ [σ] = let ⊢Empty  = Emptyⱼ ⊢Δ
-                         [Empty] = Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))
-                 in  Uₜ Empty (idRedTerm:*: ⊢Empty) Emptyₙ (≅ₜ-Emptyrefl ⊢Δ) [Empty]
-                 ,   (λ x x₁ → Uₜ₌ Empty Empty (idRedTerm:*: ⊢Empty) (idRedTerm:*: ⊢Empty) Emptyₙ Emptyₙ
-                                   (≅ₜ-Emptyrefl ⊢Δ) [Empty] [Empty] (id (Emptyⱼ ⊢Δ)))
+  --  A characterisation lemma for _⊩⟨_⟩_.
+
+  ⊩Empty⇔ :
+    Γ ⊩⟨ l ⟩ Empty ⇔ ⊢ Γ
+  ⊩Empty⇔ =
+      (λ ⊩Empty → lemma (Empty-elim ⊩Empty))
+    , (λ ⊢Γ → Emptyᵣ (idRed:*: (Emptyⱼ ⊢Γ)))
+    where
+    lemma : Γ ⊩⟨ l ⟩Empty Empty → ⊢ Γ
+    lemma (emb 0<1 ⊩Empty) = lemma ⊩Empty
+    lemma (noemb d) = wf (⊢A-red d)
+
+opaque
+  unfolding _⊩⟨_⟩_∷_ ⊩Empty⇔
+
+  -- A characterisation lemma for _⊩⟨_⟩_∷_.
+
+  ⊩∷Empty⇔ :
+    Γ ⊩⟨ l ⟩ t ∷ Empty ⇔ Γ ⊩Empty t ∷Empty
+  ⊩∷Empty⇔ =
+      (λ (⊩Empty′ , ⊩t) →
+         lemma (Empty-elim ⊩Empty′)
+           (irrelevanceTerm ⊩Empty′ (Empty-intr (Empty-elim ⊩Empty′)) ⊩t))
+    , (λ ⊩t@(Emptyₜ n d n≡n prop) →
+         ⊩Empty⇔ .proj₂ (wfTerm (⊢t-redₜ d)) , ⊩t)
+    where
+    lemma :
+      (⊩Empty : Γ ⊩⟨ l ⟩Empty Empty) →
+      Γ ⊩⟨ l ⟩ t ∷ Empty / Empty-intr ⊩Empty →
+      Γ ⊩Empty t ∷Empty
+    lemma (emb 0<1 ⊩Empty′) ⊩t = lemma ⊩Empty′ ⊩t
+    lemma (noemb _) ⊩t = ⊩t
+
+opaque
+  unfolding _⊩⟨_⟩_≡_∷_ ⊩Empty⇔
+
+  -- A characterisation lemma for _⊩⟨_⟩_≡_∷_.
+
+  ⊩≡∷Empty⇔ : Γ ⊩⟨ l ⟩ t ≡ u ∷ Empty ⇔
+    (Γ ⊩Empty t ∷Empty ×
+     Γ ⊩Empty u ∷Empty ×
+     Γ ⊩Empty t ≡ u ∷Empty)
+  ⊩≡∷Empty⇔ =
+      (λ (⊩Empty′ , ⊩t , ⊩u , t≡u) →
+        lemma (Empty-elim ⊩Empty′)
+          (irrelevanceTerm ⊩Empty′ (Empty-intr (Empty-elim ⊩Empty′)) ⊩t)
+          (irrelevanceTerm ⊩Empty′ (Empty-intr (Empty-elim ⊩Empty′)) ⊩u)
+          (irrelevanceEqTerm ⊩Empty′ (Empty-intr (Empty-elim ⊩Empty′)) t≡u))
+    , λ (⊩t@(Emptyₜ _ d _ _) , ⊩u , t≡u) →
+        ⊩Empty⇔ .proj₂ (wfTerm (⊢t-redₜ d)) , ⊩t , ⊩u , t≡u
+    where
+    lemma :
+      (⊩Empty : Γ ⊩⟨ l ⟩Empty Empty) →
+      Γ ⊩⟨ l ⟩ t ∷ Empty / Empty-intr ⊩Empty →
+      Γ ⊩⟨ l ⟩ u ∷ Empty / Empty-intr ⊩Empty →
+      Γ ⊩⟨ l ⟩ t ≡ u ∷ Empty / Empty-intr ⊩Empty →
+      Γ ⊩Empty t ∷Empty ×
+      Γ ⊩Empty u ∷Empty ×
+      Γ ⊩Empty t ≡ u ∷Empty
+    lemma (emb 0<1 ⊩Empty′) ⊩t ⊩u t≡u = lemma ⊩Empty′ ⊩t ⊩u t≡u
+    lemma (noemb _) ⊩t ⊩u t≡u = ⊩t , ⊩u , t≡u
+
+------------------------------------------------------------------------
+-- Empty
+
+opaque
+
+  -- Reducibility for Empty.
+
+  ⊩Empty : ⊢ Γ → Γ ⊩⟨ l ⟩ Empty
+  ⊩Empty = ⊩Empty⇔ .proj₂
+
+opaque
+
+  -- Validity for Empty, seen as a type formerr.
+
+  Emptyᵛ : ⊩ᵛ Γ → Γ ⊩ᵛ⟨ l ⟩ Empty
+  Emptyᵛ ⊩Γ =
+    ⊩ᵛ⇔ .proj₂
+      ( ⊩Γ
+      , (λ ⊩σ →
+           case ⊩Empty (escape-⊩ˢ∷ ⊩σ .proj₁) of λ
+             ⊩Empty′ →
+           ⊩Empty′ , λ {σ′ = _} _ → refl-⊩≡ ⊩Empty′))
+
+opaque
+
+  -- Validity for Empty, seen as a term former.
+
+  Emptyᵗᵛ : ⊩ᵛ Γ → Γ ⊩ᵛ⟨ ¹ ⟩ Empty ∷ U
+  Emptyᵗᵛ ⊩Γ =
+    ⊩ᵛ∷⇔ .proj₂
+      ( ⊩ᵛU ⊩Γ
+        , λ ⊩σ →
+            case escape-⊩ˢ∷ ⊩σ .proj₁ of λ
+              ⊢Δ →
+            case ⊩Empty ⊢Δ of λ
+              ⊩Empty′ →
+            case Emptyⱼ ⊢Δ of λ
+              ⊢Empty →
+            case ≅ₜ-Emptyrefl ⊢Δ of λ
+              Empty≅Empty →
+              Type→⊩∷U⇔ Emptyₙ .proj₂
+                ( (_ , 0<1 , ⊩Empty′)
+                , (⊢Empty , Empty≅Empty)
+                )
+            , λ _ →
+                Type→⊩≡∷U⇔ Emptyₙ Emptyₙ .proj₂
+                  ( ⊢Empty , ⊢Empty , Empty≅Empty
+                  , (_ , 0<1 , refl-⊩≡ ⊩Empty′)
+                  )
+      )

--- a/Definition/LogicalRelation/Substitution/Introductions/Emptyrec.agda
+++ b/Definition/LogicalRelation/Substitution/Introductions/Emptyrec.agda
@@ -22,7 +22,9 @@ open import Definition.Typed R
 import Definition.Typed.Weakening R as T
 open import Definition.Typed.Properties R
 open import Definition.Typed.RedSteps R
+open import Definition.Typed.Reasoning.Reduction.Primitive R
 open import Definition.LogicalRelation R
+open import Definition.LogicalRelation.Hidden R
 open import Definition.LogicalRelation.Irrelevance R
 open import Definition.LogicalRelation.Properties R
 open import Definition.LogicalRelation.Substitution R
@@ -31,160 +33,112 @@ import Definition.LogicalRelation.Substitution.Irrelevance R as S
 open import Definition.LogicalRelation.Substitution.Reflexivity R
 open import Definition.LogicalRelation.Substitution.Introductions.Empty R
 
+open import Tools.Function
 open import Tools.Product
-open import Tools.Nat
+
 
 import Tools.PropositionalEquality as PE
 
 private
   variable
-    m n : Nat
-    Γ : Con Term n
-    Δ : Con Term m
-    p p′ : M
-
--- Empty elimination closure reduction (requires reducible terms and equality).
-emptyrec-subst* : ∀ {C n n′ l}
-              → Γ ⊢ C
-              → Γ ⊢ n ⇒* n′ ∷ Empty
-              → ([Empty] : Γ ⊩⟨ l ⟩ Empty)
-              → Γ ⊩⟨ l ⟩ n′ ∷ Empty / [Empty]
-              → Γ ⊢ emptyrec p C n ⇒* emptyrec p C n′ ∷ C
-emptyrec-subst* C (id x) [Empty] [n′] = id (emptyrecⱼ C x)
-emptyrec-subst* {p = p} C (x ⇨ n⇒n′) [Empty] [n′] =
-  let q , w = redSubst*Term n⇒n′ [Empty] [n′]
-      a , s = redSubstTerm x [Empty] q
-  in  emptyrec-subst C x ⇨ conv* (emptyrec-subst* C n⇒n′ [Empty] [n′]) (refl C)
-
--- Reducibility of empty elimination under a valid substitution.
-emptyrecTerm : ∀ {F n σ l}
-             ([Γ]  : ⊩ᵛ Γ)
-             ([F]  : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
-             (⊢Δ   : ⊢ Δ)
-             ([σ]  : Δ ⊩ˢ σ ∷ Γ / [Γ] / ⊢Δ)
-             ([σn] : Δ ⊩⟨ l ⟩ n ∷ Empty / Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)))
-           → Δ ⊩⟨ l ⟩ emptyrec p (F [ σ ]) n
-               ∷ F [ σ ]
-               / proj₁ (unwrap [F] ⊢Δ [σ])
-emptyrecTerm {Γ = Γ} {Δ = Δ} {F = F} {n} {σ} {l} [Γ] [F] ⊢Δ [σ]
-           (Emptyₜ m d n≡n (ne (neNfₜ neM ⊢m m≡m))) =
-  let [Empty] = Emptyᵛ {l = l} [Γ]
-      [σEmpty] = proj₁ (unwrap [Empty] ⊢Δ [σ])
-      [σm] = neuTerm [σEmpty] neM ⊢m m≡m
-      [σF] = proj₁ (unwrap [F] ⊢Δ [σ])
-      ⊢F = escape [σF]
-      ⊢F≡F = escapeEq [σF] (reflEq [σF])
-      emptyrecM = neuTerm [σF] (emptyrecₙ neM) (emptyrecⱼ ⊢F ⊢m)
-                        (~-emptyrec ⊢F≡F m≡m)
-      reduction = emptyrec-subst* ⊢F (redₜ d) [σEmpty] [σm]
-  in proj₁ (redSubst*Term reduction [σF] emptyrecM)
+    Γ Δ : Con Term _
+    A A₁ A₂ t t₁ t₂ : Term _
+    l l′ : TypeLevel
+    σ σ₁ σ₂ : Subst _ _
+    p : M
 
 
--- Reducibility of empty elimination congruence under a valid substitution equality.
-emptyrec-congTerm : ∀ {F F′ n m σ σ′ l}
-                  ([Γ]      : ⊩ᵛ Γ)
-                  ([F]      : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
-                  ([F′]     : Γ ⊩ᵛ⟨ l ⟩ F′ / [Γ])
-                  ([F≡F′]   : Γ ⊩ᵛ⟨ l ⟩ F ≡ F′ / [Γ] / [F])
-                  (⊢Δ       : ⊢ Δ)
-                  ([σ]      : Δ ⊩ˢ σ  ∷ Γ / [Γ] / ⊢Δ)
-                  ([σ′]     : Δ ⊩ˢ σ′ ∷ Γ / [Γ] / ⊢Δ)
-                  ([σ≡σ′]   : Δ ⊩ˢ σ ≡ σ′ ∷ Γ / [Γ] / ⊢Δ / [σ])
-                  ([σn]     : Δ ⊩⟨ l ⟩ n ∷ Empty / Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)))
-                  ([σm]     : Δ ⊩⟨ l ⟩ m ∷ Empty / Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)))
-                  ([σn≡σm]  : Δ ⊩⟨ l ⟩ n ≡ m ∷ Empty / Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)))
-                → Δ ⊩⟨ l ⟩ emptyrec p (F [ σ ]) n
-                    ≡ emptyrec p (F′ [ σ′ ]) m
-                    ∷ F [ σ ]
-                    / proj₁ (unwrap [F] ⊢Δ [σ])
-emptyrec-congTerm {Γ = Γ} {Δ = Δ} {p = p} {F} {F′} {n} {m} {σ} {σ′} {l}
-                [Γ] [F] [F′] [F≡F′]
-                ⊢Δ [σ] [σ′] [σ≡σ′]
-                (Emptyₜ n′ d n≡n (ne (neNfₜ neN′ ⊢n′ n≡n₁)))
-                (Emptyₜ m′ d′ m≡m (ne (neNfₜ neM′ ⊢m′ m≡m₁)))
-                (Emptyₜ₌ n″ m″ d₁ d₁′ t≡u (ne (neNfₜ₌ x₂ x₃ prop₂))) =
-  let n″≡n′ = whrDet*Term (redₜ d₁ , ne x₂) (redₜ d , ne neN′)
-      m″≡m′ = whrDet*Term (redₜ d₁′ , ne x₃) (redₜ d′ , ne neM′)
-      [Empty] = Emptyᵛ {l = l} [Γ]
-      [σEmpty] = proj₁ (unwrap [Empty] ⊢Δ [σ])
-      [σ′Empty] = proj₁ (unwrap [Empty] ⊢Δ [σ′])
-      [σF] = proj₁ (unwrap [F] ⊢Δ [σ])
-      [σ′F] = proj₁ (unwrap [F] ⊢Δ [σ′])
-      [σ′F′] = proj₁ (unwrap [F′] ⊢Δ [σ′])
-      [σn′] = neuTerm [σEmpty] neN′ ⊢n′ n≡n₁
-      [σ′m′] = neuTerm [σ′Empty] neM′ ⊢m′ m≡m₁
-      ⊢F = escape [σF]
-      ⊢F≡F = escapeEq [σF] (reflEq [σF])
-      ⊢F′ = escape [σ′F′]
-      ⊢F′≡F′ = escapeEq [σ′F′] (reflEq [σ′F′])
-      ⊢σF≡σ′F = escapeEq [σF] (proj₂ (unwrap [F] ⊢Δ [σ]) [σ′] [σ≡σ′])
-      ⊢σ′F≡σ′F′ = escapeEq [σ′F] ([F≡F′] ⊢Δ [σ′])
-      ⊢F≡F′ = ≅-trans ⊢σF≡σ′F ⊢σ′F≡σ′F′
-      [σF≡σ′F] = proj₂ (unwrap [F] ⊢Δ [σ]) [σ′] [σ≡σ′]
-      [σ′F≡σ′F′] = [F≡F′] ⊢Δ [σ′]
-      [σF≡σ′F′] = transEq [σF] [σ′F] [σ′F′] [σF≡σ′F] [σ′F≡σ′F′]
-      emptyrecN = neuTerm [σF] (emptyrecₙ neN′) (emptyrecⱼ ⊢F ⊢n′)
-                        (~-emptyrec ⊢F≡F n≡n₁)
-      emptyrecM = neuTerm [σ′F′] (emptyrecₙ neM′) (emptyrecⱼ ⊢F′ ⊢m′)
-                        (~-emptyrec ⊢F′≡F′ m≡m₁)
-      emptyrecN≡M =
-          (neuEqTerm [σF] (emptyrecₙ neN′) (emptyrecₙ neM′)
-                     (emptyrecⱼ ⊢F ⊢n′)
-                     (conv (emptyrecⱼ ⊢F′ ⊢m′)
-                            (sym (≅-eq (escapeEq [σF]
-                              (transEq [σF] [σ′F] [σ′F′] [σF≡σ′F] [σ′F≡σ′F′])))))
-                     (~-emptyrec ⊢F≡F′
-                               (PE.subst₂ (λ x y → _ ⊢ x ~ y ∷ _)
-                                          n″≡n′ m″≡m′ prop₂)))
-      reduction₁ = emptyrec-subst* ⊢F (redₜ d) [σEmpty] [σn′]
-      reduction₂ = emptyrec-subst* ⊢F′ (redₜ d′) [σ′Empty] [σ′m′]
-      eq₁ = proj₂ (redSubst*Term reduction₁ [σF] emptyrecN)
-      eq₂ = proj₂ (redSubst*Term reduction₂ [σ′F′] emptyrecM)
-  in  transEqTerm [σF] eq₁
-                 (transEqTerm [σF] emptyrecN≡M
-                              (convEqTerm₂ [σF] [σ′F′] [σF≡σ′F′]
-                                           (symEqTerm [σ′F′] eq₂)))
+------------------------------------------------------------------------
+-- The eliminator emptyrec
 
--- Validity of empty elimination.
-emptyrecᵛ : ∀ {F n l} ([Γ] : ⊩ᵛ Γ)
-          ([Empty]  : Γ ⊩ᵛ⟨ l ⟩ Empty / [Γ])
-          ([F]  : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
-        → ([n] : Γ ⊩ᵛ⟨ l ⟩ n ∷ Empty / [Γ] / [Empty])
-        → Γ ⊩ᵛ⟨ l ⟩ emptyrec p F n ∷ F / [Γ] / [F]
-emptyrecᵛ {F = F} {n} {l = l} [Γ] [Empty] [F] [n]
-        {Δ = Δ} {σ = σ} ⊢Δ [σ] =
-  let [σn] = irrelevanceTerm {l′ = l} (proj₁ (unwrap [Empty] ⊢Δ [σ]))
-                             (Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))) (proj₁ ([n] ⊢Δ [σ]))
-  in emptyrecTerm {F = F} [Γ] [F] ⊢Δ [σ] [σn]
-    , λ {σ'} [σ′] [σ≡σ′] →
-      let [σ′n] = irrelevanceTerm {l′ = l} (proj₁ (unwrap [Empty] ⊢Δ [σ′]))
-                                  (Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))) (proj₁ ([n] ⊢Δ [σ′]))
-          [σn≡σ′n] = irrelevanceEqTerm {l′ = l} (proj₁ (unwrap [Empty] ⊢Δ [σ]))
-                                       (Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ)))
-                                       (proj₂ ([n] ⊢Δ [σ]) [σ′] [σ≡σ′])
-          congTerm = emptyrec-congTerm {F = F} {F′ = F} [Γ] [F] [F] (reflᵛ {A = F} {l = l} [Γ] [F])
-                       ⊢Δ [σ] [σ′] [σ≡σ′] [σn] [σ′n] [σn≡σ′n]
-      in congTerm
+opaque
 
--- Validity of empty elimination congruence.
-emptyrec-congᵛ : ∀ {F F′ n n′ l} ([Γ] : ⊩ᵛ Γ)
-          ([Empty]  : Γ ⊩ᵛ⟨ l ⟩ Empty / [Γ])
-          ([F]  : Γ ⊩ᵛ⟨ l ⟩ F / [Γ])
-          ([F′]  : Γ ⊩ᵛ⟨ l ⟩ F′ / [Γ])
-          ([F≡F′]  : Γ ⊩ᵛ⟨ l ⟩ F ≡ F′ / [Γ] / [F])
-          ([n] : Γ ⊩ᵛ⟨ l ⟩ n ∷ Empty / [Γ] / [Empty])
-          ([n′] : Γ ⊩ᵛ⟨ l ⟩ n′ ∷ Empty / [Γ] / [Empty])
-          ([n≡n′] : Γ ⊩ᵛ⟨ l ⟩ n ≡ n′ ∷ Empty / [Γ] / [Empty])
-        → Γ ⊩ᵛ⟨ l ⟩ emptyrec p F n ≡ emptyrec p F′ n′ ∷ F / [Γ] / [F]
-emptyrec-congᵛ {F = F} {F′} {n} {n′} {l = l}
-             [Γ] [Empty] [F] [F′] [F≡F′]
-             [n] [n′] [n≡n′] {Δ = Δ} {σ = σ} ⊢Δ [σ] =
-  let [σn] = irrelevanceTerm {l′ = l} (proj₁ (unwrap [Empty] ⊢Δ [σ]))
-                             (Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))) (proj₁ ([n] ⊢Δ [σ]))
-      [σn′] = irrelevanceTerm {l′ = l} (proj₁ (unwrap [Empty] ⊢Δ [σ]))
-                             (Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))) (proj₁ ([n′] ⊢Δ [σ]))
-      [σn≡σn′] = irrelevanceEqTerm {l′ = l} (proj₁ (unwrap [Empty] ⊢Δ [σ]))
-                                   (Emptyᵣ (idRed:*: (Emptyⱼ ⊢Δ))) ([n≡n′] ⊢Δ [σ])
-      congTerm = emptyrec-congTerm {F = F} {F′} [Γ] [F] [F′] [F≡F′]
-                   ⊢Δ [σ] [σ] (reflSubst [Γ] ⊢Δ [σ]) [σn] [σn′] [σn≡σn′]
-  in congTerm
+  -- Reducibility of equality between applications of emptyrec.
+
+  ⊩emptyrec≡emptyrec :
+    Γ ⊩ᵛ⟨ l ⟩ A₁ ≡ A₂ →
+    Γ ⊩ᵛ⟨ l′ ⟩ t₁ ≡ t₂ ∷ Empty →
+    Δ ⊩ˢ σ₁ ≡ σ₂ ∷ Γ →
+    Δ ⊩⟨ l ⟩ emptyrec p A₁ t₁ [ σ₁ ] ≡ emptyrec p A₂ t₂ [ σ₂ ] ∷ A₁ [ σ₁ ]
+  ⊩emptyrec≡emptyrec
+    {A₁} {A₂} {t₁} {t₂} {σ₁} {σ₂} {p}
+    A₁≡A₂ t₁≡t₂ σ₁≡σ₂ =
+    case ⊩ᵛ≡⇔′ .proj₁ A₁≡A₂ .proj₂ .proj₂ of λ
+      A₁≡A₂ →
+    case ⊩ᵛ≡∷⇔′ .proj₁ t₁≡t₂ .proj₂ .proj₂ of λ
+      t₁≡t₂ →
+    case ⊩≡∷Empty⇔ .proj₁ (t₁≡t₂ σ₁≡σ₂) of λ
+      (_ , _ ,
+       Emptyₜ₌ t₁′ t₂′ ([ _ , ⊢t₁′ , t₁[σ₁]⇒*t₁′ ])
+         ([ _ , ⊢t₂′ , t₂[σ₂]⇒*t₂′ ]) _ rest)  →
+    case A₁≡A₂ σ₁≡σ₂ of λ
+      A₁[σ₁]≡A₂[σ₂] →
+    case escape-⊩≡ A₁[σ₁]≡A₂[σ₂] of λ
+      ⊢A₁[σ₁]≡A₂[σ₂] →
+    case wf-⊩≡ A₁[σ₁]≡A₂[σ₂] of λ
+      (⊩A₁[σ₁] , ⊩A₂[σ₂]) →
+    case escape ⊩A₁[σ₁] of λ
+      ⊢A₁[σ₁] →
+    case escape ⊩A₂[σ₂] of λ
+      ⊢A₂[σ₂] →
+    case rest of λ where
+      (ne (neNfₜ₌ t₁′-ne t₂′-ne t₁′~t₂′)) →
+        emptyrec p (A₁ [ σ₁ ]) (t₁ [ σ₁ ]) ∷ A₁ [ σ₁ ] ⇒*⟨ emptyrec-subst* t₁[σ₁]⇒*t₁′ ⊢A₁[σ₁] ⟩⊩∷∷
+        emptyrec p (A₁ [ σ₁ ]) t₁′         ∷ A₁ [ σ₁ ] ≡⟨ neutral-⊩≡∷ ⊩A₁[σ₁]
+                                                             (emptyrecₙ t₁′-ne) (emptyrecₙ t₂′-ne)
+                                                             (emptyrecⱼ ⊢A₁[σ₁] ⊢t₁′)
+                                                             (conv (emptyrecⱼ ⊢A₂[σ₂] ⊢t₂′)
+                                                                (sym (≅-eq ⊢A₁[σ₁]≡A₂[σ₂])))
+                                                             (~-emptyrec ⊢A₁[σ₁]≡A₂[σ₂] t₁′~t₂′) ⟩⊩∷∷⇐*
+                                                         ⟨ ≅-eq ⊢A₁[σ₁]≡A₂[σ₂] ⟩⇒
+        emptyrec p (A₂ [ σ₂ ]) t₂′         ∷ A₂ [ σ₂ ] ⇐*⟨ emptyrec-subst* t₂[σ₂]⇒*t₂′ ⊢A₂[σ₂] ⟩∎∷
+        emptyrec p (A₂ [ σ₂ ]) (t₂ [ σ₂ ])             ∎
+
+opaque
+
+  -- Reducibility for emptyrec.
+
+  ⊩emptyrec :
+    Γ ⊩ᵛ⟨ l ⟩ A →
+    Γ ⊩ᵛ⟨ l′ ⟩ t ∷ Empty →
+    Δ ⊩ˢ σ ∷ Γ →
+    Δ ⊩⟨ l ⟩ emptyrec p A t [ σ ] ∷ A [ σ ]
+  ⊩emptyrec ⊩A ⊩t ⊩σ =
+    wf-⊩≡∷
+      (⊩emptyrec≡emptyrec (refl-⊩ᵛ≡ ⊩A) (refl-⊩ᵛ≡∷ ⊩t) (refl-⊩ˢ≡∷ ⊩σ))
+      .proj₁
+
+opaque
+
+  -- Validity of emptyrec.
+
+  emptyrecᵛ :
+    Γ ⊩ᵛ⟨ l ⟩ A →
+    Γ ⊩ᵛ⟨ l′ ⟩ t ∷ Empty →
+    Γ ⊩ᵛ⟨ l ⟩ emptyrec p A t ∷ A
+  emptyrecᵛ ⊩A ⊩t =
+    ⊩ᵛ∷⇔′ .proj₂
+      ( ⊩A
+      , ⊩emptyrec ⊩A ⊩t
+      , ⊩emptyrec≡emptyrec (refl-⊩ᵛ≡ ⊩A) (refl-⊩ᵛ≡∷ ⊩t)
+      )
+
+opaque
+
+  -- Validity of equality between applications of emptyrec
+
+  emptyrec-congᵛ :
+    Γ ⊩ᵛ⟨ l ⟩ A₁ ≡ A₂ →
+    Γ ⊩ᵛ⟨ l′ ⟩ t₁ ≡ t₂ ∷ Empty →
+    Γ ⊩ᵛ⟨ l ⟩ emptyrec p A₁ t₁ ≡ emptyrec p A₂ t₂ ∷ A₁
+  emptyrec-congᵛ A₁≡A₂ t₁≡t₂ =
+    case wf-⊩ᵛ≡ A₁≡A₂ of λ
+      (⊩A₁ , ⊩A₂) →
+    case wf-⊩ᵛ≡∷ t₁≡t₂ of λ
+      (⊩t₁ , ⊩t₂) →
+    ⊩ᵛ≡∷⇔′ .proj₂
+      ( emptyrecᵛ ⊩A₁ ⊩t₁
+      , conv-⊩ᵛ∷ (sym-⊩ᵛ≡ A₁≡A₂)
+          (emptyrecᵛ ⊩A₂ ⊩t₂)
+      , ⊩emptyrec≡emptyrec A₁≡A₂ t₁≡t₂
+      )

--- a/Definition/Typed/RedSteps.agda
+++ b/Definition/Typed/RedSteps.agda
@@ -78,6 +78,15 @@ fst-subst* : Γ ⊢ t ⇒* t′ ∷ Σˢ p , q ▷ A ▹ B
 fst-subst* (id x) ⊢F ⊢G = id (fstⱼ ⊢F ⊢G x)
 fst-subst* (x ⇨ t⇒t′) ⊢F ⊢G = (fst-subst ⊢F ⊢G x) ⇨ (fst-subst* t⇒t′ ⊢F ⊢G)
 
+opaque
+
+  -- emptyrec substitution of reduction closures
+  emptyrec-subst* : Γ ⊢ t ⇒* t′ ∷ Empty
+                  → Γ ⊢ A
+                  → Γ ⊢ emptyrec p A t ⇒* emptyrec p A t′ ∷ A
+  emptyrec-subst* (id x) ⊢A = id (emptyrecⱼ ⊢A x)
+  emptyrec-subst* (x ⇨ d) ⊢A = emptyrec-subst ⊢A x ⇨ emptyrec-subst* d ⊢A
+
 -- A variant of []-cong-subst for _⊢_⇒*_∷_.
 
 []-cong-subst* :

--- a/Graded/Erasure/LogicalRelation/Fundamental.agda
+++ b/Graded/Erasure/LogicalRelation/Fundamental.agda
@@ -368,16 +368,12 @@ module Fundamental
              δ ⟨ x ⟩ PE.≡ 𝟘 × θ ⟨ x ⟩ PE.≡ 𝟘 × η ⟨ x ⟩ PE.≡ 𝟘  □) }
     fundamental
       {Γ = Γ} {γ = γ}
-      (emptyrecⱼ {A = A} {t = t} {p = p} ⊢A Γ⊢t:Empty) γ▸t =
-      let invUsageEmptyrec δ▸t _ ok γ≤ = inv-usage-emptyrec γ▸t
-          [Γ] , [Empty] , ⊩ʳt = fundamental Γ⊢t:Empty δ▸t
-          [Γ]′ , [A]′ = F.fundamental ⊢A
-          [A] = IS.irrelevance {A = A} [Γ]′ [Γ] [A]′
-          [Γ]″ , [Empty]′ , [t]′ = F.fundamentalTerm Γ⊢t:Empty
-          [t] = IS.irrelevanceTerm {A = Empty} {t = t}
-                  [Γ]″ [Γ] [Empty]′ [Empty] [t]′
-          γ⊩ʳemptyrec = emptyrecʳ t ok [Empty] [A] [t] ⊩ʳt
-      in  [Γ] , [A] , subsumption-≤ (emptyrec _ A t) [A] γ⊩ʳemptyrec γ≤
+      (emptyrecⱼ {A = A} {t = t} {p = p} ⊢A ⊢t) ▸t =
+        case inv-usage-emptyrec ▸t of λ
+          (invUsageEmptyrec ▸t _ ok γ≤pδ) →
+        subsumption-▸⊩ʳ∷[]-≤ {t = emptyrec p A t} γ≤pδ $
+        emptyrecʳ ok (F.fundamental-⊩ᵛ ⊢A) (F.fundamental-⊩ᵛ∷ ⊢t)
+          (fundamental ⊢t ▸t)
     fundamental (starⱼ ⊢Γ ok) _ =
       starʳ ⊢Γ ok
     fundamental {m = 𝟙ᵐ} (unitrecⱼ {A} ⊢A ⊢t ⊢u ok) γ▸ur =

--- a/Graded/Erasure/LogicalRelation/Fundamental/Empty.agda
+++ b/Graded/Erasure/LogicalRelation/Fundamental/Empty.agda
@@ -25,14 +25,13 @@ module Graded.Erasure.LogicalRelation.Fundamental.Empty
   where
 
 open import Graded.Erasure.LogicalRelation as
-import Graded.Erasure.LogicalRelation.Irrelevance as as I
-open import Graded.Erasure.LogicalRelation.Subsumption as
+open import Graded.Erasure.LogicalRelation.Hidden as
 import Graded.Erasure.Target as T
+open import Graded.Erasure.Extraction 𝕄
 
 open import Definition.LogicalRelation R
 open import Definition.LogicalRelation.Fundamental R
-open import Definition.LogicalRelation.Substitution R
-open import Definition.LogicalRelation.Substitution.Irrelevance R
+open import Definition.LogicalRelation.Hidden R
 open import Definition.LogicalRelation.Substitution.Introductions.Universe R
 open import Definition.LogicalRelation.Substitution.Introductions.Empty R
 open import Definition.Untyped M
@@ -45,69 +44,74 @@ open import Tools.Empty
 open import Tools.Function
 open import Tools.Nat
 open import Tools.Product
-open import Tools.PropositionalEquality
+open import Tools.PropositionalEquality as PE
 open import Tools.Relation
 open import Tools.Sum
 
 private
   variable
     n : Nat
-    l : TypeLevel
+    l l′ l″ : TypeLevel
     γ : Conₘ n
     p : M
     Γ : Con Term n
     t A : Term n
     v : T.Term n
     m : Mode
-    ⊩Γ : ⊩ᵛ _
 
-Emptyʳ : ⊢ Γ
-      → ∃ λ ([Γ] : ⊩ᵛ Γ)
-      → ∃ λ ([U] : Γ ⊩ᵛ⟨ ¹ ⟩ U / [Γ])
-      → γ ▸ Γ ⊩ʳ⟨ ¹ ⟩ Empty ∷[ m ] U / [Γ] / [U]
-Emptyʳ {m = m} ⊢Γ =
-  [Γ] , [U] , λ _ _ → Uᵣ (λ { refl → T.refl }) ◀ ⌜ m ⌝
-  where
-  [Γ] = valid ⊢Γ
-  [U] = Uᵛ [Γ]
+opaque
 
-emptyrecʳ′ :
-  ∀ t →
-  Emptyrec-allowed m p →
-  (⊩A : Γ ⊩ᵛ⟨ l ⟩ A / ⊩Γ) →
-  Γ ⊩ᵛ⟨ l ⟩ t ∷ Empty / ⊩Γ / Emptyᵛ ⊩Γ →
-  γ ▸ Γ ⊩ʳ⟨ l ⟩ t ∷[ m ᵐ· p ] Empty / ⊩Γ / Emptyᵛ ⊩Γ →
-  p ·ᶜ γ ▸ Γ ⊩ʳ⟨ l ⟩ emptyrec p A t ∷[ m ] A / ⊩Γ / ⊩A
-emptyrecʳ′ {m = 𝟘ᵐ} _ _ _ _ _ _ _ with is-𝟘? 𝟘
-... | yes _  = _
-... | no 𝟘≢𝟘 = ⊥-elim $ 𝟘≢𝟘 refl
-emptyrecʳ′ {m = 𝟙ᵐ} {p} {γ} t ok _ ⊩t ⊩ʳt ⊩σ σ®σ′ with is-𝟘? 𝟙 | is-𝟘? p
-... | yes _ | _       = _
-... | no _  | yes refl =
-  case ⊩t ⊢Δ ⊩σ .proj₁ of λ where
-    (Emptyₜ _ _ _ (ne (neNfₜ _ ⊢k _))) →
-      ⊥-elim $ consistent ok _ ⊢k
-... | no _  | no p≢𝟘 =
-  case
-    subst (λ m → _ ▸ _ ⊩ʳ⟨ _ ⟩ t ∷[ m ] Empty / _ / Emptyᵛ _)
-      (≢𝟘→⌞⌟≡𝟙ᵐ p≢𝟘) ⊩ʳt ⊩σ
-      (subsumptionSubst σ®σ′ λ _ ≡𝟘 →
-       case ·ᶜ-zero-product-⟨⟩ γ ≡𝟘 of λ where
-         (inj₁ p≡𝟘) → ⊥-elim $ p≢𝟘 p≡𝟘
-         (inj₂ ≡𝟘)  → ≡𝟘)
-    ◀≢𝟘 non-trivial
-  of λ ()
+  -- Validity of Empty.
 
-emptyrecʳ :
-  ∀ t →
-  Emptyrec-allowed m p →
-  (⊩Empty : Γ ⊩ᵛ⟨ l ⟩ Empty / ⊩Γ)
-  (⊩A : Γ ⊩ᵛ⟨ l ⟩ A / ⊩Γ) →
-  Γ ⊩ᵛ⟨ l ⟩ t ∷ Empty / ⊩Γ / ⊩Empty →
-  γ ▸ Γ ⊩ʳ⟨ l ⟩ t ∷[ m ᵐ· p ] Empty / ⊩Γ / ⊩Empty →
-  p ·ᶜ γ ▸ Γ ⊩ʳ⟨ l ⟩ emptyrec p A t ∷[ m ] A / ⊩Γ / ⊩A
-emptyrecʳ {l} t ok ⊩Empty₁ ⊩A ⊩t₁ ⊩ʳt =
-  let ⊩Empty₂ = Emptyᵛ {l = l} _
-      ⊩t₂     = irrelevanceTerm {t = t} _ _ ⊩Empty₁ ⊩Empty₂ ⊩t₁
-  in  emptyrecʳ′ t ok ⊩A ⊩t₂ $
-      I.irrelevance {t = t} _ _ ⊩Empty₁ ⊩Empty₂ ⊩ʳt
+  Emptyʳ :
+    ⊢ Γ →
+    γ ▸ Γ ⊩ʳ⟨ ¹ ⟩ Empty ∷[ m ] U
+  Emptyʳ ⊢Γ =
+    ▸⊩ʳ∷⇔ .proj₂
+      ( ⊩ᵛU (valid ⊢Γ)
+      , λ _ _ → ®∷→®∷◂ (®∷U⇔ .proj₂ ((_ , 0<1) , Uᵣ (λ { refl → T.refl }))))
+
+opaque
+
+  -- Validity of emptyrec
+
+  emptyrecʳ :
+    Emptyrec-allowed m p →
+    Γ ⊩ᵛ⟨ l ⟩ A →
+    Γ ⊩ᵛ⟨ l′ ⟩ t ∷ Empty →
+    γ ▸ Γ ⊩ʳ⟨ l″ ⟩ t ∷[ m ᵐ· p ] Empty →
+    p ·ᶜ γ ▸ Γ ⊩ʳ⟨ l ⟩ emptyrec p A t ∷[ m ] A
+  emptyrecʳ {m = 𝟘ᵐ} _ ⊩A _ _ =
+    ▸⊩ʳ∷[𝟘ᵐ] ⊩A
+  emptyrecʳ {m = 𝟙ᵐ} {p} {Γ} {t} {γ} ok ⊩A ⊩t ⊩ʳt =
+    ▸⊩ʳ∷⇔ .proj₂
+      ( ⊩A
+      , (λ {σ = σ} {σ′ = σ′} ⊩σ σ®σ′ →
+        case ⊩∷Empty⇔ .proj₁ $
+             ⊩ᵛ∷⇔′ .proj₁ ⊩t .proj₂ .proj₁ ⊩σ of λ
+          (Emptyₜ t′ [ ⊢t[σ] , _ , t[σ]⇨t′ ] _ rest) →
+        case is-𝟘? p of λ where
+          (yes refl) → ⊥-elim (consistent ok _ ⊢t[σ])
+          (no p≢𝟘) →
+            case PE.sym (≢𝟘→⌞⌟≡𝟙ᵐ p≢𝟘) of λ
+              𝟙ᵐ≡⌞p⌟ →
+            case
+                                                                         $⟨ σ®σ′ ⟩
+              σ ® σ′ ∷[ 𝟙ᵐ ] Γ ◂ p ·ᶜ γ                                  →⟨ (subsumption-®∷[]◂ λ x →
+
+                  (p ·ᶜ γ) ⟨ x ⟩ ≡ 𝟘                                          →⟨ ·ᶜ-zero-product-⟨⟩ γ ⟩
+                  p ≡ 𝟘 ⊎ γ ⟨ x ⟩ ≡ 𝟘                                         →⟨ (λ { (inj₁ p≡𝟘) → ⊥-elim (p≢𝟘 p≡𝟘)
+                                                                                   ; (inj₂ γ⟨x⟩≡𝟘) → γ⟨x⟩≡𝟘
+                                                                                   }) ⟩
+                  γ ⟨ x ⟩ ≡ 𝟘                                                 □) ⟩
+
+                σ ® σ′ ∷[ 𝟙ᵐ ] Γ ◂ γ                                    ≡⟨ cong₃ (_®_∷[_]_◂_ _ _) 𝟙ᵐ≡⌞p⌟ refl refl ⟩→
+
+                σ ® σ′ ∷[ ⌞ p ⌟ ] Γ ◂ γ                                 →⟨ ▸⊩ʳ∷⇔ .proj₁ ⊩ʳt .proj₂ ⊩σ ⟩
+
+                t [ σ ] ®⟨ _ ⟩ erase str t T.[ σ′ ] ∷ Empty ◂ ⌜ ⌞ p ⌟ ⌝ →⟨ ®∷→®∷◂ω (non-trivial ∘→ PE.trans (PE.cong ⌜_⌝ 𝟙ᵐ≡⌞p⌟)) ⟩
+
+                t [ σ ] ®⟨ _ ⟩ erase str t T.[ σ′ ] ∷ Empty             ⇔⟨ ®∷Empty⇔ ⟩→
+
+                t [ σ ] ® erase str t T.[ σ′ ] ∷Empty □
+              of λ ()))


### PR DESCRIPTION
The parts of the proofs of the fundamental lemmas that are related to the empty type now use the "hidden" logical relations

Continuation of the work started in #35.

