### PR TITLE
Made some assumptions related to the weak unit type with η weaker

### DIFF
--- a/Application/NegativeOrErasedAxioms/Canonicity.agda
+++ b/Application/NegativeOrErasedAxioms/Canonicity.agda
@@ -282,14 +282,13 @@ nfN (rflⱼ _)          _ _ rflₙ        c = ⊥-elim (Id≢ℕ c)
 
 -- The following results are proved under the assumption that, if the
 -- weak unit type is allowed, η-equality is allowed for it, and
--- Unitrec-allowed 𝟙ᵐ p q holds for some p and q, then either 𝟙 ≤ 𝟘 or
--- p is 𝟘.
+-- Unitrec-allowed 𝟙ᵐ p q holds for some p and q, then p ≤ 𝟘.
 
 module _
   (Unitʷ-η→ :
      ∀ {p q} →
      Unitʷ-η → Unitʷ-allowed → Unitrec-allowed 𝟙ᵐ p q →
-     𝟙 ≤ 𝟘 ⊎ p PE.≡ 𝟘)
+     p ≤ 𝟘)
   where
 
   -- Terms that have non-negative types reduce to non-neutral terms.

--- a/Graded/Box-cong.agda
+++ b/Graded/Box-cong.agda
@@ -490,7 +490,7 @@ opaque
     No-erased-matches TR UR →
     (∀ {p q} →
      Unitʷ-η → Unitʷ-allowed → Unitrec-allowed 𝟙ᵐ p q →
-     𝟙 ≤ 𝟘 ⊎ p PE.≡ 𝟘) →
+     p ≤ 𝟘) →
     ¬ Has-[]-cong s 𝟙ᵐ q₁ q₂ q₃ q₄
   ¬-[]-cong nem Unitʷ-η→ (_ , ▸[]-cong , ⊢[]-cong) =
     case lemma

--- a/Graded/Erasure/Consequences/Resurrectable.agda
+++ b/Graded/Erasure/Consequences/Resurrectable.agda
@@ -299,7 +299,7 @@ opaque
     ⦃ ok : T 𝟘ᵐ-allowed ⦄ →
     (∀ {p q} →
      Unitʷ-η → Unitʷ-allowed → Unitrec-allowed 𝟙ᵐ p q →
-     𝟙 ≤ 𝟘 ⊎ p PE.≡ 𝟘) →
+     p ≤ 𝟘) →
     (s PE.≡ 𝕨 → Prodrec-allowed 𝟘ᵐ (𝟘 ∧ 𝟙) 𝟘 𝟘) →
     []-cong-allowed s →
     Fundamental-assumptions⁻ Γ →

--- a/Graded/FullReduction.agda
+++ b/Graded/FullReduction.agda
@@ -93,11 +93,11 @@ module _ (as : Full-reduction-assumptions) where
 
     Unitʷ-η→ :
       Unitʷ-η → Unitʷ-allowed → Unitrec-allowed 𝟙ᵐ p q →
-      𝟙 ≤ 𝟘 ⊎ p PE.≡ 𝟘
+      p ≤ 𝟘
     Unitʷ-η→ η ok _ =
       case sink⊎𝟙≤𝟘 ok (inj₂ η) of λ where
         (inj₁ (() , _))
-        (inj₂ 𝟙≤𝟘)      → inj₁ 𝟙≤𝟘
+        (inj₂ 𝟙≤𝟘)      → ≤𝟘⇔𝟙≤𝟘 .proj₂ 𝟙≤𝟘
 
     -- A lemma used in the Unit-ins and η-unit cases of
     -- fullRedTermConv↓.

--- a/Graded/Reduction.agda
+++ b/Graded/Reduction.agda
@@ -122,8 +122,7 @@ opaque
 
 -- These results are proved under the assumption that, if the weak
 -- unit type is allowed, η-equality is allowed for it, and
--- Unitrec-allowed 𝟙ᵐ p q holds for some p and q, then either 𝟙 ≤ 𝟘 or
--- p is 𝟘.
+-- Unitrec-allowed 𝟙ᵐ p q holds for some p and q, then p ≤ 𝟘.
 --
 -- Maybe things could be changed so that, if Unitʷ-η holds, then
 -- η-equality for the weak unit type is not allowed for 𝟙ᵐ, but only
@@ -133,7 +132,7 @@ module _
   (Unitʷ-η→ :
      ∀ {p q} →
      Unitʷ-η → Unitʷ-allowed → Unitrec-allowed 𝟙ᵐ p q →
-     𝟙 ≤ 𝟘 ⊎ p PE.≡ 𝟘)
+     p ≤ 𝟘)
   where
 
   -- Term reduction preserves usage.
@@ -318,21 +317,13 @@ module _
         Usage-restrictions-satisfied 𝟘ᵐ u            →⟨ ▸[𝟘ᵐ]⇔ .proj₁ γ▸ur .proj₁ ,_ ⟩
         γ ≤ᶜ 𝟘ᶜ × Usage-restrictions-satisfied 𝟘ᵐ u  →⟨ ▸[𝟘ᵐ]⇔ .proj₂ ⟩
         γ ▸[ 𝟘ᵐ ] u                                  □
-      (𝟙ᵐ , PE.refl) → case is-𝟘? p of λ where
-        (yes PE.refl) →
-          sub η▸u $ begin
-            γ             ≤⟨ γ≤pδ+η ⟩
-            𝟘 ·ᶜ δ +ᶜ η   ≈⟨ +ᶜ-congʳ $ ·ᶜ-zeroˡ _ ⟩
-            𝟘ᶜ +ᶜ η       ≈⟨ +ᶜ-identityˡ η ⟩
-            η             ∎
-        (no p≢𝟘) →
-          case Unitʷ-η→ η-ok Unit-ok unitrec-ok of λ where
-            (inj₂ p≡𝟘) → ⊥-elim (p≢𝟘 p≡𝟘)
-            (inj₁ 𝟙≤𝟘) →
-              sub η▸u $ begin
-                γ            ≤⟨ γ≤pδ+η ⟩
-                p ·ᶜ δ +ᶜ η  ≤⟨ +ᶜ-decreasingʳ 𝟙≤𝟘 ⟩
-                η            ∎
+      (𝟙ᵐ , PE.refl) →
+        sub η▸u $ begin
+          γ            ≤⟨ γ≤pδ+η ⟩
+          p ·ᶜ δ +ᶜ η  ≤⟨ +ᶜ-monotoneˡ $ ·ᶜ-monotoneˡ $ Unitʷ-η→ η-ok Unit-ok unitrec-ok ⟩
+          𝟘 ·ᶜ δ +ᶜ η  ≈⟨ +ᶜ-congʳ $ ·ᶜ-zeroˡ δ ⟩
+          𝟘ᶜ +ᶜ η      ≈⟨ +ᶜ-identityˡ η ⟩
+          η            ∎
     where
     open ≤ᶜ-reasoning
 


### PR DESCRIPTION
Previously, some properties were proven under the assumption that if the weak unit type has η equality and if Unitrec-allowed 𝟙ᵐ p q then either 𝟙 ≤ 𝟘 or p ≡ 𝟘. It is now changed to p ≤ 𝟘. (The old assumption implies the new one.)