### PR TITLE
Optimised several pieces of code

### DIFF
--- a/Definition/Conversion.agda
+++ b/Definition/Conversion.agda
@@ -182,8 +182,9 @@ mutual
     Empty-ins : Γ ⊢ k ~ l ↓ Empty
               → Γ ⊢ k [conv↓] l ∷ Empty
 
-    Unit-ins  : Γ ⊢ k ~ l ↓ Unit s
-              → Γ ⊢ k [conv↓] l ∷ Unit s
+    Unitʷ-ins : ¬ Unitʷ-η
+              → Γ ⊢ k ~ l ↓ Unitʷ
+              → Γ ⊢ k [conv↓] l ∷ Unitʷ
 
     Σʷ-ins    : Γ ⊢ k ∷ Σʷ p , q ▷ F ▹ G
               → Γ ⊢ l ∷ Σʷ p , q ▷ F ▹ G

--- a/Definition/Conversion.agda
+++ b/Definition/Conversion.agda
@@ -151,7 +151,6 @@ mutual
                → Γ ⊢ K [conv↓] L
 
     ΠΣ-cong    : ∀ {F G H E}
-               → Γ ⊢ F
                → Γ ⊢ F [conv↑] H
                → Γ ∙ F ⊢ G [conv↑] E
                → ΠΣ-allowed b p q
@@ -216,7 +215,6 @@ mutual
               → Γ ⊢ suc m [conv↓] suc n ∷ ℕ
 
     prod-cong : ∀ {F G t t′ u u′}
-              → Γ ⊢ F
               → Γ ∙ F ⊢ G
               → Γ ⊢ t [conv↑] t′ ∷ F
               → Γ ⊢ u [conv↑] u′ ∷ G [ t ]₀
@@ -272,13 +270,12 @@ prod-cong⁻¹ :
   Γ ⊢ prodʷ p t u [conv↓] prodʷ p′ t′ u′ ∷ Σʷ p″ , q ▷ F ▹ G →
   p PE.≡ p′ ×
   p PE.≡ p″ ×
-  Γ ⊢ F ×
   Γ ∙ F ⊢ G ×
   (Γ ⊢ t [conv↑] t′ ∷ F) ×
   (Γ ⊢ u [conv↑] u′ ∷ G [ t ]₀) ×
   Σʷ-allowed p q
-prod-cong⁻¹ (prod-cong F G t u ok) =
-  PE.refl , PE.refl , F , G , t , u , ok
+prod-cong⁻¹ (prod-cong G t u ok) =
+  PE.refl , PE.refl , G , t , u , ok
 
 -- An inversion lemma for J-cong.
 

--- a/Definition/Conversion/Consequences/Var.agda
+++ b/Definition/Conversion/Consequences/Var.agda
@@ -55,7 +55,7 @@ var-only-equal-to-itself =
     _             _ (univ _ _ x≡t)             → [conv↓]-lemma x≡t
     _             _ (Σʷ-ins _ _ x≡t)           → ~↓-lemma x≡t
     _             _ (Empty-ins x≡t)            → ~↓-lemma x≡t
-    _             _ (Unit-ins x≡t)             → ~↓-lemma x≡t
+    _             _ (Unitʷ-ins _ x≡t)          → ~↓-lemma x≡t
     _             _ (ℕ-ins x≡t)                → ~↓-lemma x≡t
     _             _ (Id-ins _ x≡t)             → ~↓-lemma x≡t
     _             _ (ne-ins _ _ _ x≡t)         → ~↓-lemma x≡t

--- a/Definition/Conversion/Conversion.agda
+++ b/Definition/Conversion/Conversion.agda
@@ -37,57 +37,58 @@ private
   variable
     n : Nat
     Γ Δ : Con Term n
+    A B t u : Term _
 
 mutual
   -- Conversion of algorithmic equality.
-  convConv↑Term : ∀ {t u A B}
-                → ⊢ Γ ≡ Δ
-                → Γ ⊢ A ≡ B
-                → Γ ⊢ t [conv↑] u ∷ A
-                → Δ ⊢ t [conv↑] u ∷ B
-  convConv↑Term Γ≡Δ A≡B ([↑]ₜ B₁ t′ u′ (D , _) d d′ t<>u) =
+  convConv↑Term′ :
+    ⊢ Γ ≡ Δ →
+    Γ ⊢ A ≡ B →
+    Γ ⊢ t [conv↑] u ∷ A →
+    Δ ⊢ t [conv↑] u ∷ B
+  convConv↑Term′ Γ≡Δ A≡B ([↑]ₜ B₁ t′ u′ (D , _) d d′ t<>u) =
     let _ , ⊢B = syntacticEq A≡B
         B′ , whnfB′ , D′ = whNorm ⊢B
         B₁≡B′ = trans (sym (subset* D)) (trans A≡B (subset* (red D′)))
     in  [↑]ₜ B′ t′ u′ (stabilityRed↘ Γ≡Δ (red D′ , whnfB′))
              (stabilityRed↘Term Γ≡Δ (conv↘∷ d B₁≡B′))
              (stabilityRed↘Term Γ≡Δ (conv↘∷ d′ B₁≡B′))
-             (convConv↓Term Γ≡Δ B₁≡B′ whnfB′ t<>u)
+             (convConv↓Term′ Γ≡Δ B₁≡B′ whnfB′ t<>u)
 
   -- Conversion of algorithmic equality with terms and types in WHNF.
-  convConv↓Term : ∀ {t u A B}
-                → ⊢ Γ ≡ Δ
-                → Γ ⊢ A ≡ B
-                → Whnf B
-                → Γ ⊢ t [conv↓] u ∷ A
-                → Δ ⊢ t [conv↓] u ∷ B
-  convConv↓Term Γ≡Δ A≡B whnfB (ℕ-ins x) rewrite ℕ≡A A≡B whnfB =
+  convConv↓Term′ :
+    ⊢ Γ ≡ Δ →
+    Γ ⊢ A ≡ B →
+    Whnf B →
+    Γ ⊢ t [conv↓] u ∷ A →
+    Δ ⊢ t [conv↓] u ∷ B
+  convConv↓Term′ Γ≡Δ A≡B whnfB (ℕ-ins x) rewrite ℕ≡A A≡B whnfB =
     ℕ-ins (stability~↓ Γ≡Δ x)
-  convConv↓Term Γ≡Δ A≡B whnfB (Empty-ins x) rewrite Empty≡A A≡B whnfB =
+  convConv↓Term′ Γ≡Δ A≡B whnfB (Empty-ins x) rewrite Empty≡A A≡B whnfB =
     Empty-ins (stability~↓ Γ≡Δ x)
-  convConv↓Term Γ≡Δ A≡B B-whnf (Unitʷ-ins ok t~u)
+  convConv↓Term′ Γ≡Δ A≡B B-whnf (Unitʷ-ins ok t~u)
     rewrite Unit≡A A≡B B-whnf =
     Unitʷ-ins ok (stability~↓ Γ≡Δ t~u)
-  convConv↓Term Γ≡Δ  A≡B whnfB (Σʷ-ins x x₁ x₂) with Σ≡A A≡B whnfB
+  convConv↓Term′ Γ≡Δ  A≡B whnfB (Σʷ-ins x x₁ x₂) with Σ≡A A≡B whnfB
   ... | _ , _ , PE.refl =
     Σʷ-ins (stabilityTerm Γ≡Δ (conv x A≡B))
            (stabilityTerm Γ≡Δ (conv x₁ A≡B))
            (stability~↓ Γ≡Δ x₂)
-  convConv↓Term Γ≡Δ A≡B whnfB (ne-ins t u x x₁) =
+  convConv↓Term′ Γ≡Δ A≡B whnfB (ne-ins t u x x₁) =
     ne-ins (stabilityTerm Γ≡Δ (conv t A≡B)) (stabilityTerm Γ≡Δ (conv u A≡B))
            (ne≡A x A≡B whnfB) (stability~↓ Γ≡Δ x₁)
-  convConv↓Term Γ≡Δ A≡B whnfB (univ x x₁ x₂) rewrite U≡A A≡B =
+  convConv↓Term′ Γ≡Δ A≡B whnfB (univ x x₁ x₂) rewrite U≡A A≡B =
     univ (stabilityTerm Γ≡Δ x) (stabilityTerm Γ≡Δ x₁) (stabilityConv↓ Γ≡Δ x₂)
-  convConv↓Term Γ≡Δ A≡B whnfB (zero-refl x) rewrite ℕ≡A A≡B whnfB =
+  convConv↓Term′ Γ≡Δ A≡B whnfB (zero-refl x) rewrite ℕ≡A A≡B whnfB =
     let _ , ⊢Δ , _ = contextConvSubst Γ≡Δ
     in  zero-refl ⊢Δ
-  convConv↓Term Γ≡Δ A≡B whnfB (starʷ-refl _ ok no-η)
+  convConv↓Term′ Γ≡Δ A≡B whnfB (starʷ-refl _ ok no-η)
     rewrite Unit≡A A≡B whnfB =
     let _ , ⊢Δ , _ = contextConvSubst Γ≡Δ
     in  starʷ-refl ⊢Δ ok no-η
-  convConv↓Term Γ≡Δ A≡B whnfB (suc-cong x) rewrite ℕ≡A A≡B whnfB =
+  convConv↓Term′ Γ≡Δ A≡B whnfB (suc-cong x) rewrite ℕ≡A A≡B whnfB =
     suc-cong (stabilityConv↑Term Γ≡Δ x)
-  convConv↓Term Γ≡Δ A≡B whnfB (prod-cong x₁ x₂ x₃ ok)
+  convConv↓Term′ Γ≡Δ A≡B whnfB (prod-cong x₁ x₂ x₃ ok)
     with Σ≡A A≡B whnfB
   ... | F′ , G′ , PE.refl with Σ-injectivity A≡B
   ...   | F≡F′ , G≡G′ , _ , _ =
@@ -95,16 +96,16 @@ mutual
         _ , ⊢t , _ = syntacticEqTerm (soundnessConv↑Term x₂)
         Gt≡G′t = substTypeEq G≡G′ (refl ⊢t)
     in  prod-cong (stability (Γ≡Δ ∙ F≡F′) ⊢G′)
-          (convConv↑Term Γ≡Δ F≡F′ x₂) (convConv↑Term Γ≡Δ Gt≡G′t x₃) ok
-  convConv↓Term Γ≡Δ A≡B whnfB (η-eq x₁ x₂ y y₁ x₃) with Π≡A A≡B whnfB
-  convConv↓Term Γ≡Δ A≡B whnfB (η-eq x₁ x₂ y y₁ x₃) | F′ , G′ , PE.refl =
+          (convConv↑Term′ Γ≡Δ F≡F′ x₂) (convConv↑Term′ Γ≡Δ Gt≡G′t x₃) ok
+  convConv↓Term′ Γ≡Δ A≡B whnfB (η-eq x₁ x₂ y y₁ x₃) with Π≡A A≡B whnfB
+  convConv↓Term′ Γ≡Δ A≡B whnfB (η-eq x₁ x₂ y y₁ x₃) | _ , _ , PE.refl =
     case injectivity A≡B of λ {
       (F≡F′ , G≡G′ , _ , _) →
     η-eq (stabilityTerm Γ≡Δ (conv x₁ A≡B))
          (stabilityTerm Γ≡Δ (conv x₂ A≡B))
          y y₁
-         (convConv↑Term (Γ≡Δ ∙ F≡F′) G≡G′ x₃) }
-  convConv↓Term Γ≡Δ A≡B whnfB (Σ-η ⊢p ⊢r pProd rProd fstConv sndConv)
+         (convConv↑Term′ (Γ≡Δ ∙ F≡F′) G≡G′ x₃) }
+  convConv↓Term′ Γ≡Δ A≡B whnfB (Σ-η ⊢p ⊢r pProd rProd fstConv sndConv)
     with Σ≡A A≡B whnfB
   ... | F , G , PE.refl with Σ-injectivity A≡B
   ...   | F≡ , G≡ , _ , _ =
@@ -115,19 +116,19 @@ mutual
             (stabilityTerm Γ≡Δ (conv ⊢r A≡B))
             pProd
             rProd
-            (convConv↑Term Γ≡Δ F≡ fstConv)
-            (convConv↑Term Γ≡Δ (substTypeEq G≡ (refl ⊢fst)) sndConv)
-  convConv↓Term Γ≡Δ A≡B whnfB (η-unit [t] [u] tUnit uUnit ok)
+            (convConv↑Term′ Γ≡Δ F≡ fstConv)
+            (convConv↑Term′ Γ≡Δ (substTypeEq G≡ (refl ⊢fst)) sndConv)
+  convConv↓Term′ Γ≡Δ A≡B whnfB (η-unit [t] [u] tUnit uUnit ok)
     rewrite Unit≡A A≡B whnfB =
     let [t] = stabilityTerm Γ≡Δ [t]
         [u] = stabilityTerm Γ≡Δ [u]
     in  η-unit [t] [u] tUnit uUnit ok
-  convConv↓Term Γ≡Δ Id-A-t-u≡B B-whnf (Id-ins ⊢v₁ v₁~v₂) =
+  convConv↓Term′ Γ≡Δ Id-A-t-u≡B B-whnf (Id-ins ⊢v₁ v₁~v₂) =
     case Id≡Whnf Id-A-t-u≡B B-whnf of λ {
       (_ , _ , _ , PE.refl) →
     Id-ins (stabilityTerm Γ≡Δ (conv ⊢v₁ Id-A-t-u≡B))
       (stability~↓ Γ≡Δ v₁~v₂) }
-  convConv↓Term Γ≡Δ Id-A-t-u≡B B-whnf (rfl-refl t≡u) =
+  convConv↓Term′ Γ≡Δ Id-A-t-u≡B B-whnf (rfl-refl t≡u) =
     case Id≡Whnf Id-A-t-u≡B B-whnf of λ {
       (_ , _ , _ , PE.refl) →
     case Id-injectivity Id-A-t-u≡B of λ {
@@ -137,8 +138,19 @@ mutual
        conv (trans (sym t≡t′) (trans t≡u u≡u′)) A≡A′) }}
 
 -- Conversion of algorithmic equality with the same context.
-convConvTerm : ∀ {t u A B}
-              → Γ ⊢ t [conv↑] u ∷ A
-              → Γ ⊢ A ≡ B
-              → Γ ⊢ t [conv↑] u ∷ B
-convConvTerm t<>u A≡B = convConv↑Term (reflConEq (wfEq A≡B)) A≡B t<>u
+convConv↑Term :
+  Γ ⊢ A ≡ B →
+  Γ ⊢ t [conv↑] u ∷ A →
+  Γ ⊢ t [conv↑] u ∷ B
+convConv↑Term A≡B = convConv↑Term′ (reflConEq (wfEq A≡B)) A≡B
+
+opaque
+
+  -- Conversion for _⊢_[conv↓]_∷_.
+
+  convConv↓Term :
+    Γ ⊢ A ≡ B →
+    Whnf B →
+    Γ ⊢ t [conv↓] u ∷ A →
+    Γ ⊢ t [conv↓] u ∷ B
+  convConv↓Term A≡B = convConv↓Term′ (reflConEq (wfEq A≡B)) A≡B

--- a/Definition/Conversion/Conversion.agda
+++ b/Definition/Conversion/Conversion.agda
@@ -87,15 +87,14 @@ mutual
     in  starʷ-refl ⊢Δ ok no-η
   convConv↓Term Γ≡Δ A≡B whnfB (suc-cong x) rewrite ℕ≡A A≡B whnfB =
     suc-cong (stabilityConv↑Term Γ≡Δ x)
-  convConv↓Term Γ≡Δ A≡B whnfB (prod-cong x x₁ x₂ x₃ ok)
+  convConv↓Term Γ≡Δ A≡B whnfB (prod-cong x₁ x₂ x₃ ok)
     with Σ≡A A≡B whnfB
   ... | F′ , G′ , PE.refl with Σ-injectivity A≡B
   ...   | F≡F′ , G≡G′ , _ , _ =
-    let _ , ⊢F′ = syntacticEq F≡F′
-        _ , ⊢G′ = syntacticEq G≡G′
+    let _ , ⊢G′ = syntacticEq G≡G′
         _ , ⊢t , _ = syntacticEqTerm (soundnessConv↑Term x₂)
         Gt≡G′t = substTypeEq G≡G′ (refl ⊢t)
-    in  prod-cong (stability Γ≡Δ ⊢F′) (stability (Γ≡Δ ∙ F≡F′) ⊢G′)
+    in  prod-cong (stability (Γ≡Δ ∙ F≡F′) ⊢G′)
           (convConv↑Term Γ≡Δ F≡F′ x₂) (convConv↑Term Γ≡Δ Gt≡G′t x₃) ok
   convConv↓Term Γ≡Δ A≡B whnfB (η-eq x₁ x₂ y y₁ x₃) with Π≡A A≡B whnfB
   convConv↓Term Γ≡Δ A≡B whnfB (η-eq x₁ x₂ y y₁ x₃) | F′ , G′ , PE.refl =

--- a/Definition/Conversion/Conversion.agda
+++ b/Definition/Conversion/Conversion.agda
@@ -65,8 +65,9 @@ mutual
     ℕ-ins (stability~↓ Γ≡Δ x)
   convConv↓Term Γ≡Δ A≡B whnfB (Empty-ins x) rewrite Empty≡A A≡B whnfB =
     Empty-ins (stability~↓ Γ≡Δ x)
-  convConv↓Term Γ≡Δ A≡B whnfB (Unit-ins x) rewrite Unit≡A A≡B whnfB =
-    Unit-ins (stability~↓ Γ≡Δ x)
+  convConv↓Term Γ≡Δ A≡B B-whnf (Unitʷ-ins ok t~u)
+    rewrite Unit≡A A≡B B-whnf =
+    Unitʷ-ins ok (stability~↓ Γ≡Δ t~u)
   convConv↓Term Γ≡Δ  A≡B whnfB (Σʷ-ins x x₁ x₂) with Σ≡A A≡B whnfB
   ... | _ , _ , PE.refl =
     Σʷ-ins (stabilityTerm Γ≡Δ (conv x A≡B))

--- a/Definition/Conversion/Decidable.agda
+++ b/Definition/Conversion/Decidable.agda
@@ -2,6 +2,8 @@
 -- The algorithmic equality is decidable.
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-infer-absurd-clauses #-}
+
 open import Definition.Typed.Restrictions
 open import Graded.Modality
 import Tools.PropositionalEquality as PE
@@ -19,14 +21,15 @@ open Type-restrictions R
 open import Definition.Untyped M
 open import Definition.Untyped.Neutral M type-variant
 open import Definition.Untyped.Properties M
+open import Definition.Untyped.Properties.Neutral M type-variant
 open import Definition.Typed R
 open import Definition.Typed.Properties R
+open import Definition.Typed.Reasoning.Type R
 open import Definition.Conversion R
 open import Definition.Conversion.Inversion R
 open import Definition.Conversion.Whnf R
 open import Definition.Conversion.Soundness R
 open import Definition.Conversion.Symmetry R
-open import Definition.Conversion.Transitivity R
 open import Definition.Conversion.Stability R
 open import Definition.Conversion.Conversion R
 open import Definition.Typed.Consequences.DerivedRules.Identity R
@@ -37,9 +40,10 @@ open import Definition.Typed.Consequences.Injectivity R
 open import Definition.Typed.Consequences.Inversion R
 open import Definition.Typed.Consequences.Reduction R
 open import Definition.Typed.Consequences.Equality R
-open import Definition.Typed.Consequences.Inequality R as IE
 open import Definition.Typed.Consequences.NeTypeEq R
 open import Definition.Typed.Consequences.DerivedRules.Nat R
+
+import Graded.Derived.Erased.Untyped 𝕄 as Erased
 
 open import Tools.Fin
 open import Tools.Function
@@ -52,602 +56,742 @@ private
   variable
     ℓ : Nat
     Γ Δ : Con Term ℓ
-    B F G k k′ l l′ : Term ℓ
-    p p′ p₁ p₂ q q′ r r′ : M
+    A A₁ A₂ A′ B B₁ B₂ B′ C₁ C₂ t t₁ t₂ t′ u u₁ u₂ v₁ v₂ w₁ w₂ : Term _
+    b₁ b₂ : BinderMode
+    s₁ s₂ : Strength
+    p p₁ p₂ p′ q q₁ q₂ q′ q′₁ q′₂ r₁ r₂ : M
 
+------------------------------------------------------------------------
+-- Private definitions
 
--- Algorithmic equality of variables infers propositional equality.
-strongVarEq : ∀ {m n A} → Γ ⊢ var n ~ var m ↑ A → n PE.≡ m
-strongVarEq (var-refl x x≡y) = x≡y
+private opaque
 
--- Helper function for decidability of applications.
-dec~↑-app : ∀ {k k₁ l l₁ F F₁ G G₁ B}
-          → Γ ⊢ k ∷ Π p , q ▷ F ▹ G
-          → Γ ⊢ k₁ ∷ Π p , q ▷ F₁ ▹ G₁
-          → Γ ⊢ k ~ k₁ ↓ B
-          → p PE.≡ p′
-          → Dec (Γ ⊢ l [conv↑] l₁ ∷ F)
-          → Dec (∃ λ A → Γ ⊢ k ∘⟨ p ⟩ l ~ k₁ ∘⟨ p′ ⟩ l₁ ↑ A)
-dec~↑-app k k₁ k~k₁ PE.refl (yes p) =
-  let whnfA , neK , neL = ne~↓ k~k₁
-      ⊢A , ⊢k , ⊢l = syntacticEqTerm (soundness~↓ k~k₁)
-      ΠFG₁≡A = neTypeEq neK k ⊢k
-  in
-  case Π≡A ΠFG₁≡A whnfA of λ {
-    (H , E , A≡ΠHE) →
-  case injectivity (PE.subst (λ x → _ ⊢ _ ≡ x) A≡ΠHE ΠFG₁≡A) of λ {
-    (F≡H , G₁≡E , _ , _) →
-  yes (E [ _ ] , app-cong (PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) A≡ΠHE k~k₁)
-                   (convConvTerm p F≡H)) }}
-dec~↑-app k₂ k₃ k~k₁ _ (no ¬p) =
-  no (λ { (_ , app-cong x x₁) →
-      let whnfA , neK , neL = ne~↓ x
-          ⊢A , ⊢k , ⊢l = syntacticEqTerm (soundness~↓ x)
-          ΠFG≡ΠF₂G₂ = neTypeEq neK k₂ ⊢k
-          F≡F₂ , G≡G₂ , _ = injectivity ΠFG≡ΠF₂G₂
-      in  ¬p (convConvTerm x₁ (sym F≡F₂)) })
+  -- Some lemmas used below.
 
--- Helper function for decidability for neutrals of natural number type.
-decConv↓Term-ℕ-ins : ∀ {t u t′}
-                    → Γ ⊢ t [conv↓] u ∷ ℕ
-                    → Γ ⊢ t ~ t′ ↓ ℕ
-                    → Γ ⊢ t ~ u ↓ ℕ
-decConv↓Term-ℕ-ins (ℕ-ins x) t~t = x
-decConv↓Term-ℕ-ins (ne-ins x x₁ () x₃) t~t
-decConv↓Term-ℕ-ins (zero-refl x) ([~] _ _ ())
-decConv↓Term-ℕ-ins (suc-cong x) ([~] _ _ ())
+  ~↓→∷ : Γ ⊢ t ~ u ↓ A → Γ ⊢ t ∷ A
+  ~↓→∷ = proj₁ ∘→ proj₂ ∘→ syntacticEqTerm ∘→ soundness~↓
 
--- Helper function for decidability for neutrals of empty type.
-decConv↓Term-Empty-ins : ∀ {t u t′}
-                    → Γ ⊢ t [conv↓] u ∷ Empty
-                    → Γ ⊢ t ~ t′ ↓ Empty
-                    → Γ ⊢ t ~ u ↓ Empty
-decConv↓Term-Empty-ins (Empty-ins x) t~t = x
-decConv↓Term-Empty-ins (ne-ins x x₁ () x₃) t~t
+  [conv↓]∷→∷ : Γ ⊢ t [conv↓] u ∷ A → Γ ⊢ t ∷ A
+  [conv↓]∷→∷ = proj₁ ∘→ proj₂ ∘→ syntacticEqTerm ∘→ soundnessConv↓Term
 
--- Helper function for decidability for neutrals of Sigm type.
-decConv↓Term-Σʷ-ins : ∀ {t t′ u F G H E}
-                    → Γ ⊢ t [conv↓] u ∷ Σʷ p , q ▷ F ▹ G
-                    → Γ ⊢ t ~ t′ ↓ Σʷ p′ , q′ ▷ H ▹ E
-                    → ∃ λ B → Γ ⊢ t ~ u ↓ B
-decConv↓Term-Σʷ-ins (Σʷ-ins x x₁ x₂) t~t = _ , x₂
-decConv↓Term-Σʷ-ins (prod-cong _ _ _ _ _) ()
-decConv↓Term-Σʷ-ins (ne-ins x x₁ () x₃) t~t
+  ~↓→∷→Whnf×≡ : Γ ⊢ t ~ u ↓ A → Γ ⊢ t ∷ B → Γ ⊢ B ≡ A × Whnf A
+  ~↓→∷→Whnf×≡ t~u ⊢t =
+    let A-whnf , t-ne , _ = ne~↓ t~u in
+    neTypeEq t-ne ⊢t (~↓→∷ t~u) , A-whnf
 
--- Helper function for decidability for impossibility of terms not being equal
--- as neutrals when they are equal as terms and the first is a neutral.
-decConv↓Term-ℕ : ∀ {t u t′}
-                → Γ ⊢ t [conv↓] u ∷ ℕ
-                → Γ ⊢ t ~ t′ ↓ ℕ
-                → ¬ (Γ ⊢ t ~ u ↓ ℕ)
-                → ⊥
-decConv↓Term-ℕ (ℕ-ins x) t~t ¬u~u = ¬u~u x
-decConv↓Term-ℕ (ne-ins x x₁ () x₃) t~t ¬u~u
-decConv↓Term-ℕ (zero-refl x) ([~] _ _ ()) ¬u~u
-decConv↓Term-ℕ (suc-cong x) ([~] _ _ ()) ¬u~u
+private opaque
 
-decConv↓Term-Σʷ : ∀ {t u t′ F G F′ G′}
-                → Γ ⊢ t [conv↓] u ∷ Σʷ p , q ▷ F ▹ G
-                → Γ ⊢ t ~ t′ ↓ Σʷ p′ , q′ ▷ F′ ▹ G′
-                → (∀ {B} → ¬ (Γ ⊢ t ~ u ↓ B))
-                → ⊥
-decConv↓Term-Σʷ (Σʷ-ins x x₁ x₂) t~t ¬u~u = ¬u~u x₂
-decConv↓Term-Σʷ (prod-cong _ _ _ _ _) ()
-decConv↓Term-Σʷ (ne-ins x x₁ () x₃) t~t ¬u~u
+  -- A lemma used below.
 
--- Helper function for extensional equality of Unit.
-decConv↓Term-Unit : ∀ {t t′}
-              → Γ ⊢ t [conv↓] starʷ ∷ Unitʷ
-              → Γ ⊢ t ~ t′ ↓ Unitʷ
-              → Unitʷ-η
-decConv↓Term-Unit (Unitʷ-ins _ ()) ([~] _ _ _)
-decConv↓Term-Unit (η-unit _ _ _ _ (inj₁ ())) ([~] _ _ _)
-decConv↓Term-Unit (η-unit _ _ _ _ (inj₂ η)) ([~] _ _ _) = η
-decConv↓Term-Unit (ne-ins x x₁ () x₃) ([~] _ _ k~l)
-decConv↓Term-Unit (starʷ-refl _ _ _) ()
+  [conv↓]∷ℕ→~↓ℕ :
+    Γ ⊢ t ~ t′ ↓ ℕ →
+    Γ ⊢ t [conv↓] u ∷ ℕ →
+    Γ ⊢ t ~ u ↓ ℕ
+  [conv↓]∷ℕ→~↓ℕ ([~] _ _ t~t′) t≡u =
+    case inv-[conv↓]∷-ℕ t≡u of λ where
+      (inj₁ t~u)                          → t~u
+      (inj₂ (inj₁ (PE.refl , _)))         → ⊥-elim (inv-zero~ t~t′)
+      (inj₂ (inj₂ (_ , _ , PE.refl , _))) → ⊥-elim (inv-suc~ t~t′)
 
--- Helper function for Σ-η.
-decConv↓Term-Σ-η : ∀ {t u F G}
-                  → Γ ⊢ t ∷ Σ p , q ▷ F ▹ G
-                  → Γ ⊢ u ∷ Σ p , q ▷ F ▹ G
-                  → Product t
-                  → Product u
-                  → Γ ⊢ fst p t [conv↑] fst p u ∷ F
-                  → Dec (Γ ⊢ snd p t [conv↑] snd p u ∷ G [ fst p t ]₀)
-                  → Dec (Γ ⊢ t [conv↓] u ∷ Σ p , q ▷ F ▹ G)
-decConv↓Term-Σ-η ⊢t ⊢u tProd uProd fstConv (yes Q) =
-  yes (Σ-η ⊢t ⊢u tProd uProd fstConv Q)
-decConv↓Term-Σ-η ⊢t ⊢u tProd uProd fstConv (no ¬Q) =
-  no (λ {(Σ-η _ _ _ _ _ Q) → ¬Q Q})
+private opaque
 
--- Helper function for prodrec
-dec~↑-prodrec :
-  ∀ {F G C E t t′ u v F′ G′ q″} →
-  Dec (Γ ∙ (Σʷ p , q ▷ F ▹ G) ⊢ C [conv↑] E) →
-  (Γ ∙ (Σʷ p , q ▷ F ▹ G) ⊢ C ≡ E →
-    Dec (Γ ∙ F ∙ G ⊢ u [conv↑] v ∷
-      C [ prodʷ p (var x1) (var x0) ]↑²)) →
-  Γ ⊢ t ~ t′ ↓ Σʷ p , q ▷ F′ ▹ G′ →
-  Γ ⊢ Σʷ p , q ▷ F ▹ G ≡ Σʷ p , q ▷ F′ ▹ G′ →
-  p PE.≡ p′ →
-  q′ PE.≡ q″ →
-  r PE.≡ r′ →
-  Dec (∃ λ B → Γ ⊢ prodrec r p q′ C t u ~ prodrec r′ p′ q″ E t′ v ↑ B)
-dec~↑-prodrec (yes C<>E) u<?>v t~t′ ⊢Σ≡Σ′ p≡p′ q≡q′ r≡r′ =
-  case u<?>v (soundnessConv↑ C<>E) of λ where
-    (yes u<>v) → case p≡p′ of λ where
-      PE.refl → case q≡q′ of λ where
-        PE.refl → case r≡r′ of λ where
-          PE.refl → case reflConEq (wfEq ⊢Σ≡Σ′) of λ ⊢Γ≡Γ →
-                    case stabilityConv↑ (⊢Γ≡Γ ∙ ⊢Σ≡Σ′) C<>E of λ C<>E′ →
-                    case Σ-injectivity ⊢Σ≡Σ′ of λ (⊢F≡F′ , ⊢G≡G′ , _) →
-                    case stabilityConv↑Term (⊢Γ≡Γ ∙ ⊢F≡F′ ∙ ⊢G≡G′) u<>v of λ u<>v′ →
-                      yes (_ , prodrec-cong C<>E′ t~t′ u<>v′)
-    (no ¬u<>v) → no λ where
-      (_ , prodrec-cong x x₁ x₂) →
-        case syntacticEqTerm (soundness~↓ t~t′) of λ (_ , ⊢t , _) →
-        case syntacticEqTerm (soundness~↓ x₁)   of λ (_ , ⊢t₁ , _) →
-        case ne~↓ t~t′ of λ (_ , neT , _) →
-        case neTypeEq neT ⊢t₁ ⊢t of λ ⊢Σ″≡Σ′ →
-        case reflConEq (wfEq ⊢Σ″≡Σ′) of λ ⊢Γ≡Γ →
-        case Σ-injectivity (trans ⊢Σ″≡Σ′ (sym ⊢Σ≡Σ′)) of λ (⊢F″≡F , ⊢G″≡G , _) →
-          ¬u<>v (stabilityConv↑Term (⊢Γ≡Γ ∙ ⊢F″≡F ∙ ⊢G″≡G) x₂)
-dec~↑-prodrec (no ¬C<>E) u<?>v t~t′ ⊢Σ≡Σ′ _ _ _ =  no λ where
-      (_ , prodrec-cong x x₁ x₂) →
-        case syntacticEqTerm (soundness~↓ t~t′) of λ (_ , ⊢t , _) →
-        case syntacticEqTerm (soundness~↓ x₁)   of λ (_ , ⊢t₁ , _) →
-        case ne~↓ t~t′ of λ (_ , neT , _) →
-        case neTypeEq neT ⊢t₁ ⊢t of λ ⊢Σ″≡Σ′ →
-        case reflConEq (wfEq ⊢Σ″≡Σ′) of λ ⊢Γ≡Γ →
-          ¬C<>E (stabilityConv↑ (⊢Γ≡Γ ∙ trans ⊢Σ″≡Σ′ (sym ⊢Σ≡Σ′)) x)
+  -- A lemma used below.
 
-dec~↑-var : ∀ {k k′ A}
-          → (x : Fin _)
-          → Γ ⊢ k ~ k′ ↑ A
-          → Dec (∃ λ B → Γ ⊢ var x ~ k ↑ B)
-dec~↑-var x (var-refl {x = y} x₁ x₂) with x ≟ⱽ y
-... | yes PE.refl = yes (_ , var-refl x₁ PE.refl)
-... | no ¬p = no λ { (_ , var-refl x x₁) → ¬p x₁}
-dec~↑-var x (app-cong _ _) = no λ { (_ , ())}
-dec~↑-var x (fst-cong _) = no λ { (_ , ())}
-dec~↑-var x (snd-cong _) = no λ { (_ , ())}
-dec~↑-var x (natrec-cong _ _ _ _) = no λ { (_ , ())}
-dec~↑-var x (prodrec-cong _ _ _) = no λ { (_ , ())}
-dec~↑-var x (emptyrec-cong _ _) = no λ { (_ , ())}
-dec~↑-var x (unitrec-cong _ _ _ _) = no λ { (_ , ())}
-dec~↑-var _ (J-cong _ _ _ _ _ _ _) = no λ { (_ , ()) }
-dec~↑-var _ (K-cong _ _ _ _ _ _ _) = no λ { (_ , ()) }
-dec~↑-var _ ([]-cong-cong _ _ _ _ _ _) = no λ { (_ , ()) }
+  [conv↓]∷Σʷ→~↓ :
+    Γ ⊢ t ~ t′ ↓ Σʷ p′ , q′ ▷ A′ ▹ B′ →
+    Γ ⊢ t [conv↓] u ∷ Σʷ p , q ▷ A ▹ B →
+    ∃ λ C → Γ ⊢ t ~ u ↓ C
+  [conv↓]∷Σʷ→~↓ ([~] _ _ t~t′) t≡u =
+    case inv-[conv↓]∷-Σʷ t≡u of λ where
+      (inj₁ (_ , _ , _ , _ , t~u))         → _ , t~u
+      (inj₂ (_ , _ , _ , _ , PE.refl , _)) → ⊥-elim (inv-prod~ t~t′)
 
-dec~↑-app′ : ∀ {k l l′ a A F G}
-          → Γ ⊢ l ~ l′ ↑ A
-          → (∀ {l l′ B} → Γ ⊢ l ~ l′ ↓ B → Dec (∃ λ C → Γ ⊢ k ~ l ↓ C))
-          → (∀ {F′ u u′} → Γ ⊢ F ≡ F′ → Γ ⊢ u [conv↑] u′ ∷ F′
-                           → Dec (Γ ⊢ a [conv↑] u ∷ F))
-          → Γ ⊢ k ∷ Π p , q ▷ F ▹ G
-          → p PE.≡ p₁
-          → Dec (∃ λ C → Γ ⊢ k ∘⟨ p₁ ⟩ a ~ l ↑ C)
-dec~↑-app′ (app-cong x x₁) dec dec′ ⊢l₁ p≡p₁ with dec x
-... | no ¬p = no λ{ (_ , app-cong x x₁) → ¬p (_ , x)}
-dec~↑-app′ (app-cong x x₁) _ dec′ ⊢l₁ PE.refl | yes (C , k~l) =
-  let whnfA , neK , neL = ne~↓ k~l
-      ⊢A , ⊢k , ⊢l = syntacticEqTerm (soundness~↓ k~l)
-      _ , ⊢l₂ , _ = syntacticEqTerm (soundness~↓ x)
-      ΠFG≡A = neTypeEq neK ⊢l₁ ⊢k
-      ΠF′G′≡A = neTypeEq neL ⊢l₂ ⊢l
-  in
-  case injectivity (trans ΠFG≡A (sym ΠF′G′≡A)) of λ {
-    (F≡F′ , G≡G′ , PE.refl , _) →
-  case conv ⊢l₂ (trans ΠF′G′≡A (sym ΠFG≡A)) of λ {
-    ⊢l₂′ →
-  dec~↑-app ⊢l₁ ⊢l₂′ k~l PE.refl (dec′ F≡F′ x₁) }}
-dec~↑-app′ (var-refl x x₁) _ _ _ _ = no λ { (_ , ())}
-dec~↑-app′ (fst-cong x) _ _ _ _ = no λ { (_ , ())}
-dec~↑-app′ (snd-cong x) _ _ _ _ = no λ { (_ , ())}
-dec~↑-app′ (natrec-cong x x₁ x₂ x₃) _ _ _ _ = no λ { (_ , ())}
-dec~↑-app′ (prodrec-cong x x₁ x₂) _ _ _ _ = no λ { (_ , ())}
-dec~↑-app′ (emptyrec-cong x x₁) _ _ _ _ = no λ { (_ , ())}
-dec~↑-app′ (unitrec-cong _ _ _ _) _ _ _ _ = no λ { (_ , ())}
-dec~↑-app′ (J-cong _ _ _ _ _ _ _) _ _ _ _ = no λ { (_ , ()) }
-dec~↑-app′ (K-cong _ _ _ _ _ _ _) _ _ _ _ = no λ { (_ , ()) }
-dec~↑-app′ ([]-cong-cong _ _ _ _ _ _) _ _ _ _ = no λ { (_ , ()) }
+private opaque
 
-dec~↑-fst :
-  Γ ⊢ k ~ k′ ↓ Σˢ p , q ▷ F ▹ G →
-  (∀ {l l′ B} → Γ ⊢ l ~ l′ ↓ B → Dec (∃ λ A → Γ ⊢ k ~ l ↓ A)) →
-  Γ ⊢ l ~ l′ ↑ B →
-  Dec (∃ λ A → Γ ⊢ fst p k ~ l ↑ A)
-dec~↑-fst k~k dec (fst-cong l~l) with dec l~l
-... | yes (A , k~l) =
-  case ne~↓ k~l of λ (whnfA , neK , neL) →
-  case syntacticEqTerm (soundness~↓ k~l) of λ (⊢A , ⊢k , ⊢l) →
-  case syntacticEqTerm (soundness~↓ k~k) of λ (_ , ⊢k₁ , _) →
-  case syntacticEqTerm (soundness~↓ l~l) of λ (_ , ⊢l₁ , _) →
-  case neTypeEq neK ⊢k₁ ⊢k of λ ΣFG≡A →
-  case neTypeEq neL ⊢l₁ ⊢l of λ ΣF′G′≡A →
-  case Σ≡A ΣFG≡A whnfA of λ where
-    (F , _ , PE.refl) →
-      case Σ-injectivity ΣF′G′≡A of λ where
-        (_ , _ , PE.refl , _ , _) →
-          yes (F , fst-cong k~l)
-... | no ¬p = no (λ { (_ , fst-cong x) → ¬p (_ , x) })
-dec~↑-fst _ _ (var-refl _ _)             = no λ { (_ , ()) }
-dec~↑-fst _ _ (app-cong _ _)             = no λ { (_ , ()) }
-dec~↑-fst _ _ (snd-cong _)               = no λ { (_ , ()) }
-dec~↑-fst _ _ (natrec-cong _ _ _ _)      = no λ { (_ , ()) }
-dec~↑-fst _ _ (prodrec-cong _ _ _)       = no λ { (_ , ()) }
-dec~↑-fst _ _ (emptyrec-cong _ _)        = no λ { (_ , ()) }
-dec~↑-fst _ _ (unitrec-cong _ _ _ _)     = no λ { (_ , ()) }
-dec~↑-fst _ _ (J-cong _ _ _ _ _ _ _)     = no λ { (_ , ()) }
-dec~↑-fst _ _ (K-cong _ _ _ _ _ _ _)     = no λ { (_ , ()) }
-dec~↑-fst _ _ ([]-cong-cong _ _ _ _ _ _) = no λ { (_ , ()) }
+  -- A lemma used below.
 
-dec~↑-snd :
-  Γ ⊢ k ~ k′ ↓ Σˢ p , q ▷ F ▹ G →
-  (∀ {l l′ B} → Γ ⊢ l ~ l′ ↓ B → Dec (∃ λ A → Γ ⊢ k ~ l ↓ A)) →
-  Γ ⊢ l ~ l′ ↑ B →
-  Dec (∃ λ A → Γ ⊢ snd p k ~ l ↑ A)
-dec~↑-snd {k = k} k~k dec (snd-cong l~l) with dec l~l
-... | yes (A , k~l) =
-  case ne~↓ k~l of λ (whnfA , neK , neL) →
-  case syntacticEqTerm (soundness~↓ k~l) of λ (⊢A , ⊢k , ⊢l) →
-  case syntacticEqTerm (soundness~↓ k~k) of λ (_ , ⊢k₁ , _) →
-  case syntacticEqTerm (soundness~↓ l~l) of λ (_ , ⊢l₁ , _) →
-  case neTypeEq neK ⊢k₁ ⊢k of λ ΣFG≡A →
-  case neTypeEq neL ⊢l₁ ⊢l of λ ΣF′G′≡A →
-  case Σ≡A ΣFG≡A whnfA of λ where
-    (_ , G , PE.refl) →
-      case Σ-injectivity ΣF′G′≡A of λ where
-        (_ , _ , PE.refl , _ , _) →
-          yes (G [ fst _ k ]₀ , snd-cong k~l)
-... | no ¬p = no (λ { (_ , snd-cong x₂) → ¬p (_ , x₂) })
-dec~↑-snd _ _ (var-refl _ _)             = no λ { (_ , ()) }
-dec~↑-snd _ _ (app-cong _ _)             = no λ { (_ , ()) }
-dec~↑-snd _ _ (fst-cong _)               = no λ { (_ , ()) }
-dec~↑-snd _ _ (natrec-cong _ _ _ _)      = no λ { (_ , ()) }
-dec~↑-snd _ _ (prodrec-cong _ _ _)       = no λ { (_ , ()) }
-dec~↑-snd _ _ (emptyrec-cong _ _)        = no λ { (_ , ()) }
-dec~↑-snd _ _ (unitrec-cong _ _ _ _)     = no λ { (_ , ()) }
-dec~↑-snd _ _ (J-cong _ _ _ _ _ _ _)     = no λ { (_ , ()) }
-dec~↑-snd _ _ (K-cong _ _ _ _ _ _ _)     = no λ { (_ , ()) }
-dec~↑-snd _ _ ([]-cong-cong _ _ _ _ _ _) = no λ { (_ , ()) }
+  ≡starʷ→~↓Unitʷ→Unitʷ-η :
+    Γ ⊢ t ~ u ↓ Unitʷ →
+    Γ ⊢ t [conv↓] starʷ ∷ Unitʷ →
+    Unitʷ-η
+  ≡starʷ→~↓Unitʷ→Unitʷ-η ([~] _ _ t~u) t≡star =
+    case inv-[conv↓]∷-Unitʷ t≡star of λ where
+      (inj₂ (η , _))                       → η
+      (inj₁ (no-η , inj₁ ([~] _ _ ~star))) → ⊥-elim (inv-~star ~star)
+      (inj₁ (no-η , inj₂ (PE.refl , _)))   → ⊥-elim (inv-star~ t~u)
 
-dec~↑-natrec : ∀ {l l′ A C z s n}
-             → Γ ⊢ l ~ l′ ↑ A
-             → ⊢ Γ
-             → (∀ {C′ C″} → Γ ∙ ℕ ⊢ C′ [conv↑] C″ → Dec (Γ ∙ ℕ ⊢ C [conv↑] C′))
-             → (∀ {t t′ C′} → Γ ⊢ C [ zero ]₀ ≡ C′ → Γ ⊢ t [conv↑] t′ ∷ C′ → Dec (Γ ⊢ z [conv↑] t ∷ C [ zero ]₀))
-             → (∀ {t t′ C′} → Γ ∙ ℕ ∙ C ⊢ C [ suc (var x1) ]↑² ≡ C′ → Γ ∙ ℕ ∙ C ⊢ t [conv↑] t′ ∷ C′
-                            → Dec (Γ ∙ ℕ ∙ C ⊢ s [conv↑] t ∷ C [ suc (var x1) ]↑²))
-             → (∀ {t t′ C′} → Γ ⊢ t ~ t′ ↓ C′ → Dec (∃ λ B → Γ ⊢ n ~ t ↓ B))
-             → Dec (∃ λ B → Γ ⊢ natrec p q r C z s n ~ l ↑ B)
-dec~↑-natrec {p = p} {q = q} {r = r}
-  (natrec-cong {p = p′} {q = q′} {r = r′} x x₁ x₂ x₃)
-  ⊢Γ decC decZ decS decN
-  with decC x | decN x₃ | p ≟ p′ | q ≟ q′ | r ≟ r′
-... | _ | _ | _ | _ | no r≢r′ = no λ {(_ , natrec-cong _ _ _ _) → r≢r′ PE.refl}
-... | _ | _ | _ | no q≢q′ | _ = no λ {(_ , natrec-cong _ _ _ _) → q≢q′ PE.refl}
-... | _ | _ | no p≢p′ | _ | _ = no λ {(_ , natrec-cong _ _ _ _) → p≢p′ PE.refl}
-... | _ | no ¬P | _ | _ | _ = no λ {(_ , natrec-cong _ _ _ x) → ¬P (_ , x)}
-... | no ¬P | _ | _ | _ | _ = no λ {(_ , natrec-cong x _ _ _) → ¬P x}
-... | yes C<>C′ | yes (B , n~n′) | yes _ | yes _ | yes _
-  with decZ (substTypeEq (soundnessConv↑ C<>C′) (refl (zeroⱼ ⊢Γ))) x₁
-     | decS (sucCong (soundnessConv↑ C<>C′))
-            (stabilityConv↑Term ((reflConEq (⊢Γ ∙ ℕⱼ ⊢Γ)) ∙ (sym (soundnessConv↑ C<>C′))) x₂)
-... | _ | no ¬P = no λ {(_ , natrec-cong _ _ x _) → ¬P x}
-... | no ¬P | _ = no λ {(_ , natrec-cong _ x _ _) → ¬P x}
-dec~↑-natrec (natrec-cong _ _ _ x₃) _ _ _ _ _
-  | yes C<>C′ | yes (B , n~n′) | yes PE.refl | yes PE.refl | yes PE.refl
-  | yes z<>z′ | yes s<>s′ =
-  let whnfA , neN , neN′ = ne~↓ n~n′
-      ⊢A , ⊢n , ⊢n′ = syntacticEqTerm (soundness~↓ n~n′)
-      _ , ⊢n′∷ℕ , _ = syntacticEqTerm (soundness~↓ x₃)
-      ⊢ℕ≡A = neTypeEq neN′ ⊢n′∷ℕ ⊢n′
-      A≡ℕ = ℕ≡A ⊢ℕ≡A whnfA
-      n~n″ = PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) A≡ℕ n~n′
-  in  yes (_ , natrec-cong C<>C′ z<>z′ s<>s′ n~n″)
-dec~↑-natrec (var-refl _ _) _ _ _ _ _             = no λ {(_ , ())}
-dec~↑-natrec (app-cong _ _) _ _ _ _ _             = no λ {(_ , ())}
-dec~↑-natrec (fst-cong _) _ _ _ _ _               = no λ {(_ , ())}
-dec~↑-natrec (snd-cong _) _ _ _ _ _               = no λ {(_ , ())}
-dec~↑-natrec (prodrec-cong _ _ _) _ _ _ _ _       = no λ {(_ , ())}
-dec~↑-natrec (emptyrec-cong _ _) _ _ _ _ _        = no λ {(_ , ())}
-dec~↑-natrec (unitrec-cong _ _ _ _) _ _ _ _ _     = no λ {(_ , ())}
-dec~↑-natrec (J-cong _ _ _ _ _ _ _) _ _ _ _ _     = no λ {(_ , ())}
-dec~↑-natrec (K-cong _ _ _ _ _ _ _) _ _ _ _ _     = no λ {(_ , ())}
-dec~↑-natrec ([]-cong-cong _ _ _ _ _ _) _ _ _ _ _ = no λ {(_ , ())}
+private opaque
+
+  -- A lemma used below.
+
+  dec~↑-app-cong :
+    Γ ⊢ t₁ ∷ Π p₁ , q₁ ▷ A₁ ▹ B₁ →
+    Γ ⊢ u₁ ∷ Π p₂ , q₂ ▷ A₂ ▹ B₂ →
+    Dec (∃ λ C → Γ ⊢ t₁ ~ u₁ ↓ C) →
+    (Γ ⊢ A₁ ≡ A₂ → Dec (Γ ⊢ t₂ [conv↑] u₂ ∷ A₁)) →
+    Dec (∃ λ C → Γ ⊢ t₁ ∘⟨ p₁ ⟩ t₂ ~ u₁ ∘⟨ p₂ ⟩ u₂ ↑ C)
+  dec~↑-app-cong
+    {p₁} {q₁} {A₁} {B₁} {p₂} {q₂} {A₂} {B₂}
+    ⊢t₁ ⊢u₁ (yes (C , t₁~u₁)) dec₂ =
+    let C-whnf , t₁-ne , u₁-ne = ne~↓ t₁~u₁
+        _ , ⊢t₁′ , ⊢u₁′        = syntacticEqTerm (soundness~↓ t₁~u₁)
+        Π≡C                    = neTypeEq t₁-ne ⊢t₁ ⊢t₁′
+        A₁≡A₂ , _ , p₁≡p₂ , _  =
+          ΠΣ-injectivity
+            (Π p₁ , q₁ ▷ A₁ ▹ B₁  ≡⟨ Π≡C ⟩⊢
+             C                    ≡˘⟨ neTypeEq u₁-ne ⊢u₁ ⊢u₁′ ⟩⊢∎
+             Π p₂ , q₂ ▷ A₂ ▹ B₂  ∎)
+    in
+    case dec₂ A₁≡A₂ of λ where
+      (yes t₂≡u₂) →
+        yes $
+        let _ , _ , C≡Π = ΠΣ≡Whnf Π≡C C-whnf in
+          _
+        , PE.subst (flip (_⊢_~_↑_ _ _) _)
+            (PE.cong (_ ∘⟨_⟩ _) p₁≡p₂)
+            (app-cong (PE.subst (_⊢_~_↓_ _ _ _) C≡Π t₁~u₁)
+               (convConvTerm t₂≡u₂ $
+                ΠΣ-injectivity (PE.subst (_⊢_≡_ _ _) C≡Π Π≡C)
+                  .proj₁))
+      (no t₂≢u₂) →
+        no λ (_ , t~u) →
+        let _ , _ , _ , _ , _ , _ , u≡∘ , t₁~ , t₂≡ = inv-∘~ t~u
+            _ , _ , ≡u₂                             =
+              ∘-PE-injectivity (PE.sym u≡∘)
+            Π≡Π = neTypeEq t₁-ne ⊢t₁ (~↓→∷ t₁~)
+        in
+        t₂≢u₂ $
+        convConvTerm (PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡u₂ t₂≡)
+          (sym (ΠΣ-injectivity Π≡Π .proj₁))
+  dec~↑-app-cong _ _ (no ¬t₁~u₁) _ =
+    no λ (_ , t~u) →
+    let _ , _ , _ , _ , _ , _ , u≡∘ , t₁~ , _ = inv-∘~ t~u
+        _ , ≡u₁ , _                           =
+          ∘-PE-injectivity (PE.sym u≡∘)
+    in
+    ¬t₁~u₁ (_ , PE.subst (flip (_⊢_~_↓_ _ _) _) ≡u₁ t₁~)
+
+private opaque
+
+  -- A lemma used below.
+
+  dec~↑-fst-cong :
+    Γ ⊢ t ∷ Σˢ p , q ▷ A ▹ B →
+    Dec (p PE.≡ p′ × ∃ λ C → Γ ⊢ t ~ u ↓ C) →
+    Dec (∃ λ C → Γ ⊢ fst p t ~ fst p′ u ↑ C)
+  dec~↑-fst-cong ⊢t (yes (PE.refl , _ , t~u)) =
+    yes $
+    let _ , _ , C≡Σ = uncurry ΠΣ≡Whnf (~↓→∷→Whnf×≡ t~u ⊢t) in
+    _ , fst-cong (PE.subst (_⊢_~_↓_ _ _ _) C≡Σ t~u)
+  dec~↑-fst-cong _ (no not-both-equal) =
+    no λ (_ , fst-t~fst-u) →
+    case inv-fst~ fst-t~fst-u of λ {
+      (_ , _ , _ , PE.refl , t~) →
+    not-both-equal (PE.refl , _ , t~) }
+
+private opaque
+
+  -- A lemma used below.
+
+  dec~↑-snd-cong :
+    Γ ⊢ t ∷ Σˢ p , q ▷ A ▹ B →
+    Dec (p PE.≡ p′ × ∃ λ C → Γ ⊢ t ~ u ↓ C) →
+    Dec (∃ λ C → Γ ⊢ snd p t ~ snd p′ u ↑ C)
+  dec~↑-snd-cong ⊢t (yes (PE.refl , _ , t~u)) =
+    yes $
+    let _ , _ , C≡Σ = uncurry ΠΣ≡Whnf (~↓→∷→Whnf×≡ t~u ⊢t) in
+    _ , snd-cong (PE.subst (_⊢_~_↓_ _ _ _) C≡Σ t~u)
+  dec~↑-snd-cong _ (no not-both-equal) =
+    no λ (_ , snd-t~snd-u) →
+    case inv-snd~ snd-t~snd-u of λ {
+      (_ , _ , _ , _ , _ , PE.refl , t~) →
+    not-both-equal (PE.refl , _ , t~) }
+
+private opaque
+
+  -- A lemma used below.
+
+  dec~↑-prodrec-cong :
+    Γ ⊢ t₁ ∷ Σʷ p₁ , q₁ ▷ A₁ ▹ B₁ →
+    Γ ⊢ t₂ ∷ Σʷ p₂ , q₂ ▷ A₂ ▹ B₂ →
+    Dec
+      (r₁ PE.≡ r₂ × q′₁ PE.≡ q′₂ ×
+       ∃ λ D → Γ ⊢ t₁ ~ t₂ ↓ D) →
+    (⊢ Γ ∙ Σʷ p₁ , q₁ ▷ A₁ ▹ B₁ ≡ Γ ∙ Σʷ p₂ , q₂ ▷ A₂ ▹ B₂ →
+     Dec (Γ ∙ Σʷ p₁ , q₁ ▷ A₁ ▹ B₁ ⊢ C₁ [conv↑] C₂)) →
+    (⊢ Γ ∙ A₂ ∙ B₂ ≡ Γ ∙ A₁ ∙ B₁ →
+     Γ ∙ A₂ ∙ B₂ ⊢ C₂ [ prodʷ p₂ (var x1) (var x0) ]↑² ≡
+       C₁ [ prodʷ p₁ (var x1) (var x0) ]↑² →
+     Dec
+       (Γ ∙ A₁ ∙ B₁ ⊢ u₁ [conv↑] u₂ ∷
+          C₁ [ prodʷ p₁ (var x1) (var x0) ]↑²)) →
+    Dec
+      (∃ λ D →
+       Γ ⊢ prodrec r₁ p₁ q′₁ C₁ t₁ u₁ ~ prodrec r₂ p₂ q′₂ C₂ t₂ u₂ ↑ D)
+  dec~↑-prodrec-cong
+    {p₁} {q₁} {A₁} {B₁} {p₂} {q₂} {A₂} {B₂}
+    ⊢t₁ ⊢t₂ (yes (PE.refl , PE.refl , D , t₁~t₂)) dec₁ dec₃ =
+    let _ , _ , ok             = inversion-ΠΣ (syntacticTerm ⊢t₁)
+        D-whnf , t₁-ne , t₂-ne = ne~↓ t₁~t₂
+        _ , ⊢t₁′ , ⊢t₂′        = syntacticEqTerm (soundness~↓ t₁~t₂)
+        Σ₁≡D                   = neTypeEq t₁-ne ⊢t₁ ⊢t₁′
+        Σ₁≡Σ₂                  =
+          Σʷ p₁ , q₁ ▷ A₁ ▹ B₁  ≡⟨ Σ₁≡D ⟩⊢
+          D                     ≡⟨ neTypeEq t₂-ne ⊢t₂′ ⊢t₂ ⟩⊢∎
+          Σʷ p₂ , q₂ ▷ A₂ ▹ B₂  ∎
+        A₁≡A₂ , B₁≡B₂ , p₁≡p₂ , _ = ΠΣ-injectivity Σ₁≡Σ₂
+        Γ≡Γ                       = reflConEq (wfTerm ⊢t₁)
+        ΓA₁B₁≡ΓA₂B₂               = Γ≡Γ ∙ A₁≡A₂ ⊢_≡_.∙ B₁≡B₂
+    in
+    case p₁≡p₂ of λ {
+      PE.refl →
+    case (dec₁ (Γ≡Γ ∙ Σ₁≡Σ₂)
+            ×-dec′ λ C₁≡C₂ →
+          dec₃
+            (symConEq ΓA₁B₁≡ΓA₂B₂)
+             (_⊢_≡_.sym $
+              stabilityEq ΓA₁B₁≡ΓA₂B₂ $
+              subst↑²TypeEq-prod (soundnessConv↑ C₁≡C₂) ok)) of λ where
+      (yes (C₁≡C₂ , u₁≡u₂)) →
+        yes $
+        case ΠΣ≡Whnf Σ₁≡D D-whnf of λ {
+          (_ , _ , PE.refl) →
+        let A₁≡ , B₁≡ , _ = ΠΣ-injectivity Σ₁≡D in
+          _
+        , prodrec-cong (stabilityConv↑ (Γ≡Γ ∙ Σ₁≡D) C₁≡C₂) t₁~t₂
+            (stabilityConv↑Term (Γ≡Γ ∙ A₁≡ ∙ B₁≡) u₁≡u₂) }
+      (no not-both-equal) →
+        no λ (_ , pr~pr) →
+        let _ , _ , _ , _ , _ , _ , _ , pr≡pr , C₁≡ , t₁~ , u₁≡ =
+              inv-prodrec~ pr~pr
+            ≡A₁ , ≡B₁ , _ =
+              ΠΣ-injectivity (neTypeEq t₁-ne (~↓→∷ t₁~) ⊢t₁)
+            _ , _ , _ , ≡C₂ , _ , ≡u₂ =
+              prodrec-PE-injectivity (PE.sym pr≡pr)
+        in
+        not-both-equal
+          ( stabilityConv↑ (Γ≡Γ ∙ neTypeEq t₁-ne (~↓→∷ t₁~) ⊢t₁)
+              (PE.subst (_⊢_[conv↑]_ _ _) ≡C₂ C₁≡)
+          , stabilityConv↑Term (Γ≡Γ ∙ ≡A₁ ∙ ≡B₁)
+              (PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡u₂ u₁≡)
+          ) }
+  dec~↑-prodrec-cong _ _ (no not-all-equal) _ _ =
+    no λ (_ , pr~pr) →
+    let _ , _ , _ , _ , _ , _ , _ , pr≡pr , _ , t₁~ , _ =
+          inv-prodrec~ pr~pr
+        r₁≡r₂ , _ , q′₁≡q′₂ , _ , ≡t₂ , _ =
+          prodrec-PE-injectivity (PE.sym pr≡pr)
+    in
+    not-all-equal
+      ( r₁≡r₂
+      , q′₁≡q′₂
+      , _ , PE.subst (flip (_⊢_~_↓_ _ _) _) ≡t₂ t₁~
+      )
+
+private opaque
+
+  -- A lemma used below.
+
+  dec~↑-emptyrec-cong :
+    Γ ⊢ t₁ ∷ Empty →
+    Dec
+      (p₁ PE.≡ p₂ ×
+       Γ ⊢ A₁ [conv↑] A₂ ×
+       ∃ λ B → Γ ⊢ t₁ ~ t₂ ↓ B) →
+    Dec (∃ λ B → Γ ⊢ emptyrec p₁ A₁ t₁ ~ emptyrec p₂ A₂ t₂ ↑ B)
+  dec~↑-emptyrec-cong ⊢t₁ (yes (PE.refl , A₁≡A₂ , _ , t₁~t₂)) =
+    yes $
+    case uncurry Empty≡A (~↓→∷→Whnf×≡ t₁~t₂ ⊢t₁) of λ {
+      PE.refl →
+    _ , emptyrec-cong A₁≡A₂ t₁~t₂ }
+  dec~↑-emptyrec-cong _ (no not-all-equal) =
+    no λ (_ , er~er) →
+    let _ , _ , _ , er≡er , A₁≡ , t₁~ = inv-emptyrec~ er~er
+        p₁≡p₂ , ≡A₂ , ≡t₂             =
+          emptyrec-PE-injectivity (PE.sym er≡er)
+    in
+    not-all-equal
+      ( p₁≡p₂
+      , PE.subst (_⊢_[conv↑]_ _ _) ≡A₂ A₁≡
+      , _ , PE.subst (flip (_⊢_~_↓_ _ _) _) ≡t₂ t₁~
+      )
+
+private opaque
+
+  -- A lemma used below.
+
+  dec~↑-unitrec-cong :
+    ¬ Unitʷ-η →
+    Γ ⊢ t₁ ∷ Unitʷ →
+    Dec
+      (p₁ PE.≡ p₂ × q₁ PE.≡ q₂ ×
+       (Γ ∙ Unitʷ ⊢ A₁ [conv↑] A₂) ×
+       ∃ λ B → Γ ⊢ t₁ ~ t₂ ↓ B) →
+    (Γ ⊢ A₁ [ starʷ ]₀ ≡ A₂ [ starʷ ]₀ →
+     Dec (Γ ⊢ u₁ [conv↑] u₂ ∷ A₁ [ starʷ ]₀)) →
+    Dec
+      (∃ λ B → Γ ⊢ unitrec p₁ q₁ A₁ t₁ u₁ ~ unitrec p₂ q₂ A₂ t₂ u₂ ↑ B)
+  dec~↑-unitrec-cong
+    no-η ⊢t₁ (yes (PE.refl , PE.refl , A₁≡A₂ , _ , t₁~t₂)) dec =
+    case dec $
+         substTypeEq (soundnessConv↑ A₁≡A₂) $
+         _⊢_≡_∷_.refl $
+         starⱼ (wfTerm ⊢t₁) (⊢∷Unit→Unit-allowed ⊢t₁) of λ where
+      (yes u₁≡u₂) →
+        yes $
+        let B≡Unit = uncurry Unit≡A (~↓→∷→Whnf×≡ t₁~t₂ ⊢t₁) in
+          _
+        , unitrec-cong A₁≡A₂ (PE.subst (_⊢_~_↓_ _ _ _) B≡Unit t₁~t₂)
+            u₁≡u₂ no-η
+      (no u₁≢u₂) →
+        no λ (_ , ur~ur) →
+        let _ , _ , _ , _ , ur≡ur , _ , _ , u₁≡ , _ = inv-unitrec~ ur~ur
+            _ , _ , _ , _ , ≡u₂                     =
+              unitrec-PE-injectivity (PE.sym ur≡ur)
+        in
+        u₁≢u₂ (PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡u₂ u₁≡)
+  dec~↑-unitrec-cong _ _ (no not-all-equal) _ =
+    no λ (_ , ur~ur) →
+    let _ , _ , _ , _ , ur≡ur , A₁≡ , t₁~ , _ = inv-unitrec~ ur~ur
+        p₁≡p₂ , q₁≡q₂ , ≡A₂ , ≡t₂ , _         =
+          unitrec-PE-injectivity (PE.sym ur≡ur)
+    in
+    not-all-equal
+      ( p₁≡p₂
+      , q₁≡q₂
+      , PE.subst (_⊢_[conv↑]_ _ _) ≡A₂ A₁≡
+      , _ , PE.subst (flip (_⊢_~_↓_ _ _) _) ≡t₂ t₁~
+      )
+
+private opaque
+
+  -- A lemma used below.
+
+  dec~↑-natrec-cong :
+    Γ ⊢ v₁ ∷ ℕ →
+    Dec
+      (p₁ PE.≡ p₂ × q₁ PE.≡ q₂ × r₁ PE.≡ r₂ ×
+       Γ ∙ ℕ ⊢ A₁ [conv↑] A₂ ×
+       ∃ λ B → Γ ⊢ v₁ ~ v₂ ↓ B) →
+    (Γ ⊢ A₁ [ zero ]₀ ≡ A₂ [ zero ]₀ →
+     Dec (Γ ⊢ t₁ [conv↑] t₂ ∷ A₁ [ zero ]₀)) →
+    (⊢ Γ ∙ ℕ ∙ A₂ ≡ Γ ∙ ℕ ∙ A₁ →
+     Γ ∙ ℕ ∙ A₂ ⊢ A₂ [ suc (var x1) ]↑² ≡ A₁ [ suc (var x1) ]↑² →
+     Dec (Γ ∙ ℕ ∙ A₁ ⊢ u₁ [conv↑] u₂ ∷ A₁ [ suc (var x1) ]↑²)) →
+    Dec
+      (∃ λ B →
+       Γ ⊢ natrec p₁ q₁ r₁ A₁ t₁ u₁ v₁ ~
+         natrec p₂ q₂ r₂ A₂ t₂ u₂ v₂ ↑ B)
+  dec~↑-natrec-cong
+    ⊢v₁ (yes (PE.refl , PE.refl , PE.refl , A₁≡A₂ , _ , v₁~v₂)) dec₁
+    dec₂ =
+    case
+      (let A₁≡A₂     = soundnessConv↑ A₁≡A₂
+           ⊢Γ        = wfTerm ⊢v₁
+           ΓℕA₁≡ΓℕA₂ = reflConEq (⊢Γ ∙[ ℕⱼ ]) ∙ sym A₁≡A₂
+       in
+       dec₁ (substTypeEq A₁≡A₂ (refl (zeroⱼ ⊢Γ)))
+         ×-dec
+       dec₂ ΓℕA₁≡ΓℕA₂
+         (stabilityEq (symConEq ΓℕA₁≡ΓℕA₂) $ sym $ sucCong A₁≡A₂))
+      of λ where
+      (yes (t₁≡t₂ , u₁≡u₂)) →
+        yes $
+        let B≡ℕ = uncurry ℕ≡A (~↓→∷→Whnf×≡ v₁~v₂ ⊢v₁) in
+          _
+        , natrec-cong A₁≡A₂ t₁≡t₂ u₁≡u₂
+            (PE.subst (_⊢_~_↓_ _ _ _) B≡ℕ v₁~v₂)
+      (no not-both-equal) →
+        no λ (_ , nr~nr) →
+        let _ , _ , _ , _ , _ , nr≡nr , _ , t₁≡ , u₁≡ , _ =
+              inv-natrec~ nr~nr
+            _ , _ , _ , _ , ≡t₂ , ≡u₂ , _ =
+              natrec-PE-injectivity (PE.sym nr≡nr)
+        in
+        not-both-equal
+          ( PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡t₂ t₁≡
+          , PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡u₂ u₁≡
+          )
+  dec~↑-natrec-cong _ (no not-all-equal) _ _ =
+    no λ (_ , nr~nr) →
+    let _ , _ , _ , _ , _ , nr≡nr , A₁≡ , _ , _ , v₁~ =
+          inv-natrec~ nr~nr
+        p₁≡p₂ , q₁≡q₂ , r₁≡r₂ , ≡A₂ , _ , _ , ≡v₂ =
+          natrec-PE-injectivity (PE.sym nr≡nr)
+    in
+    not-all-equal
+      ( p₁≡p₂
+      , q₁≡q₂
+      , r₁≡r₂
+      , PE.subst (_⊢_[conv↑]_ _ _) ≡A₂ A₁≡
+      , _ , PE.subst (flip (_⊢_~_↓_ _ _) _) ≡v₂ v₁~
+      )
+
+private opaque
+
+  -- A lemma used below.
+
+  dec~↑-J-cong :
+    Γ ⊢ w₁ ∷ Id A₁ t₁ v₁ →
+    Dec
+      (p₁ PE.≡ p₂ × q₁ PE.≡ q₂ ×
+       Γ ⊢ A₁ [conv↑] A₂ ×
+       ∃ λ C → Γ ⊢ w₁ ~ w₂ ↓ C) →
+    (Γ ⊢ A₁ ≡ A₂ → Dec (Γ ⊢ t₁ [conv↑] t₂ ∷ A₁)) →
+    (⊢ Γ ∙ A₁ ∙ Id (wk1 A₁) (wk1 t₁) (var x0) ≡
+       Γ ∙ A₂ ∙ Id (wk1 A₂) (wk1 t₂) (var x0) →
+     Dec (Γ ∙ A₁ ∙ Id (wk1 A₁) (wk1 t₁) (var x0) ⊢ B₁ [conv↑] B₂)) →
+    (Γ ⊢ B₁ [ t₁ , rfl ]₁₀ ≡ B₂ [ t₂ , rfl ]₁₀ →
+     Dec (Γ ⊢ u₁ [conv↑] u₂ ∷ B₁ [ t₁ , rfl ]₁₀)) →
+    (Γ ⊢ A₁ ≡ A₂ → Dec (Γ ⊢ v₁ [conv↑] v₂ ∷ A₁)) →
+    Dec
+      (∃ λ C →
+       Γ ⊢ J p₁ q₁ A₁ t₁ B₁ u₁ v₁ w₁ ~ J p₂ q₂ A₂ t₂ B₂ u₂ v₂ w₂ ↑ C)
+  dec~↑-J-cong _ (no not-all-equal) _ _ _ _ =
+    no λ (_ , J~J) →
+    let _ , _ , _ , _ , _ , _ , _ , _ , J≡J , A₁≡ , _ , _ , _ , _ ,
+          w₁~ , _ = inv-J~ J~J
+        p₁≡p₂ , q₁≡q₂ , ≡A₂ , _ , _ , _ , _ , ≡w₂ =
+          J-PE-injectivity (PE.sym J≡J)
+    in
+    not-all-equal
+      ( p₁≡p₂
+      , q₁≡q₂
+      , PE.subst (_⊢_[conv↑]_ _ _) ≡A₂ A₁≡
+      , _ , PE.subst (flip (_⊢_~_↓_ _ _) _) ≡w₂ w₁~
+      )
+  dec~↑-J-cong
+    ⊢w₁ (yes (PE.refl , PE.refl , A₁≡A₂ , _ , w₁~w₂))
+    dec₁ dec₂ dec₃ dec₄ =
+    case
+      (let A₁≡A₂ = soundnessConv↑ A₁≡A₂ in
+       dec₁ A₁≡A₂
+         ×-dec′ λ t₁≡t₂ →
+       let t₁≡t₂ = soundnessConv↑Term t₁≡t₂ in
+       dec₂ (J-motive-context-cong′ A₁≡A₂ t₁≡t₂)
+         ×-dec′ λ B₁≡B₂ →
+       dec₃ (J-motive-rfl-cong (soundnessConv↑ B₁≡B₂) t₁≡t₂)
+         ×-dec
+       dec₄ A₁≡A₂)
+      of λ where
+      (yes (t₁≡t₂ , B₁≡B₂ , u₁≡u₂ , v₁≡v₂)) →
+        yes $
+          _
+        , J-cong A₁≡A₂ t₁≡t₂ B₁≡B₂ u₁≡u₂ v₁≡v₂ w₁~w₂
+            (neTypeEq (ne~↓ w₁~w₂ .proj₂ .proj₁) (~↓→∷ w₁~w₂) ⊢w₁)
+      (no not-all-equal) →
+        no λ (_ , J~J) →
+        let _ , _ , _ , _ , _ , _ , _ , _ , J≡J , _ , t₁≡ , B₁≡ , u₁≡ ,
+              v₁≡ , _ = inv-J~ J~J
+            _ , _ , _ , ≡t₂ , ≡B₂ , ≡u₂ , ≡v₂ , _ =
+              J-PE-injectivity (PE.sym J≡J)
+        in
+        not-all-equal
+          ( PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡t₂ t₁≡
+          , PE.subst (_⊢_[conv↑]_ _ _) ≡B₂ B₁≡
+          , PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡u₂ u₁≡
+          , PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡v₂ v₁≡
+          )
+
+private opaque
+
+  -- A lemma used below.
+
+  dec~↑-K-cong :
+    K-allowed →
+    Γ ⊢ v₁ ∷ Id A₁ t₁ t₁ →
+    Dec
+      (p₁ PE.≡ p₂ ×
+       Γ ⊢ A₁ [conv↑] A₂ ×
+       ∃ λ C → Γ ⊢ v₁ ~ v₂ ↓ C) →
+    (Γ ⊢ A₁ ≡ A₂ → Dec (Γ ⊢ t₁ [conv↑] t₂ ∷ A₁)) →
+    (⊢ Γ ∙ Id A₁ t₁ t₁ ≡ Γ ∙ Id A₂ t₂ t₂ →
+     Dec (Γ ∙ Id A₁ t₁ t₁ ⊢ B₁ [conv↑] B₂)) →
+    (Γ ⊢ B₁ [ rfl ]₀ ≡ B₂ [ rfl ]₀ →
+     Dec (Γ ⊢ u₁ [conv↑] u₂ ∷ B₁ [ rfl ]₀)) →
+    Dec (∃ λ C → Γ ⊢ K p₁ A₁ t₁ B₁ u₁ v₁ ~ K p₂ A₂ t₂ B₂ u₂ v₂ ↑ C)
+  dec~↑-K-cong _ _ (no not-all-equal) _ _ _ =
+    no λ (_ , K~K) →
+    let _ , _ , _ , _ , _ , _ , _ , K≡K , A₁≡ , _ , _ , _ , v₁~ , _ =
+          inv-K~ K~K
+        p₁≡p₂ , ≡A₂ , _ , _ , _ , ≡v₂ = K-PE-injectivity (PE.sym K≡K)
+    in
+    not-all-equal
+      ( p₁≡p₂
+      , PE.subst (_⊢_[conv↑]_ _ _) ≡A₂ A₁≡
+      , _ , PE.subst (flip (_⊢_~_↓_ _ _) _) ≡v₂ v₁~
+      )
+  dec~↑-K-cong
+    ok ⊢v₁ (yes (PE.refl , A₁≡A₂ , _ , v₁~v₂)) dec₁ dec₂ dec₃ =
+    case
+      (let A₁≡A₂ = soundnessConv↑ A₁≡A₂ in
+       dec₁ A₁≡A₂
+         ×-dec′ λ t₁≡t₂ →
+       let t₁≡t₂ = soundnessConv↑Term t₁≡t₂ in
+       dec₂ (K-motive-context-cong′ A₁≡A₂ t₁≡t₂)
+         ×-dec′ λ B₁≡B₂ →
+       dec₃ (K-motive-rfl-cong (soundnessConv↑ B₁≡B₂)))
+      of λ where
+      (yes (t₁≡t₂ , B₁≡B₂ , u₁≡u₂)) →
+        yes $
+          _
+        , K-cong A₁≡A₂ t₁≡t₂ B₁≡B₂ u₁≡u₂ v₁~v₂
+            (neTypeEq (ne~↓ v₁~v₂ .proj₂ .proj₁) (~↓→∷ v₁~v₂) ⊢v₁) ok
+      (no not-all-equal) →
+        no λ (_ , K~K) →
+        let _ , _ , _ , _ , _ , _ , _ , K≡K , _ , t₁≡ , B₁≡ , u₁≡ , _ =
+              inv-K~ K~K
+            _ , _ , ≡t₂ , ≡B₂ , ≡u₂ , _ = K-PE-injectivity (PE.sym K≡K)
+        in
+        not-all-equal
+          ( PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡t₂ t₁≡
+          , PE.subst (_⊢_[conv↑]_ _ _) ≡B₂ B₁≡
+          , PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡u₂ u₁≡
+          )
+
+private opaque
+
+  -- A lemma used below.
+
+  dec~↑-[]-cong-cong :
+    let open Erased s₁ in
+    []-cong-allowed s₁ →
+    Γ ⊢ v₁ ∷ Id A₁ t₁ u₁ →
+    Dec
+      (s₁ PE.≡ s₂ ×
+       Γ ⊢ A₁ [conv↑] A₂ ×
+       ∃ λ B → Γ ⊢ v₁ ~ v₂ ↓ B) →
+    (Γ ⊢ A₁ ≡ A₂ → Dec (Γ ⊢ t₁ [conv↑] t₂ ∷ A₁)) →
+    (Γ ⊢ A₁ ≡ A₂ → Dec (Γ ⊢ u₁ [conv↑] u₂ ∷ A₁)) →
+    Dec
+      (∃ λ B → Γ ⊢ []-cong s₁ A₁ t₁ u₁ v₁ ~ []-cong s₂ A₂ t₂ u₂ v₂ ↑ B)
+  dec~↑-[]-cong-cong
+    ok ⊢v₁ (yes (PE.refl , A₁≡A₂ , _ , v₁~v₂)) dec₁ dec₂ =
+    case
+       (let A₁≡A₂ = soundnessConv↑ A₁≡A₂ in
+        dec₁ A₁≡A₂ ×-dec dec₂ A₁≡A₂)
+      of λ where
+      (yes (t₁≡t₂ , u₁≡u₂)) →
+        yes $
+          _
+        , []-cong-cong A₁≡A₂ t₁≡t₂ u₁≡u₂ v₁~v₂
+            (neTypeEq (ne~↓ v₁~v₂ .proj₂ .proj₁) (~↓→∷ v₁~v₂) ⊢v₁) ok
+      (no not-both-equal) →
+        no λ (_ , bc~bc) →
+        let _ , _ , _ , _ , _ , _ , bc≡bc , _ , t₁≡ , u₁≡ , _ =
+              inv-[]-cong~ bc~bc
+            _ , _ , ≡t₂ , ≡u₂ , _ =
+              []-cong-PE-injectivity (PE.sym bc≡bc)
+        in
+        not-both-equal
+          ( PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡t₂ t₁≡
+          , PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡u₂ u₁≡
+          )
+  dec~↑-[]-cong-cong _ _ (no not-all-equal) _ _ =
+    no λ (_ , bc~bc) →
+    let _ , _ , _ , _ , _ , _ , bc≡bc , A₁≡ , _ , _ , v₁~ , _ =
+          inv-[]-cong~ bc~bc
+        s₁≡s₂ , ≡A₂ , _ , _ , ≡v₂ =
+          []-cong-PE-injectivity (PE.sym bc≡bc)
+    in
+    not-all-equal
+      ( s₁≡s₂
+      , PE.subst (_⊢_[conv↑]_ _ _) ≡A₂ A₁≡
+      , _ , PE.subst (flip (_⊢_~_↓_ _ _) _) ≡v₂ v₁~
+      )
+
+private opaque
+
+  -- A lemma used below.
+
+  decConv↓-ΠΣ :
+    Γ ⊢ A₁ →
+    ΠΣ-allowed b₁ p₁ q₁ →
+    Dec
+      (b₁ PE.≡ b₂ × p₁ PE.≡ p₂ × q₁ PE.≡ q₂ ×
+       Γ ⊢ A₁ [conv↑] A₂) →
+    (⊢ Γ ∙ A₁ ≡ Γ ∙ A₂ → Dec (Γ ∙ A₁ ⊢ B₁ [conv↑] B₂)) →
+    Dec
+      (Γ ⊢ ΠΣ⟨ b₁ ⟩ p₁ , q₁ ▷ A₁ ▹ B₁ [conv↓]
+         ΠΣ⟨ b₂ ⟩ p₂ , q₂ ▷ A₂ ▹ B₂)
+  decConv↓-ΠΣ ⊢A₁ ok (yes (PE.refl , PE.refl , PE.refl , A₁≡A₂)) dec =
+    case dec (reflConEq (wf ⊢A₁) ∙ soundnessConv↑ A₁≡A₂) of λ where
+      (yes B₁≡B₂) → yes (ΠΣ-cong ⊢A₁ A₁≡A₂ B₁≡B₂ ok)
+      (no B₁≢B₂)  →
+        no λ ΠΣ≡ΠΣ →
+        let _ , _ , ΠΣ≡ΠΣ , _ , B₁≡ = inv-[conv↓]-ΠΣ ΠΣ≡ΠΣ
+            _ , _ , _ , _ , ≡B₂     = ΠΣ-PE-injectivity (PE.sym ΠΣ≡ΠΣ)
+        in
+        B₁≢B₂ (PE.subst (_⊢_[conv↑]_ _ _) ≡B₂ B₁≡)
+  decConv↓-ΠΣ _ _ (no not-all-equal) _ =
+    no λ ΠΣ≡ΠΣ →
+    let _ , _ , ΠΣ≡ΠΣ , A₁≡ , _         = inv-[conv↓]-ΠΣ ΠΣ≡ΠΣ
+        b₁≡b₂ , p₁≡p₂ , q₁≡q₂ , ≡A₂ , _ =
+          ΠΣ-PE-injectivity (PE.sym ΠΣ≡ΠΣ)
+    in
+    not-all-equal
+      ( b₁≡b₂
+      , p₁≡p₂
+      , q₁≡q₂
+      , PE.subst (_⊢_[conv↑]_ _ _) ≡A₂ A₁≡
+      )
+
+private opaque
+
+  -- A lemma used below.
+
+  decConv↓-Id :
+    Dec (Γ ⊢ A₁ [conv↑] A₂) →
+    (Γ ⊢ A₂ ≡ A₁ → Dec (Γ ⊢ t₁ [conv↑] t₂ ∷ A₁)) →
+    (Γ ⊢ A₂ ≡ A₁ → Dec (Γ ⊢ u₁ [conv↑] u₂ ∷ A₁)) →
+    Dec (Γ ⊢ Id A₁ t₁ u₁ [conv↓] Id A₂ t₂ u₂)
+  decConv↓-Id (yes A₁≡A₂) dec₁ dec₂ =
+    let A₂≡A₁ = _⊢_≡_.sym (soundnessConv↑ A₁≡A₂) in
+    case dec₁ A₂≡A₁ ×-dec dec₂ A₂≡A₁ of λ where
+      (yes (t₁≡t₂ , u₁≡u₂)) → yes (Id-cong A₁≡A₂ t₁≡t₂ u₁≡u₂)
+      (no not-both-equal)   →
+        no λ Id≡Id →
+        let _ , _ , _ , Id≡Id , _ , t₁≡ , u₁≡ = inv-[conv↓]-Id Id≡Id
+            _ , ≡t₂ , ≡u₂                     =
+              Id-PE-injectivity (PE.sym Id≡Id)
+        in
+        not-both-equal
+          ( PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡t₂ t₁≡
+          , PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡u₂ u₁≡
+          )
+  decConv↓-Id (no A₁≢A₂) _ _ =
+    no λ Id≡Id →
+    let _ , _ , _ , Id≡Id , A₁≡ , _ = inv-[conv↓]-Id Id≡Id
+        ≡A₂ , _                     = Id-PE-injectivity (PE.sym Id≡Id)
+    in
+    A₁≢A₂ (PE.subst (_⊢_[conv↑]_ _ _) ≡A₂ A₁≡)
+
+------------------------------------------------------------------------
+-- Public definitions
 
 mutual
   -- Decidability of algorithmic equality of neutrals.
   dec~↑ : ∀ {k l R T k′ l′}
         → Γ ⊢ k ~ k′ ↑ R → Γ ⊢ l ~ l′ ↑ T
         → Dec (∃ λ A → Γ ⊢ k ~ l ↑ A)
-  dec~↑ (var-refl x x₁) y = dec~↑-var _ y
-  dec~↑ (app-cong x x₁) y =
-    dec~↑-app′ y (dec~↓ x) (λ F≡F′ → decConv↑TermConv F≡F′ x₁)
-      (proj₁ (proj₂ (syntacticEqTerm (soundness~↓ x)))) PE.refl
-  dec~↑ (fst-cong k~k) l~l =
-    dec~↑-fst k~k (dec~↓ k~k) l~l
-  dec~↑ (snd-cong k~k) l~l =
-    dec~↑-snd k~k (dec~↓ k~k) l~l
-  dec~↑ (natrec-cong x x₁ x₂ x₃) y =
-    dec~↑-natrec y (wfEqTerm (soundness~↑ y)) (decConv↑ x)
-                 (λ z → decConv↑TermConv z x₁)
-                 (λ z → decConv↑TermConv z x₂) (dec~↓ x₃)
-
-  dec~↑ (unitrec-cong {p = p} {q = q} x x₁ x₂ no-η)
-        (unitrec-cong {p = p′} {q = q′} x₃ x₄ x₅ _) =
-    case dec~↓ x₁ x₄ of λ where
-      (no ¬p) → no λ{ (_ , unitrec-cong x x₁ x₂ _) → ¬p (_ , x₁)}
-      (yes (A , k~k′)) → case (decConv↑ x x₃) of λ where
-        (no ¬p) → no λ{ (_ , unitrec-cong x x₁ x₂ _) → ¬p x}
-        (yes F<>F′) →
-          let F≡F′ = soundnessConv↑ F<>F′
-              k≡l = soundness~↓ x₁
-              ⊢Unit , ⊢k , _ = syntacticEqTerm k≡l
-              ok = inversion-Unit ⊢Unit
-              ⊢Γ = wf ⊢Unit
-              F₊≡F′₊ = substTypeEq F≡F′ (refl (starⱼ ⊢Γ ok))
-              _ , ⊢k′ , _ = syntacticEqTerm (soundness~↓ k~k′)
-              whA , neK , _ = ne~↓ k~k′
-              A≡Unit = neTypeEq neK ⊢k ⊢k′
-              k~k″ = PE.subst (λ x → _ ⊢ _ ~ _ ↓ x)
-                              (Unit≡A A≡Unit whA)
-                              k~k′
-          in  case (decConv↑Term x₂ (convConv↑Term (reflConEq ⊢Γ) (sym F₊≡F′₊) x₅)) of λ where
-            (no ¬p) → no λ{ (_ , unitrec-cong x x₁ x₂ _) → ¬p x₂}
-            (yes u<>u′) → case p ≟ p′ of λ where
-              (no p≉p′) →
-                no λ { (_ , unitrec-cong x x₁ x₂ _) → p≉p′ PE.refl }
-              (yes p≈p′) → case q ≟ q′ of λ where
-                (no q≉q′) →
-                  no λ { (_ , unitrec-cong x x₁ x₂ _) → q≉q′ PE.refl }
-                (yes PE.refl) → case p≈p′ of λ where
-                  PE.refl → yes (_ , unitrec-cong F<>F′ k~k″ u<>u′ no-η)
-
-  dec~↑
-    (prodrec-cong {p = p}  {r = r}  {q′ = q}  x  x₁ x₂)
-    (prodrec-cong {p = p′} {r = r′} {q′ = q′} x₃ x₄ x₅)
-    with dec~↓ x₁ x₄ | r ≟ r′ | p ≟ p′ | q ≟ q′
-  ... | yes (B , t~t′) | yes PE.refl | yes PE.refl | yes PE.refl =
-    case ne~↓ t~t′ of λ (whnfB , neT , neT′) →
-    case syntacticEqTerm (soundness~↓ t~t′) of λ (⊢B , ⊢t , ⊢t′) →
-    case syntacticEqTerm (soundness~↓ x₁) of λ (⊢Σ , ⊢t₁ , ⊢w) →
-    case syntacticEqTerm (soundness~↓ x₄) of λ (⊢Σ′ , ⊢t′₁ , ⊢w′) →
-    case neTypeEq neT ⊢t ⊢t₁ of λ ⊢B≡Σ →
-    case neTypeEq neT′ ⊢t′ ⊢t′₁ of λ ⊢B≡Σ′ →
-    case Σ≡A (sym ⊢B≡Σ) whnfB of λ where
-      (_ , _ , PE.refl) →
-        case trans (sym ⊢B≡Σ′) ⊢B≡Σ of λ ⊢Σ′≡Σ →
-        case Σ-injectivity ⊢Σ′≡Σ of λ where
-          (⊢F′≡F , ⊢G′≡G , _ , PE.refl , _) → case Σ-injectivity ⊢B≡Σ′ of  λ where
-            (⊢F′≡F″ , _ , _ , _ , _) →
-              case reflConEq (wf ⊢B) of λ ⊢Γ≡Γ →
-                dec~↑-prodrec
-                  (decConv↑ x (stabilityConv↑ (⊢Γ≡Γ ∙ ⊢Σ′≡Σ) x₃))
-                  (λ C≡C′ → decConv↑TermConv
-                     (subst↑²TypeEq-prod C≡C′ (⊢∷ΠΣ→ΠΣ-allowed ⊢t₁))
-                     x₂
-                     (stabilityConv↑Term (⊢Γ≡Γ ∙ ⊢F′≡F ∙ ⊢G′≡G) x₅))
-                  t~t′ (sym ⊢B≡Σ) PE.refl PE.refl PE.refl
-  ... | no ¬P | _ | _ | _ =
-    no (λ { (_ , prodrec-cong _ x _) → ¬P (_ , x) })
-  ... | _ | no ¬r≡r′ | _ | _ =
-    no (λ { (_ , prodrec-cong _ _ _) → ¬r≡r′ PE.refl })
-  ... | _ | _ | no ¬p≡p′ | _ =
-    no (λ { (_ , prodrec-cong _ _ _) → ¬p≡p′ PE.refl })
-  ... | _ | _ | _ | no ¬q≡q′ =
-    no (λ { (_ , prodrec-cong _ _ _) → ¬q≡q′ PE.refl })
-  dec~↑ (prodrec-cong _ _ _) (var-refl _ _) = no λ { (_ , ()) }
-  dec~↑ (prodrec-cong _ _ _) (app-cong _ _) = no λ { (_ , ()) }
-  dec~↑ (prodrec-cong _ _ _) (fst-cong _) = no λ { (_ , ()) }
-  dec~↑ (prodrec-cong _ _ _) (snd-cong _) = no λ { (_ , ()) }
-  dec~↑ (prodrec-cong _ _ _) (natrec-cong _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ (prodrec-cong _ _ _) (emptyrec-cong _ _) = no λ { (_ , ()) }
-  dec~↑ (prodrec-cong _ _ _) (unitrec-cong _ _ _ _) = no λ{(_ , ())}
-  dec~↑ (prodrec-cong _ _ _) (J-cong _ _ _ _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ (prodrec-cong _ _ _) (K-cong _ _ _ _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ (prodrec-cong _ _ _) ([]-cong-cong _ _ _ _ _ _) =
-    no λ { (_ , ()) }
-
-  dec~↑ (emptyrec-cong {p = p′} x x₁) (emptyrec-cong {p = p″} x₄ x₅)
-        with decConv↑ x x₄ | dec~↓ x₁ x₅ | p′ ≟ p″
-  ... | yes p | yes (A , k~l) | yes PE.refl =
-    let whnfA , neK , neL = ne~↓ k~l
-        ⊢A , ⊢k , ⊢l = syntacticEqTerm (soundness~↓ k~l)
-        _ , ⊢l∷Empty , _ = syntacticEqTerm (soundness~↓ x₁)
-        ⊢Empty≡A = neTypeEq neK ⊢l∷Empty ⊢k
-        A≡Empty = Empty≡A ⊢Empty≡A whnfA
-        k~l′ = PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) A≡Empty k~l
-    in  yes (_ , emptyrec-cong p k~l′)
-  ... | yes p | yes (A , k~l) | no ¬p′≡p″ =
-    no (λ { (_ , emptyrec-cong _ _) → ¬p′≡p″ PE.refl })
-  ... | yes p | no ¬p | _ =
-    no (λ { (_ , emptyrec-cong _ b) → ¬p (_ , b) })
-  ... | no ¬p | r | _ = no (λ { (_ , emptyrec-cong a _) → ¬p a })
-  dec~↑ (emptyrec-cong _ _) (var-refl _ _) = no (λ { (_ , ()) })
-  dec~↑ (emptyrec-cong _ _) (fst-cong _) = no (λ { (_ , ()) })
-  dec~↑ (emptyrec-cong _ _) (snd-cong _) = no (λ { (_ , ()) })
-  dec~↑ (emptyrec-cong _ _) (app-cong _ _) = no (λ { (_ , ()) })
-  dec~↑ (emptyrec-cong _ _) (natrec-cong _ _ _ _) = no (λ { (_ , ()) })
-  dec~↑ (emptyrec-cong _ _) (prodrec-cong _ _ _) = no λ{(_ , ())}
-  dec~↑ (emptyrec-cong _ _) (unitrec-cong _ _ _ _) = no λ{(_ , ())}
-  dec~↑ (emptyrec-cong _ _) (J-cong _ _ _ _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ (emptyrec-cong _ _) (K-cong _ _ _ _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ (emptyrec-cong _ _) ([]-cong-cong _ _ _ _ _ _) =
-    no λ { (_ , ()) }
-  dec~↑ (unitrec-cong _ _ _ _) (var-refl _ _) = no λ{(_ , ())}
-  dec~↑ (unitrec-cong _ _ _ _) (app-cong _ _) = no λ{(_ , ())}
-  dec~↑ (unitrec-cong _ _ _ _) (fst-cong _) = no λ{(_ , ())}
-  dec~↑ (unitrec-cong _ _ _ _) (snd-cong _) = no λ{(_ , ())}
-  dec~↑ (unitrec-cong _ _ _ _) (natrec-cong _ _ _ _) = no λ{(_ , ())}
-  dec~↑ (unitrec-cong _ _ _ _) (prodrec-cong _ _ _) = no λ{(_ , ())}
-  dec~↑ (unitrec-cong _ _ _ _) (emptyrec-cong _ _) = no λ{(_ , ())}
-  dec~↑ (unitrec-cong _ _ _ _) (J-cong _ _ _ _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ (unitrec-cong _ _ _ _) (K-cong _ _ _ _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ (unitrec-cong _ _ _ _) ([]-cong-cong _ _ _ _ _ _) =
-    no λ { (_ , ()) }
-  dec~↑
-    (J-cong {p = p₁} {q = q₁} A₁≡A₃ t₁≡t₃ B₁≡B₃ u₁≡u₃ v₁≡v₃ w₁~w₃
-       C₁≡Id-t₁-v₁)
-    (J-cong {p = p₂} {q = q₂} A₂≡A₄ t₂≡t₄ B₂≡B₄ u₂≡u₄ v₂≡v₄ w₂~w₄ _) =
-    case p₁ ≟ p₂ of λ {
-      (no p₁≢p₂) → no $
-        p₁≢p₂ ∘→ proj₁ ∘→ proj₂ ∘→ J-cong⁻¹ ∘→ proj₂
-    ; (yes PE.refl) →
-    case q₁ ≟ q₂ of λ {
-      (no q₁≢q₂) → no $
-        q₁≢q₂ ∘→ proj₁ ∘→ proj₂ ∘→ proj₂ ∘→ J-cong⁻¹ ∘→ proj₂
-    ; (yes PE.refl) →
-    case decConv↑ A₁≡A₃ A₂≡A₄ of λ {
-      (no A₁≢A₂) → no $
-        A₁≢A₂ ∘→ proj₁ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ J-cong⁻¹ ∘→ proj₂
-    ; (yes A₁≡A₂) →
-    case soundnessConv↑ A₁≡A₂ of λ {
-      ⊢A₁≡A₂ →
-    case decConv↑TermConv ⊢A₁≡A₂ t₁≡t₃ t₂≡t₄ of λ {
-      (no t₁≢t₂) → no $
-        t₁≢t₂ ∘→ proj₁ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→
-        J-cong⁻¹ ∘→ proj₂
-    ; (yes t₁≡t₂) →
-    case soundnessConv↑Term t₁≡t₂ of λ {
-      ⊢t₁≡t₂ →
-    case decConv↑′ (J-motive-context-cong′ ⊢A₁≡A₂ ⊢t₁≡t₂)
-           B₁≡B₃ B₂≡B₄ of λ {
-      (no B₁≢B₂) → no $
-        B₁≢B₂ ∘→ proj₁ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→
-        J-cong⁻¹ ∘→ proj₂
-    ; (yes B₁≡B₂) →
-    case decConv↑TermConv
-           (J-motive-rfl-cong (soundnessConv↑ B₁≡B₂) ⊢t₁≡t₂)
-           u₁≡u₃ u₂≡u₄ of λ {
-      (no u₁≢u₂) → no $
-        u₁≢u₂ ∘→ proj₁ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→
-        proj₂ ∘→ J-cong⁻¹ ∘→ proj₂
-    ; (yes u₁≡u₂) →
-    case decConv↑TermConv ⊢A₁≡A₂ v₁≡v₃ v₂≡v₄ of λ {
-      (no v₁≢v₂) → no $
-        v₁≢v₂ ∘→ proj₁ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→
-        proj₂ ∘→ proj₂ ∘→ J-cong⁻¹ ∘→ proj₂
-    ; (yes v₁≡v₂) →
-    case dec~↓ w₁~w₃ w₂~w₄ of λ {
-      (no ¬w₁~w₂) → no $
-        ¬w₁~w₂ ∘→ (_ ,_) ∘→ proj₁ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→
-        proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ J-cong⁻¹ ∘→ proj₂
-    ; (yes (_ , w₁~w₂)) →
-    case neTypeEq (ne~↓ w₁~w₂ .proj₂ .proj₁)
-           (syntacticEqTerm (soundness~↓ w₁~w₃) .proj₂ .proj₁)
-           (syntacticEqTerm (soundness~↓ w₁~w₂) .proj₂ .proj₁) of λ {
-      C₁≡D →
-    yes
-      ( _
-      , J-cong A₁≡A₂ t₁≡t₂ B₁≡B₂ u₁≡u₂ v₁≡v₂ w₁~w₂
-          (trans (sym C₁≡D) C₁≡Id-t₁-v₁)
-      ) }}}}}}}}}}}
-  dec~↑ (J-cong _ _ _ _ _ _ _) (var-refl _ _) = no (λ { (_ , ()) })
-  dec~↑ (J-cong _ _ _ _ _ _ _) (fst-cong _) = no (λ { (_ , ()) })
-  dec~↑ (J-cong _ _ _ _ _ _ _) (snd-cong _) = no (λ { (_ , ()) })
-  dec~↑ (J-cong _ _ _ _ _ _ _) (app-cong _ _) = no (λ { (_ , ()) })
-  dec~↑ (J-cong _ _ _ _ _ _ _) (natrec-cong _ _ _ _) = no (λ { (_ , ()) })
-  dec~↑ (J-cong _ _ _ _ _ _ _) (prodrec-cong _ _ _) = no λ{(_ , ())}
-  dec~↑ (J-cong _ _ _ _ _ _ _) (emptyrec-cong _ _) = no λ { (_ , ()) }
-  dec~↑ (J-cong _ _ _ _ _ _ _) (unitrec-cong _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ (J-cong _ _ _ _ _ _ _) (K-cong _ _ _ _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ (J-cong _ _ _ _ _ _ _) ([]-cong-cong _ _ _ _ _ _) = no λ { (_ , ()) }
-
-  dec~↑ (K-cong {p = p₁} A₁≡A₃ t₁≡t₃ B₁≡B₃ u₁≡u₃ v₁~v₃ C₁≡Id-t₁-t₁ ok)
-     (K-cong {p = p₂} A₂≡A₄ t₂≡t₄ B₂≡B₄ u₂≡u₄ v₂~v₄ _ _) =
-    case p₁ ≟ p₂ of λ {
-      (no p₁≢p₂) → no $
-        p₁≢p₂ ∘→ proj₁ ∘→ proj₂ ∘→ K-cong⁻¹ ∘→ proj₂
-    ; (yes PE.refl) →
-    case decConv↑ A₁≡A₃ A₂≡A₄ of λ {
-      (no A₁≢A₂) → no $
-        A₁≢A₂ ∘→ proj₁ ∘→ proj₂ ∘→ proj₂ ∘→ K-cong⁻¹ ∘→ proj₂
-    ; (yes A₁≡A₂) →
-    case soundnessConv↑ A₁≡A₂ of λ {
-      ⊢A₁≡A₂ →
-    case decConv↑TermConv ⊢A₁≡A₂ t₁≡t₃ t₂≡t₄ of λ {
-      (no t₁≢t₂) → no $
-        t₁≢t₂ ∘→ proj₁ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ K-cong⁻¹ ∘→ proj₂
-    ; (yes t₁≡t₂) →
-    case decConv↑′
-           (K-motive-context-cong′ ⊢A₁≡A₂ (soundnessConv↑Term t₁≡t₂))
-           B₁≡B₃ B₂≡B₄ of λ {
-      (no B₁≢B₂) → no $
-        B₁≢B₂ ∘→ proj₁ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→
-        K-cong⁻¹ ∘→ proj₂
-    ; (yes B₁≡B₂) →
-    case decConv↑TermConv (K-motive-rfl-cong (soundnessConv↑ B₁≡B₂))
-           u₁≡u₃ u₂≡u₄ of λ {
-      (no u₁≢u₂) → no $
-        u₁≢u₂ ∘→ proj₁ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→
-        K-cong⁻¹ ∘→ proj₂
-    ; (yes u₁≡u₂) →
-    case dec~↓ v₁~v₃ v₂~v₄ of λ {
-      (no ¬v₁~v₂) → no $
-        ¬v₁~v₂ ∘→ (_ ,_) ∘→ proj₁ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→ proj₂ ∘→
-        proj₂ ∘→ proj₂ ∘→ K-cong⁻¹ ∘→ proj₂
-    ; (yes (_ , v₁~v₂)) →
-    case neTypeEq (ne~↓ v₁~v₂ .proj₂ .proj₁)
-           (syntacticEqTerm (soundness~↓ v₁~v₃) .proj₂ .proj₁)
-           (syntacticEqTerm (soundness~↓ v₁~v₂) .proj₂ .proj₁) of λ {
-      C₁≡D →
-    yes
-      ( _
-      , K-cong A₁≡A₂ t₁≡t₂ B₁≡B₂ u₁≡u₂ v₁~v₂
-          (trans (sym C₁≡D) C₁≡Id-t₁-t₁) ok
-      ) }}}}}}}}
-  dec~↑ (K-cong _ _ _ _ _ _ _) (var-refl _ _) = no (λ { (_ , ()) })
-  dec~↑ (K-cong _ _ _ _ _ _ _) (fst-cong _) = no (λ { (_ , ()) })
-  dec~↑ (K-cong _ _ _ _ _ _ _) (snd-cong _) = no (λ { (_ , ()) })
-  dec~↑ (K-cong _ _ _ _ _ _ _) (app-cong _ _) = no (λ { (_ , ()) })
-  dec~↑ (K-cong _ _ _ _ _ _ _) (natrec-cong _ _ _ _) = no (λ { (_ , ()) })
-  dec~↑ (K-cong _ _ _ _ _ _ _) (prodrec-cong _ _ _) = no λ{(_ , ())}
-  dec~↑ (K-cong _ _ _ _ _ _ _) (emptyrec-cong _ _) = no λ { (_ , ()) }
-  dec~↑ (K-cong _ _ _ _ _ _ _) (unitrec-cong _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ (K-cong _ _ _ _ _ _ _) (J-cong _ _ _ _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ (K-cong _ _ _ _ _ _ _) ([]-cong-cong _ _ _ _ _ _) = no λ { (_ , ()) }
-
-  dec~↑ ([]-cong-cong {s = s} A₁≡A₃ t₁≡t₃ u₁≡u₃ v₁~v₃ B₁≡Id-t₁-u₁ ok)
-     ([]-cong-cong {s = s′} A₂≡A₄ t₂≡t₄ u₂≡u₄ v₂~v₄ _ _) =
-    case decConv↑ A₁≡A₃ A₂≡A₄ of λ where
-      (no A₁≢A₂) → no λ where
-        (_ , []-cong-cong A₁≡A₂ _ _ _ _ _) → A₁≢A₂ A₁≡A₂
-      (yes A₁≡A₂) → case decConv↑TermConv (soundnessConv↑ A₁≡A₂)
-                           t₁≡t₃ t₂≡t₄ of λ where
-        (no t₁≢t₂) → no λ where
-          (_ , []-cong-cong _ t₁≡t₂ _ _ _ _) → t₁≢t₂ t₁≡t₂
-        (yes t₁≡t₂) → case decConv↑TermConv (soundnessConv↑ A₁≡A₂)
-                             u₁≡u₃ u₂≡u₄ of λ where
-          (no u₁≢u₂) → no λ where
-            (_ , []-cong-cong _ _ u₁≡u₂ _ _ _) → u₁≢u₂ u₁≡u₂
-          (yes u₁≡u₂) → case dec~↓ v₁~v₃ v₂~v₄ of λ where
-            (no ¬v₁~v₂) → no λ where
-              (_ , []-cong-cong _ _ _ v₁~v₂ _ _) → ¬v₁~v₂ (_ , v₁~v₂)
-            (yes (_ , v₁~v₂)) →
-              case neTypeEq (ne~↓ v₁~v₂ .proj₂ .proj₁)
-                     (syntacticEqTerm (soundness~↓ v₁~v₃) .proj₂ .proj₁)
-                     (syntacticEqTerm (soundness~↓ v₁~v₂)
-                        .proj₂ .proj₁) of λ {
-                B₁≡C → case decStrength s s′ of λ where
-                  (yes PE.refl) → yes
-                    ( _
-                    , []-cong-cong A₁≡A₂ t₁≡t₂ u₁≡u₂ v₁~v₂
-                        (trans (sym B₁≡C) B₁≡Id-t₁-u₁) ok
-                    )
-                  (no s≢s) → no λ where
-                    (_ , []-cong-cong _ _ _ _ _ _) → s≢s PE.refl }
-  dec~↑ ([]-cong-cong _ _ _ _ _ _) (var-refl _ _) = no (λ { (_ , ()) })
-  dec~↑ ([]-cong-cong _ _ _ _ _ _) (fst-cong _) = no (λ { (_ , ()) })
-  dec~↑ ([]-cong-cong _ _ _ _ _ _) (snd-cong _) = no (λ { (_ , ()) })
-  dec~↑ ([]-cong-cong _ _ _ _ _ _) (app-cong _ _) = no (λ { (_ , ()) })
-  dec~↑ ([]-cong-cong _ _ _ _ _ _) (natrec-cong _ _ _ _) = no (λ { (_ , ()) })
-  dec~↑ ([]-cong-cong _ _ _ _ _ _) (prodrec-cong _ _ _) = no λ{(_ , ())}
-  dec~↑ ([]-cong-cong _ _ _ _ _ _) (emptyrec-cong _ _) = no λ { (_ , ()) }
-  dec~↑ ([]-cong-cong _ _ _ _ _ _) (unitrec-cong _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ ([]-cong-cong _ _ _ _ _ _) (J-cong _ _ _ _ _ _ _) = no λ { (_ , ()) }
-  dec~↑ ([]-cong-cong _ _ _ _ _ _) (K-cong _ _ _ _ _ _ _) = no λ { (_ , ()) }
+  dec~↑ (var-refl {x} ⊢x _) u~ = case inv-~-var u~ of λ where
+    (inj₁ (y , PE.refl , _)) → case x ≟ⱽ y of λ where
+      (yes x≡y) → yes (_ , var-refl ⊢x x≡y)
+      (no x≢y)  → no (x≢y ∘→ var-PE-injectivity ∘→ inv-~var ∘→ proj₂)
+    (inj₂ (u≢var , _)) → no (u≢var ∘→ (_ ,_) ∘→ inv-var~ ∘→ proj₂)
+  dec~↑ (app-cong t₁~ t₂≡) u~ = case inv-~-∘ u~ of λ where
+    (inj₁
+       (_ , _ , _ , _ , _ , _ , _ , _ , _ ,
+        PE.refl , _ , u₁~ , u₂≡)) →
+      dec~↑-app-cong (~↓→∷ t₁~) (~↓→∷ u₁~) (dec~↓ t₁~ u₁~)
+        (λ B₁≡C₁ → decConv↑TermConv B₁≡C₁ t₂≡ u₂≡)
+    (inj₂ (u≢∘ , _)) →
+      no λ (_ , t~u) →
+      let _ , _ , _ , _ , _ , _ , u≡∘ , _ = inv-∘~ t~u in
+      u≢∘ (_ , _ , _ , u≡∘)
+  dec~↑ (fst-cong t′~) u~ = case inv-~-fst u~ of λ where
+    (inj₁ (_ , _ , _ , _ , _ , PE.refl , _ , u′~)) →
+      dec~↑-fst-cong (~↓→∷ t′~) (_ ≟ _ ×-dec dec~↓ t′~ u′~)
+    (inj₂ (u≢fst , _)) →
+      no λ (_ , t~u) →
+      let _ , _ , _ , u≡fst , _ = inv-fst~ t~u in
+      u≢fst (_ , _ , u≡fst)
+  dec~↑ (snd-cong t′~) u~ = case inv-~-snd u~ of λ where
+    (inj₁ (_ , _ , _ , _ , _ , _ , _ , PE.refl , _ , u′~)) →
+      dec~↑-snd-cong (~↓→∷ t′~) (_ ≟ _ ×-dec dec~↓ t′~ u′~)
+    (inj₂ (u≢snd , _)) →
+      no λ (_ , t~u) →
+      let _ , _ , _ , _ , _ , u≡snd , _ = inv-snd~ t~u in
+      u≢snd (_ , _ , u≡snd)
+  dec~↑ (prodrec-cong B≡ t₁~ t₂≡) u~ = case inv-~-prodrec u~ of λ where
+    (inj₁
+       (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ ,
+        PE.refl , _ , C≡ , u₁~ , u₂≡)) →
+      dec~↑-prodrec-cong (~↓→∷ t₁~) (~↓→∷ u₁~)
+        (_ ≟ _ ×-dec _ ≟ _ ×-dec dec~↓ t₁~ u₁~)
+        (λ eq → decConv↑′ eq B≡ C≡)
+        (λ eq₁ eq₂ → decConv↑Term t₂≡ (convConv↑Term eq₁ eq₂ u₂≡))
+    (inj₂ (u≢pr , _)) →
+      no λ (_ , t~u) →
+      let _ , _ , _ , _ , _ , _ , _ , u≡pr , _ = inv-prodrec~ t~u in
+      u≢pr (_ , _ , _ , _ , _ , _ , u≡pr)
+  dec~↑ (emptyrec-cong B≡ t′~) u~ = case inv-~-emptyrec u~ of λ where
+    (inj₁ (_ , _ , _ , _ , PE.refl , _ , C≡ , u′~)) →
+      dec~↑-emptyrec-cong (~↓→∷ t′~)
+        (_ ≟ _ ×-dec decConv↑ B≡ C≡ ×-dec dec~↓ t′~ u′~)
+    (inj₂ (u≢er , _)) →
+      no λ (_ , t~u) →
+      let _ , _ , _ , u≡er , _ = inv-emptyrec~ t~u in
+      u≢er (_ , _ , _ , u≡er)
+  dec~↑ (unitrec-cong B≡ t₁~ t₂≡ no-η) u~ =
+    case inv-~-unitrec u~ of λ where
+      (inj₁
+         (_ , _ , _ , _ , _ , _ , _ , _ , _ ,
+          PE.refl , _ , C≡ , u₁~ , u₂≡ , _)) →
+        dec~↑-unitrec-cong no-η (~↓→∷ t₁~)
+          (_ ≟ _ ×-dec _ ≟ _ ×-dec decConv↑ B≡ C≡ ×-dec dec~↓ t₁~ u₁~)
+          (λ eq → decConv↑TermConv eq t₂≡ u₂≡)
+      (inj₂ (u≢ur , _)) →
+        no λ (_ , t~u) →
+        let _ , _ , _ , _ , u≡ur , _ = inv-unitrec~ t~u in
+        u≢ur (_ , _ , _ , _ , _ , u≡ur)
+  dec~↑ (natrec-cong B≡ t₁≡ t₂≡ t₃~) u~ =
+    case inv-~-natrec u~ of λ where
+      (inj₁
+         (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ ,
+          PE.refl , _ , C≡ , u₁≡ , u₂≡ , u₃~)) →
+        dec~↑-natrec-cong (~↓→∷ t₃~)
+          (_ ≟ _ ×-dec _ ≟ _ ×-dec _ ≟ _ ×-dec decConv↑ B≡ C≡ ×-dec
+           dec~↓ t₃~ u₃~)
+          (λ eq → decConv↑TermConv eq t₁≡ u₁≡)
+          (λ eq₁ eq₂ → decConv↑Term t₂≡ (convConv↑Term eq₁ eq₂ u₂≡))
+      (inj₂ (u≢nr , _)) →
+        no λ (_ , t~u) →
+        let _ , _ , _ , _ , _ , u≡nr , _ = inv-natrec~ t~u in
+        u≢nr (_ , _ , _ , _ , _ , _ , _ , u≡nr)
+  dec~↑ (J-cong B₁≡ t₁≡ B₂≡ t₂≡ t₃≡ t₄~ B₃≡Id) u~ =
+    case inv-~-J u~ of λ where
+      (inj₁
+         (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ ,
+          _ , PE.refl , _ ,
+          C₁≡ , u₁≡ , C₂≡ , u₂≡ , u₃≡ , u₄~ , _)) →
+        dec~↑-J-cong (conv (~↓→∷ t₄~) B₃≡Id)
+          (_ ≟ _ ×-dec _ ≟ _ ×-dec decConv↑ B₁≡ C₁≡ ×-dec dec~↓ t₄~ u₄~)
+          (λ eq → decConv↑TermConv eq t₁≡ u₁≡)
+          (λ eq → decConv↑′ eq B₂≡ C₂≡)
+          (λ eq → decConv↑TermConv eq t₂≡ u₂≡)
+          (λ eq → decConv↑TermConv eq t₃≡ u₃≡)
+      (inj₂ (u≢J , _)) →
+        no λ (_ , t~u) →
+        let _ , _ , _ , _ , _ , _ , _ , _ , u≡J , _ = inv-J~ t~u in
+        u≢J (_ , _ , _ , _ , _ , _ , _ , _ , u≡J)
+  dec~↑ (K-cong B₁≡ t₁≡ B₂≡ t₂≡ t₃~ B₃≡Id ok) u~ =
+    case inv-~-K u~ of λ where
+      (inj₁
+         (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ ,
+          PE.refl , _ , C₁≡ , u₁≡ , C₂≡ , u₂≡ , u₃~ , _)) →
+        dec~↑-K-cong ok (conv (~↓→∷ t₃~) B₃≡Id)
+          (_ ≟ _ ×-dec decConv↑ B₁≡ C₁≡ ×-dec dec~↓ t₃~ u₃~)
+          (λ eq → decConv↑TermConv eq t₁≡ u₁≡)
+          (λ eq → decConv↑′ eq B₂≡ C₂≡)
+          (λ eq → decConv↑TermConv eq t₂≡ u₂≡)
+      (inj₂ (u≢K , _)) →
+        no λ (_ , t~u) →
+        let _ , _ , _ , _ , _ , _ , _ , u≡K , _ = inv-K~ t~u in
+        u≢K (_ , _ , _ , _ , _ , _ , u≡K)
+  dec~↑ ([]-cong-cong B₁≡ t₁≡ t₂≡ t₃~ B₂≡Id ok) u~ =
+    case inv-~-[]-cong u~ of λ where
+      (inj₁
+         (_ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ ,
+          PE.refl , _ , C₁≡ , u₁≡ , u₂≡ , u₃~ , _)) →
+        dec~↑-[]-cong-cong ok (conv (~↓→∷ t₃~) B₂≡Id)
+          (decStrength _ _ ×-dec decConv↑ B₁≡ C₁≡ ×-dec dec~↓ t₃~ u₃~)
+          (λ eq → decConv↑TermConv eq t₁≡ u₁≡)
+          (λ eq → decConv↑TermConv eq t₂≡ u₂≡)
+      (inj₂ (u≢bc , _)) →
+        no λ (_ , t~u) →
+        let _ , _ , _ , _ , _ , _ , u≡bc , _ = inv-[]-cong~ t~u in
+        u≢bc (_ , _ , _ , _ , _ , u≡bc)
 
   dec~↑′ : ∀ {k l R T}
         → ⊢ Γ ≡ Δ
@@ -694,146 +838,66 @@ mutual
   decConv↓ : ∀ {A B A′ B′}
            → Γ ⊢ A [conv↓] A′ → Γ ⊢ B [conv↓] B′
            → Dec (Γ ⊢ A [conv↓] B)
-  -- True cases
-  decConv↓ (U-refl x) (U-refl x₁) = yes (U-refl x)
-  decConv↓ (ℕ-refl x) (ℕ-refl x₁) = yes (ℕ-refl x)
-  decConv↓ (Empty-refl x) (Empty-refl x₁) = yes (Empty-refl x)
-
-  -- Inspective cases
-  decConv↓ (Unit-refl {s = s} x ok) (Unit-refl {s = s′} _ _) =
-    case decStrength s s′ of λ where
-    (yes PE.refl) → yes (Unit-refl x ok)
-    (no s≢s′) → no (λ { (Unit-refl x x₁) → s≢s′ PE.refl})
-  decConv↓ (ne x) (ne x₁) with dec~↓ x x₁
-  decConv↓ (ne x) (ne x₁) | yes (A , k~l) =
-    let whnfA , neK , neL = ne~↓ k~l
-        ⊢A , ⊢k , _ = syntacticEqTerm (soundness~↓ k~l)
-        _ , ⊢k∷U , _ = syntacticEqTerm (soundness~↓ x)
-        ⊢U≡A = neTypeEq neK ⊢k∷U ⊢k
-        A≡U = U≡A ⊢U≡A
-        k~l′ = PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) A≡U k~l
-    in  yes (ne k~l′)
-  decConv↓ (ne x) (ne x₁) | no ¬p = no (λ x₂ → ¬p (U , (decConv↓-ne x₂ x)))
-
-  decConv↓
-    (ΠΣ-cong {b = b₁} {p = p′} {q = q′} x x₁ x₂ ok)
-    (ΠΣ-cong {b = b₂} {p = p″} {q = q″} x₃ x₄ x₅ _)
-           with decConv↑ x₁ x₄
-  ... | yes p
-    with decConv↑′ (reflConEq (wf x) ∙ soundnessConv↑ p) x₂ x₅
-       | p′ ≟ p″ | q′ ≟ q″ | decBinderMode b₁ b₂
-  ... | yes p₁ | yes PE.refl | yes PE.refl | yes PE.refl =
-    yes (ΠΣ-cong x p p₁ ok)
-  ... | no ¬p | _ | _ | _ =
-    no (λ { (ne ([~] _ _ ())); (ΠΣ-cong _ _ p _) → ¬p p })
-  ... | _ | no ¬p′≡p″ | _ | _ =
-    no (λ { (ne ([~] _ _ ())); (ΠΣ-cong _ _ _ _) → ¬p′≡p″ PE.refl })
-  ... | _ | _ | no ¬q′≡q″ | _ =
-    no (λ { (ne ([~] _ _ ())); (ΠΣ-cong _ _ _ _) → ¬q′≡q″ PE.refl })
-  ... | _ | _ | _ | no b₁≢b₂ =
-    no λ { (ne ([~] _ _ ())); (ΠΣ-cong _ _ _ _) → b₁≢b₂ PE.refl }
-  decConv↓ (ΠΣ-cong _ _ _ _) (ΠΣ-cong _ _ _ _) | no ¬p =
-    no (λ { (ne ([~] _ _ ())) ; (ΠΣ-cong _ p _ _) → ¬p p })
-
-  decConv↓ (Id-cong A₁≡A₃ t₁≡t₃ u₁≡u₃) (Id-cong A₂≡A₄ t₂≡t₄ u₂≡u₄) =
-    case decConv↑ A₁≡A₃ A₂≡A₄ of λ where
-      (no A₁≢A₂) → no λ where
-        (ne ([~] _ _ ()))
-        (Id-cong A₁≡A₂ _ _) → A₁≢A₂ A₁≡A₂
-      (yes A₁≡A₂) → case decConv↑TermConv (soundnessConv↑ A₁≡A₂)
-                           t₁≡t₃ t₂≡t₄ of λ where
-        (no t₁≢t₂) → no λ where
-          (ne ([~] _ _ ()))
-          (Id-cong _ t₁≡t₂ _) → t₁≢t₂ t₁≡t₂
-        (yes t₁≡t₂) → case decConv↑TermConv (soundnessConv↑ A₁≡A₂)
-                             u₁≡u₃ u₂≡u₄ of λ where
-          (no u₁≢u₂) → no λ where
-            (ne ([~] _ _ ()))
-            (Id-cong _ _ u₁≡u₂) → u₁≢u₂ u₁≡u₂
-          (yes u₁≡u₂) → yes (Id-cong A₁≡A₂ t₁≡t₂ u₁≡u₂)
-
-  -- False cases
-  decConv↓ (U-refl x) (ℕ-refl x₁) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (U-refl x) (Empty-refl x₁) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (U-refl _) (Unit-refl _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (U-refl x) (ne x₁) =
-    no (λ x₂ → let whnfA , neK , neL = ne~↓ x₁
-               in  ⊥-elim (IE.U≢ne neK (soundnessConv↓ x₂)))
-  decConv↓ (U-refl _) (ΠΣ-cong _ _ _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (U-refl _) (Id-cong _ _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (ℕ-refl x) (U-refl x₁) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (ℕ-refl x) (Empty-refl x₁) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (ℕ-refl _) (Unit-refl _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (ℕ-refl x) (ne x₁) =
-    no (λ x₂ → let whnfA , neK , neL = ne~↓ x₁
-               in  ⊥-elim (IE.ℕ≢ne neK (soundnessConv↓ x₂)))
-  decConv↓ (ℕ-refl _) (ΠΣ-cong _ _ _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (ℕ-refl _) (Id-cong _ _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Empty-refl x) (U-refl x₁) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Empty-refl x) (ℕ-refl x₁) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Empty-refl _) (Unit-refl _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Empty-refl x) (ne x₁) =
-    no (λ x₂ → let whnfA , neK , neL = ne~↓ x₁
-               in  ⊥-elim (IE.Empty≢neⱼ neK (soundnessConv↓ x₂)))
-  decConv↓ (Empty-refl _) (ΠΣ-cong _ _ _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Empty-refl _) (Id-cong _ _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Unit-refl _ _) (U-refl _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Unit-refl _ _) (ℕ-refl _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Unit-refl _ _) (Empty-refl _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Unit-refl _ _) (ne x) =
-    no (λ y → let _ , neK , _ = ne~↓ x
-              in  ⊥-elim (IE.Unit≢neⱼ neK (soundnessConv↓ y)))
-  decConv↓ (Unit-refl _ _) (ΠΣ-cong _ _ _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Unit-refl _ _) (Id-cong _ _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (ne x) (U-refl x₁) =
-    no (λ x₂ → let whnfA , neK , neL = ne~↓ x
-               in  ⊥-elim (IE.U≢ne neK (sym (soundnessConv↓ x₂))))
-  decConv↓ (ne x) (ℕ-refl x₁) =
-    no (λ x₂ → let whnfA , neK , neL = ne~↓ x
-               in  ⊥-elim (IE.ℕ≢ne neK (sym (soundnessConv↓ x₂))))
-  decConv↓ (ne x) (Empty-refl x₁) =
-    no (λ x₂ → let whnfA , neK , neL = ne~↓ x
-               in  ⊥-elim (IE.Empty≢neⱼ neK (sym (soundnessConv↓ x₂))))
-  decConv↓ (ne x) (Unit-refl _ _) =
-    no (λ y → let whnfA , neK , neL = ne~↓ x
-              in  ⊥-elim (IE.Unit≢neⱼ neK (sym (soundnessConv↓ y))))
-  decConv↓ (ne x) (ΠΣ-cong _ _ _ _) =
-    no (λ y → let whnfA , neK , neL = ne~↓ x
-              in  ⊥-elim (IE.ΠΣ≢ne neK (sym (soundnessConv↓ y))))
-  decConv↓ (ne A~A′) (Id-cong _ _ _) =
-    no λ A≡B →
-    ⊥-elim $
-    IE.Id≢ne (ne~↓ A~A′ .proj₂ .proj₁) (sym (soundnessConv↓ A≡B))
-  decConv↓ (ΠΣ-cong _ _ _ _) (U-refl _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (ΠΣ-cong _ _ _ _) (ℕ-refl _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (ΠΣ-cong _ _ _ _) (Empty-refl _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (ΠΣ-cong _ _ _ _) (Unit-refl _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (ΠΣ-cong _ _ _ _) (ne x) =
-    no (λ y → let whnfA , neK , neL = ne~↓ x
-              in  ⊥-elim (IE.ΠΣ≢ne neK (soundnessConv↓ y)))
-  decConv↓ (ΠΣ-cong _ _ _ _) (Id-cong _ _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Id-cong _ _ _) (U-refl _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Id-cong _ _ _) (ℕ-refl _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Id-cong _ _ _) (Empty-refl _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Id-cong _ _ _) (Unit-refl _ _) = no (λ { (ne ([~] _ _ ())) })
-  decConv↓ (Id-cong _ _ _) (ne B~B′) =
-    no λ A≡B →
-    ⊥-elim $
-    IE.Id≢ne (ne~↓ B~B′ .proj₂ .proj₁) (soundnessConv↓ A≡B)
-  decConv↓ (Id-cong _ _ _) (ΠΣ-cong _ _ _ _) = no (λ { (ne ([~] _ _ ())) })
-
-  -- Helper function for decidability of neutral types.
-  decConv↓-ne : ∀ {A B A′}
-              → Γ ⊢ A [conv↓] B
-              → Γ ⊢ A ~ A′ ↓ U
-              → Γ ⊢ A ~ B ↓ U
-  decConv↓-ne (U-refl x) ()
-  decConv↓-ne (ℕ-refl x) ()
-  decConv↓-ne (Empty-refl x) ()
-  decConv↓-ne (ne x) A~A = x
-  decConv↓-ne (ΠΣ-cong _ _ _ _) ([~] _ _ ())
-  decConv↓-ne (Unit-refl _ _) ()
-  decConv↓-ne (Id-cong _ _ _) ([~] _ _ ())
+  decConv↓ (ne A~) B≡ =
+    let _ , A-ne , _ = ne~↓ A~ in
+    case inv-[conv↓]-ne′ B≡ of λ where
+      (inj₁ B~) →
+        case dec~↓ A~ B~ of λ where
+          (yes (_ , A~B)) →
+            yes $ ne $
+            let U≡A′ = neTypeEq A-ne (~↓→∷ A~) (~↓→∷ A~B) in
+            PE.subst (_⊢_~_↓_ _ _ _) (U≡A U≡A′) A~B
+          (no ¬A~B) → no (¬A~B ∘→ (_ ,_) ∘→ inv-[conv↓]-ne A-ne)
+      (inj₂ (¬-B-ne , _)) →
+        no λ A≡B →
+        ¬-B-ne (ne~↓ (inv-[conv↓]-ne A-ne A≡B) .proj₂ .proj₂)
+  decConv↓ U≡U@(U-refl _) B≡ =
+    case inv-[conv↓]-U′ B≡ of λ where
+      (inj₁ (PE.refl , _)) → yes U≡U
+      (inj₂ (B≢U , _))     → no (B≢U ∘→ inv-[conv↓]-U)
+  decConv↓ (ΠΣ-cong ⊢A₁ A₁≡ A₂≡ ok) B≡ =
+    case inv-[conv↓]-ΠΣ′ B≡ of λ where
+      (inj₁
+         (_ , _ , _ , _ , _ , _ , _ , PE.refl , PE.refl , B₁≡ , B₂≡)) →
+        decConv↓-ΠΣ ⊢A₁ ok
+          (decBinderMode _ _ ×-dec _ ≟ _ ×-dec _ ≟ _ ×-dec
+           decConv↑ A₁≡ B₁≡)
+          (λ eq → decConv↑′ eq A₂≡ B₂≡)
+      (inj₂ (B≢ΠΣ , _)) →
+        no λ ΠΣ≡B →
+        let _ , _ , B≡ΠΣ , _ = inv-[conv↓]-ΠΣ ΠΣ≡B in
+        B≢ΠΣ (_ , _ , _ , _ , _ , B≡ΠΣ)
+  decConv↓ Empty≡Empty@(Empty-refl _) B≡ =
+    case inv-[conv↓]-Empty′ B≡ of λ where
+      (inj₁ (PE.refl , _)) → yes Empty≡Empty
+      (inj₂ (B≢Empty , _)) → no (B≢Empty ∘→ inv-[conv↓]-Empty)
+  decConv↓ Unit≡Unit@(Unit-refl {s = s} _ _) B≡ =
+    case inv-[conv↓]-Unit′ B≡ of λ where
+      (inj₁ (s′ , PE.refl , _)) →
+        case decStrength s s′ of λ where
+          (yes PE.refl) → yes Unit≡Unit
+          (no s≢s′)     →
+            no λ Unit≡Unit →
+            case inv-[conv↓]-Unit Unit≡Unit of λ {
+              PE.refl →
+            s≢s′ PE.refl }
+      (inj₂ (B≢Unit , _)) → no (B≢Unit ∘→ (_ ,_) ∘→ inv-[conv↓]-Unit)
+  decConv↓ ℕ≡ℕ@(ℕ-refl _) B≡ =
+    case inv-[conv↓]-ℕ′ B≡ of λ where
+      (inj₁ (PE.refl , _)) → yes ℕ≡ℕ
+      (inj₂ (B≢ℕ , _))     → no (B≢ℕ ∘→ inv-[conv↓]-ℕ)
+  decConv↓ (Id-cong A′≡ t₁≡ t₂≡) B≡ =
+    case inv-[conv↓]-Id′ B≡ of λ where
+      (inj₁
+         (_ , _ , _ , _ , _ , _ ,
+          PE.refl , PE.refl , B′≡ , u₁≡ , u₂≡)) →
+        decConv↓-Id (decConv↑ A′≡ B′≡)
+          (λ A′≡B′ → decConv↑Term t₁≡ (convConvTerm u₁≡ A′≡B′))
+          (λ A′≡B′ → decConv↑Term t₂≡ (convConvTerm u₂≡ A′≡B′))
+      (inj₂ (B≢Id , _)) →
+        no λ Id≡B →
+        let _ , _ , _ , B≡Id , _ = inv-[conv↓]-Id Id≡B in
+        B≢Id (_ , _ , _ , B≡Id)
 
   -- Decidability of algorithmic equality of terms.
   decConv↑Term : ∀ {t u A t′ u′}
@@ -868,214 +932,193 @@ mutual
   decConv↓Term : ∀ {t u A t′ u′}
                → Γ ⊢ t [conv↓] t′ ∷ A → Γ ⊢ u [conv↓] u′ ∷ A
                → Dec (Γ ⊢ t [conv↓] u ∷ A)
-  -- True cases
-  decConv↓Term (zero-refl x) (zero-refl x₁) = yes (zero-refl x)
-  decConv↓Term (starʷ-refl x x₁ no-η) (starʷ-refl _ _ _) =
-    yes (starʷ-refl x x₁ no-η)
-  decConv↓Term (starʷ-refl _ _ _) (η-unit _ _ _ _ (inj₁ ()))
-  decConv↓Term (starʷ-refl _ _ no-η) (η-unit _ _ _ _ (inj₂ η)) =
-    ⊥-elim (no-η η)
-  decConv↓Term (η-unit ⊢t _ tUnit _ ok) (η-unit ⊢u _ uUnit _ _) =
-    yes (η-unit ⊢t ⊢u tUnit uUnit ok)
-  decConv↓Term (η-unit _ _ _ _ (inj₁ ())) (starʷ-refl _ _ _)
-  decConv↓Term (η-unit _ _ _ _ (inj₂ η)) (starʷ-refl _ _ no-η) =
-    ⊥-elim (no-η η)
-  decConv↓Term ⊢rfl≡rfl@(rfl-refl _) (rfl-refl _) = yes ⊢rfl≡rfl
-
-  -- Inspective cases
-  decConv↓Term (ℕ-ins x) (ℕ-ins x₁) with dec~↓ x x₁
-  decConv↓Term (ℕ-ins x) (ℕ-ins x₁) | yes (A , k~l) =
-    let whnfA , neK , neL = ne~↓ k~l
-        ⊢A , ⊢k , ⊢l = syntacticEqTerm (soundness~↓ k~l)
-        _ , ⊢l∷ℕ , _ = syntacticEqTerm (soundness~↓ x)
-        ⊢ℕ≡A = neTypeEq neK ⊢l∷ℕ ⊢k
-        A≡ℕ = ℕ≡A ⊢ℕ≡A whnfA
-        k~l′ = PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) A≡ℕ k~l
-    in  yes (ℕ-ins k~l′)
-  decConv↓Term (ℕ-ins x) (ℕ-ins x₁) | no ¬p =
-    no (λ x₂ → ¬p (ℕ , decConv↓Term-ℕ-ins x₂ x))
-  decConv↓Term (Empty-ins x) (Empty-ins x₁) with dec~↓ x x₁
-  decConv↓Term (Empty-ins x) (Empty-ins x₁) | yes (A , k~l) =
-    let whnfA , neK , neL = ne~↓ k~l
-        ⊢A , ⊢k , ⊢l = syntacticEqTerm (soundness~↓ k~l)
-        _ , ⊢l∷Empty , _ = syntacticEqTerm (soundness~↓ x)
-        ⊢Empty≡A = neTypeEq neK ⊢l∷Empty ⊢k
-        A≡Empty = Empty≡A ⊢Empty≡A whnfA
-        k~l′ = PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) A≡Empty k~l
-    in  yes (Empty-ins k~l′)
-  decConv↓Term (Empty-ins x) (Empty-ins x₁) | no ¬p =
-    no (λ x₂ → ¬p (Empty , decConv↓Term-Empty-ins x₂ x))
-  decConv↓Term (Unitʷ-ins no-η t~t′) (Unitʷ-ins _ u~u′)
-    with dec~↓ t~t′ u~u′
-  ... | yes (A , t~u) =
-    case ne~↓ t~u of λ
-      (A-whnf , t-ne , _) →
-    yes $
-    Unitʷ-ins no-η $
-    PE.subst (_⊢_~_↓_ _ _ _)
-      (Unit≡A
-         (neTypeEq t-ne
-            (syntacticEqTerm (soundness~↓ t~t′) .proj₂ .proj₁)
-            (syntacticEqTerm (soundness~↓ t~u) .proj₂ .proj₁))
-         A-whnf)
-      t~u
-  ... | no ¬t~u =
-    case Unitʷ-η? of λ where
-      (no no-η) → no λ where
-        (Unitʷ-ins _ t~u)          → ¬t~u (_ , t~u)
-        (η-unit _ _ _ _ (inj₁ ()))
-        (η-unit _ _ _ _ (inj₂ η))  → no-η η
-      (yes η) → yes $
-        η-unit
-          (syntacticEqTerm (soundness~↓ t~t′) .proj₂ .proj₁)
-          (syntacticEqTerm (soundness~↓ u~u′) .proj₂ .proj₁)
-          (ne (ne~↓ t~t′ .proj₂ .proj₁))
-          (ne (ne~↓ u~u′ .proj₂ .proj₁))
-          (inj₂ η)
-  decConv↓Term (Σʷ-ins x x₁ x₂) (Σʷ-ins x₃ x₄ x₅) with dec~↓ x₂ x₅
-  ... | yes (B , t~u) =
-    let ⊢B , ⊢t , ⊢u = syntacticEqTerm (soundness~↓ t~u)
-        whnfB , neT , _ = ne~↓ t~u
-        Σ≡B = neTypeEq neT x ⊢t
-        _ , _ , B≡Σ′ = Σ≡A Σ≡B whnfB
-    in  yes (Σʷ-ins x x₃ (PE.subst (λ x →  _ ⊢ _ ~ _ ↓ x) B≡Σ′ t~u))
-  ... | no ¬p = no (λ x₆ → ¬p (decConv↓Term-Σʷ-ins x₆ x₂))
-  decConv↓Term (ne-ins x x₁ x₂ x₃) (ne-ins x₄ x₅ x₆ x₇)
-               with dec~↓ x₃ x₇
-  decConv↓Term (ne-ins x x₁ x₂ x₃) (ne-ins x₄ x₅ x₆ x₇) | yes (A , k~l) =
-    yes (ne-ins x x₄ x₆ k~l)
-  decConv↓Term (ne-ins x x₁ x₂ x₃) (ne-ins x₄ x₅ x₆ x₇) | no ¬p =
-    no (λ x₈ → ¬p (inv-[conv↓]∷-ne x₆ x₈))
-  decConv↓Term (univ x x₁ x₂) (univ x₃ x₄ x₅)
-               with decConv↓  x₂ x₅
-  decConv↓Term (univ x x₁ x₂) (univ x₃ x₄ x₅) | yes p =
-    yes (univ x x₃ p)
-  decConv↓Term (univ x x₁ x₂) (univ x₃ x₄ x₅) | no ¬p =
-    no (λ { (ne-ins x₆ x₇ () x₉)
-          ; (univ x₆ x₇ x₈) → ¬p x₈ })
-  decConv↓Term (suc-cong x) (suc-cong x₁) with decConv↑Term  x x₁
-  decConv↓Term (suc-cong x) (suc-cong x₁) | yes p =
-    yes (suc-cong p)
-  decConv↓Term (suc-cong x) (suc-cong x₁) | no ¬p =
-    no (λ { (ℕ-ins ([~] _ _ ()))
-          ; (ne-ins x₂ x₃ () x₅)
-          ; (suc-cong x₂) → ¬p x₂ })
-  decConv↓Term (Σ-η ⊢t _ tProd _ fstConvT sndConvT)
-               (Σ-η ⊢u _ uProd _ fstConvU sndConvU)
-               with decConv↑Term fstConvT fstConvU
-  ... | yes P = let ⊢F , ⊢G = syntacticΣ (syntacticTerm ⊢t)
-                    fstt≡fstu = soundnessConv↑Term P
-                    Gfstt≡Gfstu = substTypeEq (refl ⊢G) fstt≡fstu
-                    sndConv = decConv↑TermConv Gfstt≡Gfstu sndConvT sndConvU
-                in  decConv↓Term-Σ-η ⊢t ⊢u tProd uProd P sndConv
-  ... | no ¬P = no (λ { (Σ-η _ _ _ _ P _) → ¬P P } )
-  decConv↓Term (prod-cong x x₁ x₂ x₃ ok) (prod-cong x₄ x₅ x₆ x₇ _)
-    with decConv↑Term x₂ x₆
-  ... | no ¬P = no λ eq → case prod-cong⁻¹ eq of λ
-    (_ , _ , _ , _ , t , _) → ¬P t
-  ... | yes P with decConv↑TermConv (substTypeEq (refl x₁) (soundnessConv↑Term P)) x₃ x₇
-  ... | yes Q = yes (prod-cong x x₁ P Q ok)
-  ... | no ¬Q = no λ eq → case prod-cong⁻¹ eq of λ
-    (_ , _ , _ , _ , _ , u , _) → ¬Q u
-  decConv↓Term (η-eq {p = p} {f = t} x₁ x₂ x₃ x₄ x₅) (η-eq {f = u} x₇ x₈ x₉ x₁₀ x₁₁)
-    with decConv↑Term x₅ x₁₁
-  ... | yes P =
-    let ⊢F , ⊢G = syntacticΠ (syntacticTerm x₁)
-        G≡G = refl ⊢G
-    in
-    yes (η-eq x₁ x₇ x₃ x₉ $
-         transConv↑Term G≡G x₅
-           (transConv↑Term G≡G (symConvTerm x₅)
-           (transConv↑Term G≡G P
-           (transConv↑Term G≡G x₁₁
-           (symConvTerm x₁₁)))))
-  ... | no ¬P = no (λ { (ne-ins x₁₂ x₁₃ () x₁₅)
-                      ; (η-eq x₁₃ x₁₄ x₁₅ x₁₆ x₁₇) → ¬P x₁₇ })
-  decConv↓Term (Id-ins ⊢v₁ v₁~v₃) (Id-ins ⊢v₂ v₂~v₄) =
-    case dec~↓ v₁~v₃ v₂~v₄ of λ where
-      (no ¬v₁~v₂) → no λ where
-        (Id-ins _ v₁~v₂)  → ¬v₁~v₂ (_ , v₁~v₂)
-        (rfl-refl _)      → case v₂~v₄ of λ { ([~] _ _ ()) }
-        (ne-ins _ _ () _)
-      (yes (_ , v₁~v₂)) →
-        case ne~↓ v₁~v₂ of λ {
-          (B-whnf , v₁-ne , _) →
-        case neTypeEq v₁-ne
-               (syntacticEqTerm (soundness~↓ v₁~v₃) .proj₂ .proj₁)
-               (syntacticEqTerm (soundness~↓ v₁~v₂)
-                  .proj₂ .proj₁) of λ {
-          Id≡B →
-        case Id≡Whnf Id≡B B-whnf of λ {
-          (_ , _ , _ , PE.refl) →
-        yes (Id-ins ⊢v₁ v₁~v₂) }}}
-
-  -- False cases
-  decConv↓Term  (ℕ-ins x) (zero-refl x₁) =
-    no (λ x₂ → decConv↓Term-ℕ x₂ x λ { ([~] _ _ ()) })
-  decConv↓Term  (ℕ-ins x) (suc-cong x₁) =
-    no (λ x₂ → decConv↓Term-ℕ x₂ x (λ { ([~] _ _ ()) }))
-  decConv↓Term  (zero-refl x) (ℕ-ins x₁) =
-    no (λ x₂ → decConv↓Term-ℕ (symConv↓Term′ x₂) x₁ (λ { ([~] _ _ ()) }))
-  decConv↓Term  (zero-refl x) (suc-cong x₁) =
-    no (λ { (ℕ-ins ([~] _ _ ())) ; (ne-ins x₂ x₃ () x₅) })
-  decConv↓Term  (suc-cong x) (ℕ-ins x₁) =
-    no (λ x₂ → decConv↓Term-ℕ (symConv↓Term′ x₂) x₁ (λ { ([~] _ _ ()) }))
-  decConv↓Term  (suc-cong x) (zero-refl x₁) =
-    no (λ { (ℕ-ins ([~] _ _ ())) ; (ne-ins x₂ x₃ () x₅) })
-  decConv↓Term (Unitʷ-ins no-η _) (η-unit _ _ _ _ (inj₂ η)) =
-    ⊥-elim (no-η η)
-  decConv↓Term (η-unit _ _ _ _ (inj₂ η)) (Unitʷ-ins no-η _) =
-    ⊥-elim (no-η η)
-  decConv↓Term (Σʷ-ins x x₁ x₂) (prod-cong x₃ x₄ x₅ x₆ _) =
-    no λ x₇ → decConv↓Term-Σʷ x₇ x₂ (λ{ ()})
-  decConv↓Term (prod-cong x x₁ x₂ x₃ _) (Σʷ-ins x₄ x₅ x₆) =
-    no (λ x₇ → decConv↓Term-Σʷ (symConv↓Term′ x₇) x₆ (λ{ ()}))
-  decConv↓Term (starʷ-refl _ _ no-η) (Unitʷ-ins _ u~) =
-    no λ ≡u → no-η (decConv↓Term-Unit (symConv↓Term′ ≡u) u~)
-  decConv↓Term (Unitʷ-ins _ t~) (starʷ-refl _ _ no-η) =
-    no λ t≡ → no-η (decConv↓Term-Unit t≡ t~)
-  decConv↓Term (Id-ins _ v₁~v₃) (rfl-refl _) =
-    no λ where
-      (Id-ins _ ~rfl)   → case ne~↓ ~rfl  .proj₂ .proj₂ of λ ()
-      (rfl-refl _)      → case ne~↓ v₁~v₃ .proj₂ .proj₁ of λ ()
-      (ne-ins _ _ () _)
-  decConv↓Term (rfl-refl _) (Id-ins _ v₂~v₄) =
-    no λ where
-      (Id-ins _ rfl~)   → case ne~↓ rfl~  .proj₂ .proj₁ of λ ()
-      (rfl-refl _)      → case ne~↓ v₂~v₄ .proj₂ .proj₁ of λ ()
-      (ne-ins _ _ () _)
-
-  -- Impossible cases
-  decConv↓Term (ℕ-ins x) (ne-ins x₁ x₂ () x₄)
-  decConv↓Term (Empty-ins x) (ne-ins x₁ x₂ () x₄)
-  decConv↓Term (Σʷ-ins x x₁ x₂) (ne-ins x₃ x₄ () x₆)
-  decConv↓Term (ne-ins x x₁ () x₃) (ℕ-ins x₄)
-  decConv↓Term (ne-ins x x₁ () x₃) (Empty-ins x₄)
-  decConv↓Term (ne-ins _ _ () _) (Unitʷ-ins _ _)
-  decConv↓Term (ne-ins x x₁ () x₃) (Σʷ-ins x₄ x₅ x₆)
-  decConv↓Term (ne-ins x x₁ () x₃) (univ x₄ x₅ x₆)
-  decConv↓Term (ne-ins x x₁ () x₃) (zero-refl x₄)
-  decConv↓Term (ne-ins x x₁ () x₃) (suc-cong x₄)
-  decConv↓Term (ne-ins x x₁ () x₃) (prod-cong x₄ x₅ x₆ x₇ _)
-  decConv↓Term (ne-ins x x₁ () x₃) (η-eq x₄ x₅ x₆ x₇ x₈)
-  decConv↓Term (ne-ins x x₁ () x₃) (Σ-η x₄ x₅ x₆ x₇ x₈ x₉)
-  decConv↓Term (ne-ins x x₁ () x₃) (η-unit _ _ _ _ _)
-  decConv↓Term (ne-ins _ _ () _) (Id-ins _ _)
-  decConv↓Term (ne-ins _ _ () _) (rfl-refl _)
-  decConv↓Term (univ x x₁ x₂) (ne-ins x₃ x₄ () x₆)
-  decConv↓Term (zero-refl x) (ne-ins x₁ x₂ () x₄)
-  decConv↓Term (rfl-refl _) (ne-ins _ _ () _)
-  decConv↓Term (suc-cong x) (ne-ins x₁ x₂ () x₄)
-  decConv↓Term (prod-cong x x₁ x₂ x₃ _) (ne-ins x₄ x₅ () x₇)
-  decConv↓Term (η-eq x x₁ x₂ x₃ x₄) (ne-ins x₅ x₆ () x₈)
-  decConv↓Term (Σ-η x x₁ x₂ x₃ x₄ x₅) (ne-ins x₆ x₇ () x₉)
-  decConv↓Term (Id-ins _ _) (ne-ins _ _ () _)
-  decConv↓Term (Unitʷ-ins _ _) (η-unit _ _ _ _ (inj₁ ()))
-  decConv↓Term (Unitʷ-ins _ _) (ne-ins _ _ () _)
-  decConv↓Term (ne-ins x x₁ () x₃) (starʷ-refl _ _ _)
-  decConv↓Term (starʷ-refl _ _ _) (ne-ins x₂ x₃ () x₅)
-  decConv↓Term (η-unit _ _ _ _ (inj₁ ())) (Unitʷ-ins _ _)
-  decConv↓Term (η-unit _ _ _ _ _) (ne-ins x₄ x₅ () x₇)
+  decConv↓Term (ne-ins ⊢t _ A-ne t~) u≡ =
+    let _ , u~ = inv-[conv↓]∷-ne A-ne u≡ in
+    case dec~↓ t~ u~ of λ where
+      (yes (_ , t~u)) → yes (ne-ins ⊢t ([conv↓]∷→∷ u≡) A-ne t~u)
+      (no ¬t~u)       → no (¬t~u ∘→ inv-[conv↓]∷-ne A-ne)
+  decConv↓Term (univ ⊢A _ A≡) B≡ =
+    case decConv↓ A≡ (inv-[conv↓]∷-U B≡) of λ where
+      (yes A≡B) → yes (univ ⊢A ([conv↓]∷→∷ B≡) A≡B)
+      (no A≢B)  → no (A≢B ∘→ inv-[conv↓]∷-U)
+  decConv↓Term (η-eq ⊢t _ t-fun _ t0≡) u≡ =
+    let u-fun , _ , u0≡ = inv-[conv↓]∷-Π u≡ in
+    case decConv↑Term t0≡ u0≡ of λ where
+      (yes t0≡u0) → yes (η-eq ⊢t ([conv↓]∷→∷ u≡) t-fun u-fun t0≡u0)
+      (no t0≢u0)  →
+        no λ t≡u →
+        let _ , _ , t0≡u0 = inv-[conv↓]∷-Π t≡u in
+        t0≢u0 t0≡u0
+  decConv↓Term (Σ-η ⊢t _ t-prod _ fst-t≡ snd-t≡) u≡ =
+    let u-prod , _ , fst-u≡ , snd-u≡ = inv-[conv↓]∷-Σˢ u≡ in
+    case
+      (decConv↑Term fst-t≡ fst-u≡
+         ×-dec′ λ fst-t≡fst-u →
+       decConv↑TermConv
+         (substTypeEq
+            (refl (inversion-ΠΣ (syntacticTerm ⊢t) .proj₂ .proj₁))
+            (soundnessConv↑Term fst-t≡fst-u))
+         snd-t≡ snd-u≡)
+      of λ where
+      (yes (fst-t≡fst-u , snd-t≡snd-u)) →
+        yes $
+        Σ-η ⊢t ([conv↓]∷→∷ u≡) t-prod u-prod fst-t≡fst-u snd-t≡snd-u
+      (no not-both-equal) →
+        no λ t≡u →
+        let _ , _ , fst-t≡fst-u , snd-t≡snd-u = inv-[conv↓]∷-Σˢ t≡u in
+        not-both-equal (fst-t≡fst-u , snd-t≡snd-u)
+  decConv↓Term (Σʷ-ins ⊢t _ t~) u≡ = case inv-[conv↓]∷-Σʷ u≡ of λ where
+    (inj₁ (_ , _ , _ , _ , u~)) →
+      case dec~↓ t~ u~ of λ where
+        (yes (_ , t~u)) →
+          yes $
+          Σʷ-ins ⊢t ([conv↓]∷→∷ u≡) $
+          PE.subst (_⊢_~_↓_ _ _ _)
+            (uncurry Σ≡A (~↓→∷→Whnf×≡ t~u ⊢t) .proj₂ .proj₂) t~u
+        (no ¬t~u) → no (¬t~u ∘→ [conv↓]∷Σʷ→~↓ t~)
+    (inj₂ (_ , _ , _ , _ , PE.refl , _)) →
+      no λ t≡prod →
+      let _ , [~] _ _ ~prod = [conv↓]∷Σʷ→~↓ t~ t≡prod in
+      inv-~prod ~prod
+  decConv↓Term (prod-cong ⊢A ⊢B t₁≡ t₂≡ ok) u≡ =
+    case inv-[conv↓]∷-Σʷ u≡ of λ where
+      (inj₁ (_ , _ , _ , _ , u~)) →
+        no λ prod≡u →
+        let _ , [~] _ _ ~prod =
+              [conv↓]∷Σʷ→~↓ u~ (symConv↓Term′ prod≡u)
+        in
+        inv-~prod ~prod
+      (inj₂ (_ , _ , _ , _ , PE.refl , _ , u₁≡ , u₂≡)) →
+        case
+          (decConv↑Term t₁≡ u₁≡
+             ×-dec′ λ t₁≡u₁ →
+           decConv↑TermConv
+             (substTypeEq (refl ⊢B) (soundnessConv↑Term t₁≡u₁))
+             t₂≡ u₂≡)
+          of λ where
+          (yes (t₁≡u₁ , t₂≡u₂)) → yes (prod-cong ⊢A ⊢B t₁≡u₁ t₂≡u₂ ok)
+          (no not-both-equal)   →
+            no λ t≡u →
+            let _ , _ , _ , _ , t₁≡u₁ , t₂≡u₂ , _ = prod-cong⁻¹ t≡u in
+            not-both-equal (t₁≡u₁ , t₂≡u₂)
+  decConv↓Term (Empty-ins t~) u≡ =
+    case dec~↓ t~ (inv-[conv↓]∷-Empty u≡) of λ where
+      (yes (_ , t~u)) →
+        yes $ Empty-ins $
+        PE.subst (_⊢_~_↓_ _ _ _)
+          (uncurry Empty≡A (~↓→∷→Whnf×≡ t~u (~↓→∷ t~))) t~u
+      (no ¬t~u) → no (¬t~u ∘→ (_ ,_) ∘→ inv-[conv↓]∷-Empty)
+  decConv↓Term (Unitʷ-ins no-η t~) u≡ =
+    case inv-[conv↓]∷-Unitʷ u≡ of λ where
+      (inj₁ (_ , inj₁ u~)) → case dec~↓ t~ u~ of λ where
+        (yes (_ , t~u)) →
+          yes $ Unitʷ-ins no-η $
+          PE.subst (_⊢_~_↓_ _ _ _)
+            (uncurry Unit≡A (~↓→∷→Whnf×≡ t~u (~↓→∷ t~))) t~u
+        (no ¬t~u) →
+          no λ t≡u →
+          case inv-[conv↓]∷-Unitʷ t≡u of λ where
+            (inj₁ (_ , inj₁ t~u))           → ¬t~u (_ , t~u)
+            (inj₁ (_ , inj₂ (PE.refl , _))) →
+              let [~] _ _ t~ = t~ in
+              inv-star~ t~
+            (inj₂ (η , _)) → no-η η
+      (inj₁ (_ , inj₂ (PE.refl , _))) →
+        no (no-η ∘→ ≡starʷ→~↓Unitʷ→Unitʷ-η t~)
+      (inj₂ (η , _)) → ⊥-elim (no-η η)
+  decConv↓Term (η-unit ⊢t _ t-whnf _ η) u≡ =
+    case inv-[conv↓]∷-Unit u≡ of λ where
+      (inj₁ (η , u-whnf , _)) →
+        yes (η-unit ⊢t ([conv↓]∷→∷ u≡) t-whnf u-whnf η)
+      (inj₂ (no-η , _)) → ⊥-elim (no-η η)
+  decConv↓Term star≡star@(starʷ-refl _ _ no-η) u≡ =
+    case inv-[conv↓]∷-Unitʷ u≡ of λ where
+      (inj₁ (_ , inj₂ (PE.refl , _))) → yes star≡star
+      (inj₁ (_ , inj₁ u~))            →
+        no (no-η ∘→ ≡starʷ→~↓Unitʷ→Unitʷ-η u~ ∘→ symConv↓Term′)
+      (inj₂ (η , _)) → ⊥-elim (no-η η)
+  decConv↓Term (ℕ-ins t~) u≡ = case inv-[conv↓]∷-ℕ u≡ of λ where
+    (inj₁ u~) → case dec~↓ t~ u~ of λ where
+      (yes (A , t~u)) →
+        yes $ ℕ-ins $
+        PE.subst (_⊢_~_↓_ _ _ _)
+          (uncurry ℕ≡A (~↓→∷→Whnf×≡ t~u (~↓→∷ t~))) t~u
+      (no ¬t~u) → no (¬t~u ∘→ (_ ,_) ∘→ [conv↓]∷ℕ→~↓ℕ t~)
+    (inj₂ (inj₁ (PE.refl , _))) →
+      no λ t≡zero →
+      let [~] _ _ ~zero = [conv↓]∷ℕ→~↓ℕ t~ t≡zero in
+      inv-~zero ~zero
+    (inj₂ (inj₂ (_ , _ , PE.refl , _))) →
+      no λ t≡suc →
+      let [~] _ _ ~suc = [conv↓]∷ℕ→~↓ℕ t~ t≡suc in
+      inv-~suc ~suc
+  decConv↓Term zero≡zero@(zero-refl _) u≡ =
+    case inv-[conv↓]∷-ℕ u≡ of λ where
+      (inj₁ u~) →
+        no λ zero≡t →
+        let [~] _ _ ~zero = [conv↓]∷ℕ→~↓ℕ u~ (symConv↓Term′ zero≡t) in
+        inv-~zero ~zero
+      (inj₂ (inj₁ (PE.refl , _)))         → yes zero≡zero
+      (inj₂ (inj₂ (_ , _ , PE.refl , _))) →
+        no λ zero≡suc →
+        case inv-[conv↓]∷-ℕ zero≡suc of λ where
+          (inj₁ ([~] _ _ zero~suc))      → inv-zero~ zero~suc
+          (inj₂ (inj₁ (_ , ())))
+          (inj₂ (inj₂ (_ , _ , () , _)))
+  decConv↓Term (suc-cong t≡) u≡ = case inv-[conv↓]∷-ℕ u≡ of λ where
+    (inj₁ u~) →
+      no λ suc≡t →
+      let [~] _ _ ~suc = [conv↓]∷ℕ→~↓ℕ u~ (symConv↓Term′ suc≡t) in
+      inv-~suc ~suc
+    (inj₂ (inj₁ (PE.refl , _))) →
+      no λ suc≡zero →
+      case inv-[conv↓]∷-ℕ suc≡zero of λ where
+        (inj₁ ([~] _ _ suc~zero))          → inv-~zero suc~zero
+        (inj₂ (inj₁ (() , _)))
+        (inj₂ (inj₂ (_ , _ , _ , () , _)))
+    (inj₂ (inj₂ (_ , _ , PE.refl , _ , u≡))) →
+      case decConv↑Term t≡ u≡ of λ where
+        (yes t≡u) → yes (suc-cong t≡u)
+        (no t≢u)  →
+          no λ suc-t≡suc-u →
+          case inv-[conv↓]∷-ℕ suc-t≡suc-u of λ where
+            (inj₁ ([~] _ _ suc~suc)) →
+              inv-suc~ suc~suc
+            (inj₂ (inj₁ (() , _)))
+            (inj₂ (inj₂ (_ , _ , PE.refl , PE.refl , t≡u))) →
+              t≢u t≡u
+  decConv↓Term (Id-ins ⊢t t~) u≡ = case inv-[conv↓]∷-Id u≡ of λ where
+    (inj₁ (_ , _ , _ , u~)) →
+      case dec~↓ t~ u~ of λ where
+        (yes (_ , t~u)) →
+          yes $
+          Id-ins ⊢t $
+          PE.subst (_⊢_~_↓_ _ _ _)
+            (uncurry Id≡Whnf (~↓→∷→Whnf×≡ t~u (~↓→∷ t~))
+               .proj₂ .proj₂ .proj₂)
+            t~u
+        (no ¬t~u) →
+          no λ t≡u →
+          case inv-[conv↓]∷-Id t≡u of λ where
+            (inj₁ (_ , _ , _ , t~u)) → ¬t~u (_ , t~u)
+            (inj₂ (_ , PE.refl , _)) →
+              let [~] _ _ rfl~ = u~ in
+              inv-rfl~ rfl~
+    (inj₂ (PE.refl , _)) →
+      no λ rfl≡u →
+      ¬-Neutral-rfl $
+      case inv-[conv↓]∷-Id rfl≡u of λ where
+        (inj₁ (_ , _ , _ , t~rfl)) → ne~↓ t~rfl .proj₂ .proj₂
+        (inj₂ (PE.refl , _))       → ne~↓ t~ .proj₂ .proj₁
+  decConv↓Term rfl≡rfl@(rfl-refl _) u≡ =
+    case inv-[conv↓]∷-Id u≡ of λ where
+      (inj₁ (_ , _ , _ , u~)) →
+        no λ rfl≡u →
+        ¬-Neutral-rfl $
+        case inv-[conv↓]∷-Id rfl≡u of λ where
+          (inj₁ (_ , _ , _ , rfl~u)) → ne~↓ rfl~u .proj₂ .proj₁
+          (inj₂ (_ , PE.refl , _))   → ne~↓ u~ .proj₂ .proj₁
+      (inj₂ (PE.refl , _)) → yes rfl≡rfl
 
   -- Decidability of algorithmic equality of terms of equal types.
   decConv↑TermConv : ∀ {t u A B t′ u′}

--- a/Definition/Conversion/Decidable.agda
+++ b/Definition/Conversion/Decidable.agda
@@ -150,9 +150,9 @@ private opaque
         , PE.subst (flip (_⊢_~_↑_ _ _) _)
             (PE.cong (_ ∘⟨_⟩ _) p₁≡p₂)
             (app-cong (PE.subst (_⊢_~_↓_ _ _ _) C≡Π t₁~u₁)
-               (convConvTerm t₂≡u₂ $
-                ΠΣ-injectivity (PE.subst (_⊢_≡_ _ _) C≡Π Π≡C)
-                  .proj₁))
+               (convConv↑Term
+                  (ΠΣ-injectivity (PE.subst (_⊢_≡_ _ _) C≡Π Π≡C) .proj₁)
+                  t₂≡u₂))
       (no t₂≢u₂) →
         no λ (_ , t~u) →
         let _ , _ , _ , _ , _ , _ , u≡∘ , t₁~ , t₂≡ = inv-∘~ t~u
@@ -161,8 +161,8 @@ private opaque
             Π≡Π = neTypeEq t₁-ne ⊢t₁ (~↓→∷ t₁~)
         in
         t₂≢u₂ $
-        convConvTerm (PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡u₂ t₂≡)
-          (sym (ΠΣ-injectivity Π≡Π .proj₁))
+        convConv↑Term (sym (ΠΣ-injectivity Π≡Π .proj₁)) $
+        PE.subst (flip (_⊢_[conv↑]_∷_ _ _) _) ≡u₂ t₂≡
   dec~↑-app-cong _ _ (no ¬t₁~u₁) _ =
     no λ (_ , t~u) →
     let _ , _ , _ , _ , _ , _ , u≡∘ , t₁~ , _ = inv-∘~ t~u
@@ -712,7 +712,7 @@ mutual
       dec~↑-prodrec-cong (~↓→∷ t₁~) (~↓→∷ u₁~)
         (_ ≟ _ ×-dec _ ≟ _ ×-dec dec~↓ t₁~ u₁~)
         (λ eq → decConv↑′ eq B≡ C≡)
-        (λ eq₁ eq₂ → decConv↑Term t₂≡ (convConv↑Term eq₁ eq₂ u₂≡))
+        (λ eq₁ eq₂ → decConv↑Term t₂≡ (convConv↑Term′ eq₁ eq₂ u₂≡))
     (inj₂ (u≢pr , _)) →
       no λ (_ , t~u) →
       let _ , _ , _ , _ , _ , _ , _ , u≡pr , _ = inv-prodrec~ t~u in
@@ -746,7 +746,7 @@ mutual
           (_ ≟ _ ×-dec _ ≟ _ ×-dec _ ≟ _ ×-dec decConv↑ B≡ C≡ ×-dec
            dec~↓ t₃~ u₃~)
           (λ eq → decConv↑TermConv eq t₁≡ u₁≡)
-          (λ eq₁ eq₂ → decConv↑Term t₂≡ (convConv↑Term eq₁ eq₂ u₂≡))
+          (λ eq₁ eq₂ → decConv↑Term t₂≡ (convConv↑Term′ eq₁ eq₂ u₂≡))
       (inj₂ (u≢nr , _)) →
         no λ (_ , t~u) →
         let _ , _ , _ , _ , _ , u≡nr , _ = inv-natrec~ t~u in
@@ -894,8 +894,8 @@ mutual
          (_ , _ , _ , _ , _ , _ ,
           PE.refl , PE.refl , B′≡ , u₁≡ , u₂≡)) →
         decConv↓-Id (decConv↑ A′≡ B′≡)
-          (λ A′≡B′ → decConv↑Term t₁≡ (convConvTerm u₁≡ A′≡B′))
-          (λ A′≡B′ → decConv↑Term t₂≡ (convConvTerm u₂≡ A′≡B′))
+          (λ A′≡B′ → decConv↑Term t₁≡ (convConv↑Term A′≡B′ u₁≡))
+          (λ A′≡B′ → decConv↑Term t₂≡ (convConv↑Term A′≡B′ u₂≡))
       (inj₂ (B≢Id , _)) →
         no λ Id≡B →
         let _ , _ , _ , B≡Id , _ = inv-[conv↓]-Id Id≡B in
@@ -1129,4 +1129,4 @@ mutual
                 → Γ ⊢ u [conv↑] u′ ∷ B
                 → Dec (Γ ⊢ t [conv↑] u ∷ A)
   decConv↑TermConv A≡B t u =
-    decConv↑Term t (convConvTerm u (sym A≡B))
+    decConv↑Term t (convConv↑Term (sym A≡B) u)

--- a/Definition/Conversion/Decidable.agda
+++ b/Definition/Conversion/Decidable.agda
@@ -125,7 +125,7 @@ decConv↓Term-ne-ins () (univ x x₁ x₂)
 decConv↓Term-ne-ins () (zero-refl x)
 decConv↓Term-ne-ins () (suc-cong x)
 decConv↓Term-ne-ins () (η-eq x₁ x₂ x₃ x₄ x₅)
-decConv↓Term-ne-ins () (Unit-ins x)
+decConv↓Term-ne-ins () (Unitʷ-ins _ _)
 decConv↓Term-ne-ins () (Σʷ-ins x x₁ x₂)
 decConv↓Term-ne-ins () (prod-cong _ _ _ _ _)
 decConv↓Term-ne-ins () (Σ-η x x₁ x₂ x₃ x₄ x₅)
@@ -160,7 +160,7 @@ decConv↓Term-Unit : ∀ {t t′}
               → Γ ⊢ t [conv↓] starʷ ∷ Unitʷ
               → Γ ⊢ t ~ t′ ↓ Unitʷ
               → Unitʷ-η
-decConv↓Term-Unit (Unit-ins ()) ([~] _ _ k~l)
+decConv↓Term-Unit (Unitʷ-ins _ ()) ([~] _ _ _)
 decConv↓Term-Unit (η-unit _ _ _ _ (inj₁ ())) ([~] _ _ _)
 decConv↓Term-Unit (η-unit _ _ _ _ (inj₂ η)) ([~] _ _ _) = η
 decConv↓Term-Unit (ne-ins x x₁ () x₃) ([~] _ _ k~l)
@@ -895,14 +895,6 @@ mutual
   decConv↓Term (starʷ-refl _ _ _) (η-unit _ _ _ _ (inj₁ ()))
   decConv↓Term (starʷ-refl _ _ no-η) (η-unit _ _ _ _ (inj₂ η)) =
     ⊥-elim (no-η η)
-  decConv↓Term (Unit-ins t~t′) (η-unit ⊢u _ uUnit _ ok) =
-    let _ , neT , _ = ne~↓ t~t′
-        _ , ⊢t , _ = syntacticEqTerm (soundness~↓ t~t′)
-    in  yes (η-unit ⊢t ⊢u (ne neT) uUnit ok)
-  decConv↓Term (η-unit ⊢t _ tUnit _ ok) (Unit-ins u~u′) =
-    let _ , neU , _ = ne~↓ u~u′
-        _ , ⊢u , _ = syntacticEqTerm (soundness~↓ u~u′)
-    in  yes (η-unit ⊢t ⊢u tUnit (ne neU) ok)
   decConv↓Term (η-unit ⊢t _ tUnit _ ok) (η-unit ⊢u _ uUnit _ _) =
     yes (η-unit ⊢t ⊢u tUnit uUnit ok)
   decConv↓Term (η-unit _ _ _ _ (inj₁ ())) (starʷ-refl _ _ _)
@@ -933,34 +925,33 @@ mutual
     in  yes (Empty-ins k~l′)
   decConv↓Term (Empty-ins x) (Empty-ins x₁) | no ¬p =
     no (λ x₂ → ¬p (Empty , decConv↓Term-Empty-ins x₂ x))
-  decConv↓Term (Unit-ins {s = 𝕨} x) (Unit-ins x₁) with dec~↓ x x₁
-  ... | yes (A , k~l) =
-    let whA , neT , neU = ne~↓ k~l
-        _ , ⊢t , _ = syntacticEqTerm (soundness~↓ k~l)
-        _ , ⊢t′ , _ = syntacticEqTerm (soundness~↓ x)
-        A≡Unit = neTypeEq neT ⊢t′ ⊢t
-        k~l′ = PE.subst (λ x → _ ⊢ _ ~ _ ↓ x)
-                        (Unit≡A A≡Unit whA) k~l
-    in yes (Unit-ins k~l′)
-  ... | no ¬p =
+  decConv↓Term (Unitʷ-ins no-η t~t′) (Unitʷ-ins _ u~u′)
+    with dec~↓ t~t′ u~u′
+  ... | yes (A , t~u) =
+    case ne~↓ t~u of λ
+      (A-whnf , t-ne , _) →
+    yes $
+    Unitʷ-ins no-η $
+    PE.subst (_⊢_~_↓_ _ _ _)
+      (Unit≡A
+         (neTypeEq t-ne
+            (syntacticEqTerm (soundness~↓ t~t′) .proj₂ .proj₁)
+            (syntacticEqTerm (soundness~↓ t~u) .proj₂ .proj₁))
+         A-whnf)
+      t~u
+  ... | no ¬t~u =
     case Unitʷ-η? of λ where
       (no no-η) → no λ where
-        (Unit-ins x) → ¬p (_ , x)
+        (Unitʷ-ins _ t~u)          → ¬t~u (_ , t~u)
         (η-unit _ _ _ _ (inj₁ ()))
-        (η-unit _ _ _ _ (inj₂ η)) → no-η η
+        (η-unit _ _ _ _ (inj₂ η))  → no-η η
       (yes η) → yes $
         η-unit
-          (syntacticEqTerm (soundness~↓ x) .proj₂ .proj₁)
-          (syntacticEqTerm (soundness~↓ x₁) .proj₂ .proj₁)
-          (ne (ne~↓ x .proj₂ .proj₁))
-          (ne (ne~↓ x₁ .proj₂ .proj₁))
+          (syntacticEqTerm (soundness~↓ t~t′) .proj₂ .proj₁)
+          (syntacticEqTerm (soundness~↓ u~u′) .proj₂ .proj₁)
+          (ne (ne~↓ t~t′ .proj₂ .proj₁))
+          (ne (ne~↓ u~u′ .proj₂ .proj₁))
           (inj₂ η)
-  decConv↓Term (Unit-ins {s = 𝕤} t~t′) (Unit-ins u~u′) =
-    let _ , neT , _ = ne~↓ t~t′
-        _ , ⊢t , _ = syntacticEqTerm (soundness~↓ t~t′)
-        _ , neU , _ = ne~↓ u~u′
-        _ , ⊢u , _ = syntacticEqTerm (soundness~↓ u~u′)
-    in  yes (η-unit ⊢t ⊢u (ne neT) (ne neU) (inj₁ PE.refl))
   decConv↓Term (Σʷ-ins x x₁ x₂) (Σʷ-ins x₃ x₄ x₅) with dec~↓ x₂ x₅
   ... | yes (B , t~u) =
     let ⊢B , ⊢t , ⊢u = syntacticEqTerm (soundness~↓ t~u)
@@ -1051,14 +1042,18 @@ mutual
     no (λ x₂ → decConv↓Term-ℕ (symConv↓Term′ x₂) x₁ (λ { ([~] _ _ ()) }))
   decConv↓Term  (suc-cong x) (zero-refl x₁) =
     no (λ { (ℕ-ins ([~] _ _ ())) ; (ne-ins x₂ x₃ () x₅) })
+  decConv↓Term (Unitʷ-ins no-η _) (η-unit _ _ _ _ (inj₂ η)) =
+    ⊥-elim (no-η η)
+  decConv↓Term (η-unit _ _ _ _ (inj₂ η)) (Unitʷ-ins no-η _) =
+    ⊥-elim (no-η η)
   decConv↓Term (Σʷ-ins x x₁ x₂) (prod-cong x₃ x₄ x₅ x₆ _) =
     no λ x₇ → decConv↓Term-Σʷ x₇ x₂ (λ{ ()})
   decConv↓Term (prod-cong x x₁ x₂ x₃ _) (Σʷ-ins x₄ x₅ x₆) =
     no (λ x₇ → decConv↓Term-Σʷ (symConv↓Term′ x₇) x₆ (λ{ ()}))
-  decConv↓Term (starʷ-refl _ _ no-η) (Unit-ins x₂) =
-    no λ y → no-η (decConv↓Term-Unit (symConv↓Term′ y) x₂)
-  decConv↓Term (Unit-ins x) (starʷ-refl _ _ no-η) =
-    no λ y → no-η (decConv↓Term-Unit y x)
+  decConv↓Term (starʷ-refl _ _ no-η) (Unitʷ-ins _ u~) =
+    no λ ≡u → no-η (decConv↓Term-Unit (symConv↓Term′ ≡u) u~)
+  decConv↓Term (Unitʷ-ins _ t~) (starʷ-refl _ _ no-η) =
+    no λ t≡ → no-η (decConv↓Term-Unit t≡ t~)
   decConv↓Term (Id-ins _ v₁~v₃) (rfl-refl _) =
     no λ where
       (Id-ins _ ~rfl)   → case ne~↓ ~rfl  .proj₂ .proj₂ of λ ()
@@ -1076,7 +1071,7 @@ mutual
   decConv↓Term (Σʷ-ins x x₁ x₂) (ne-ins x₃ x₄ () x₆)
   decConv↓Term (ne-ins x x₁ () x₃) (ℕ-ins x₄)
   decConv↓Term (ne-ins x x₁ () x₃) (Empty-ins x₄)
-  decConv↓Term (ne-ins x x₁ () x₃) (Unit-ins x₄)
+  decConv↓Term (ne-ins _ _ () _) (Unitʷ-ins _ _)
   decConv↓Term (ne-ins x x₁ () x₃) (Σʷ-ins x₄ x₅ x₆)
   decConv↓Term (ne-ins x x₁ () x₃) (univ x₄ x₅ x₆)
   decConv↓Term (ne-ins x x₁ () x₃) (zero-refl x₄)
@@ -1095,9 +1090,11 @@ mutual
   decConv↓Term (η-eq x x₁ x₂ x₃ x₄) (ne-ins x₅ x₆ () x₈)
   decConv↓Term (Σ-η x x₁ x₂ x₃ x₄ x₅) (ne-ins x₆ x₇ () x₉)
   decConv↓Term (Id-ins _ _) (ne-ins _ _ () _)
-  decConv↓Term (Unit-ins x) (ne-ins x₁ x₂ () x₄)
+  decConv↓Term (Unitʷ-ins _ _) (η-unit _ _ _ _ (inj₁ ()))
+  decConv↓Term (Unitʷ-ins _ _) (ne-ins _ _ () _)
   decConv↓Term (ne-ins x x₁ () x₃) (starʷ-refl _ _ _)
   decConv↓Term (starʷ-refl _ _ _) (ne-ins x₂ x₃ () x₅)
+  decConv↓Term (η-unit _ _ _ _ (inj₁ ())) (Unitʷ-ins _ _)
   decConv↓Term (η-unit _ _ _ _ _) (ne-ins x₄ x₅ () x₇)
 
   -- Decidability of algorithmic equality of terms of equal types.

--- a/Definition/Conversion/Decidable.agda
+++ b/Definition/Conversion/Decidable.agda
@@ -22,6 +22,7 @@ open import Definition.Untyped.Properties M
 open import Definition.Typed R
 open import Definition.Typed.Properties R
 open import Definition.Conversion R
+open import Definition.Conversion.Inversion R
 open import Definition.Conversion.Whnf R
 open import Definition.Conversion.Soundness R
 open import Definition.Conversion.Symmetry R
@@ -112,27 +113,6 @@ decConv↓Term-Σʷ-ins : ∀ {t t′ u F G H E}
 decConv↓Term-Σʷ-ins (Σʷ-ins x x₁ x₂) t~t = _ , x₂
 decConv↓Term-Σʷ-ins (prod-cong _ _ _ _ _) ()
 decConv↓Term-Σʷ-ins (ne-ins x x₁ () x₃) t~t
-
--- Helper function for decidability for neutrals of a neutral type.
-decConv↓Term-ne-ins : ∀ {t u A}
-                    → Neutral A
-                    → Γ ⊢ t [conv↓] u ∷ A
-                    → ∃ λ B → Γ ⊢ t ~ u ↓ B
-decConv↓Term-ne-ins () (ℕ-ins x)
-decConv↓Term-ne-ins () (Empty-ins x)
-decConv↓Term-ne-ins neA (ne-ins x x₁ x₂ x₃) = _ , x₃
-decConv↓Term-ne-ins () (univ x x₁ x₂)
-decConv↓Term-ne-ins () (zero-refl x)
-decConv↓Term-ne-ins () (suc-cong x)
-decConv↓Term-ne-ins () (η-eq x₁ x₂ x₃ x₄ x₅)
-decConv↓Term-ne-ins () (Unitʷ-ins _ _)
-decConv↓Term-ne-ins () (Σʷ-ins x x₁ x₂)
-decConv↓Term-ne-ins () (prod-cong _ _ _ _ _)
-decConv↓Term-ne-ins () (Σ-η x x₁ x₂ x₃ x₄ x₅)
-decConv↓Term-ne-ins () (η-unit _ _ _ _ _)
-decConv↓Term-ne-ins () (starʷ-refl _ _ _)
-decConv↓Term-ne-ins () (Id-ins _ _)
-decConv↓Term-ne-ins () (rfl-refl _)
 
 -- Helper function for decidability for impossibility of terms not being equal
 -- as neutrals when they are equal as terms and the first is a neutral.
@@ -965,7 +945,7 @@ mutual
   decConv↓Term (ne-ins x x₁ x₂ x₃) (ne-ins x₄ x₅ x₆ x₇) | yes (A , k~l) =
     yes (ne-ins x x₄ x₆ k~l)
   decConv↓Term (ne-ins x x₁ x₂ x₃) (ne-ins x₄ x₅ x₆ x₇) | no ¬p =
-    no (λ x₈ → ¬p (decConv↓Term-ne-ins x₆ x₈))
+    no (λ x₈ → ¬p (inv-[conv↓]∷-ne x₆ x₈))
   decConv↓Term (univ x x₁ x₂) (univ x₃ x₄ x₅)
                with decConv↓  x₂ x₅
   decConv↓Term (univ x x₁ x₂) (univ x₃ x₄ x₅) | yes p =

--- a/Definition/Conversion/Decidable.agda
+++ b/Definition/Conversion/Decidable.agda
@@ -605,7 +605,6 @@ private opaque
   -- A lemma used below.
 
   decConv↓-ΠΣ :
-    Γ ⊢ A₁ →
     ΠΣ-allowed b₁ p₁ q₁ →
     Dec
       (b₁ PE.≡ b₂ × p₁ PE.≡ p₂ × q₁ PE.≡ q₂ ×
@@ -614,16 +613,19 @@ private opaque
     Dec
       (Γ ⊢ ΠΣ⟨ b₁ ⟩ p₁ , q₁ ▷ A₁ ▹ B₁ [conv↓]
          ΠΣ⟨ b₂ ⟩ p₂ , q₂ ▷ A₂ ▹ B₂)
-  decConv↓-ΠΣ ⊢A₁ ok (yes (PE.refl , PE.refl , PE.refl , A₁≡A₂)) dec =
-    case dec (reflConEq (wf ⊢A₁) ∙ soundnessConv↑ A₁≡A₂) of λ where
-      (yes B₁≡B₂) → yes (ΠΣ-cong ⊢A₁ A₁≡A₂ B₁≡B₂ ok)
+  decConv↓-ΠΣ ok (yes (PE.refl , PE.refl , PE.refl , A₁≡A₂)) dec =
+    case
+      (let A₁≡A₂ = soundnessConv↑ A₁≡A₂ in
+       dec (reflConEq (wfEq A₁≡A₂) ∙ A₁≡A₂))
+      of λ where
+      (yes B₁≡B₂) → yes (ΠΣ-cong A₁≡A₂ B₁≡B₂ ok)
       (no B₁≢B₂)  →
         no λ ΠΣ≡ΠΣ →
         let _ , _ , ΠΣ≡ΠΣ , _ , B₁≡ = inv-[conv↓]-ΠΣ ΠΣ≡ΠΣ
             _ , _ , _ , _ , ≡B₂     = ΠΣ-PE-injectivity (PE.sym ΠΣ≡ΠΣ)
         in
         B₁≢B₂ (PE.subst (_⊢_[conv↑]_ _ _) ≡B₂ B₁≡)
-  decConv↓-ΠΣ _ _ (no not-all-equal) _ =
+  decConv↓-ΠΣ _ (no not-all-equal) _ =
     no λ ΠΣ≡ΠΣ →
     let _ , _ , ΠΣ≡ΠΣ , A₁≡ , _         = inv-[conv↓]-ΠΣ ΠΣ≡ΠΣ
         b₁≡b₂ , p₁≡p₂ , q₁≡q₂ , ≡A₂ , _ =
@@ -855,11 +857,11 @@ mutual
     case inv-[conv↓]-U′ B≡ of λ where
       (inj₁ (PE.refl , _)) → yes U≡U
       (inj₂ (B≢U , _))     → no (B≢U ∘→ inv-[conv↓]-U)
-  decConv↓ (ΠΣ-cong ⊢A₁ A₁≡ A₂≡ ok) B≡ =
+  decConv↓ (ΠΣ-cong A₁≡ A₂≡ ok) B≡ =
     case inv-[conv↓]-ΠΣ′ B≡ of λ where
       (inj₁
          (_ , _ , _ , _ , _ , _ , _ , PE.refl , PE.refl , B₁≡ , B₂≡)) →
-        decConv↓-ΠΣ ⊢A₁ ok
+        decConv↓-ΠΣ ok
           (decBinderMode _ _ ×-dec _ ≟ _ ×-dec _ ≟ _ ×-dec
            decConv↑ A₁≡ B₁≡)
           (λ eq → decConv↑′ eq A₂≡ B₂≡)
@@ -980,7 +982,7 @@ mutual
       no λ t≡prod →
       let _ , [~] _ _ ~prod = [conv↓]∷Σʷ→~↓ t~ t≡prod in
       inv-~prod ~prod
-  decConv↓Term (prod-cong ⊢A ⊢B t₁≡ t₂≡ ok) u≡ =
+  decConv↓Term (prod-cong ⊢B t₁≡ t₂≡ ok) u≡ =
     case inv-[conv↓]∷-Σʷ u≡ of λ where
       (inj₁ (_ , _ , _ , _ , u~)) →
         no λ prod≡u →
@@ -996,10 +998,10 @@ mutual
              (substTypeEq (refl ⊢B) (soundnessConv↑Term t₁≡u₁))
              t₂≡ u₂≡)
           of λ where
-          (yes (t₁≡u₁ , t₂≡u₂)) → yes (prod-cong ⊢A ⊢B t₁≡u₁ t₂≡u₂ ok)
+          (yes (t₁≡u₁ , t₂≡u₂)) → yes (prod-cong ⊢B t₁≡u₁ t₂≡u₂ ok)
           (no not-both-equal)   →
             no λ t≡u →
-            let _ , _ , _ , _ , t₁≡u₁ , t₂≡u₂ , _ = prod-cong⁻¹ t≡u in
+            let _ , _ , _ , t₁≡u₁ , t₂≡u₂ , _ = prod-cong⁻¹ t≡u in
             not-both-equal (t₁≡u₁ , t₂≡u₂)
   decConv↓Term (Empty-ins t~) u≡ =
     case dec~↓ t~ (inv-[conv↓]∷-Empty u≡) of λ where

--- a/Definition/Conversion/EqRelInstance.agda
+++ b/Definition/Conversion/EqRelInstance.agda
@@ -343,8 +343,8 @@ eqRelInstance = record {
           (redₜ uRed , uWhnf)
           (redₜ u'Red , u'Whnf)
           (η-unit [u] [u'] uWhnf u'Whnf ok);
-  ≅-ΠΣ-cong = λ x x₁ x₂ ok → liftConv (ΠΣ-cong x x₁ x₂ ok);
-  ≅ₜ-ΠΣ-cong = λ x x₁ x₂ ok →
+  ≅-ΠΣ-cong = λ _ x₁ x₂ ok → liftConv (ΠΣ-cong x₁ x₂ ok);
+  ≅ₜ-ΠΣ-cong = λ _ x₁ x₂ ok →
     let _ , F∷U , H∷U = syntacticEqTerm (soundnessConv↑Term x₁)
         _ , G∷U , E∷U = syntacticEqTerm (soundnessConv↑Term x₂)
         ⊢Γ = wfTerm F∷U
@@ -354,12 +354,12 @@ eqRelInstance = record {
         E∷U′ = stabilityTerm (reflConEq ⊢Γ ∙ F≡H) E∷U
     in
     liftConvTerm $
-    univ (ΠΣⱼ F∷U G∷U ok) (ΠΣⱼ H∷U E∷U′ ok) (ΠΣ-cong x F<>H G<>E ok);
+    univ (ΠΣⱼ F∷U G∷U ok) (ΠΣⱼ H∷U E∷U′ ok) (ΠΣ-cong F<>H G<>E ok);
   ≅ₜ-zerorefl = liftConvTerm ∘ᶠ zero-refl;
   ≅ₜ-starrefl = λ x x₁ → liftConvTerm (star-refl x x₁);
   ≅-suc-cong = liftConvTerm ∘ᶠ suc-cong;
-  ≅-prod-cong = λ x x₁ x₂ x₃ x₄ →
-                  liftConvTerm (prod-cong x x₁ x₂ x₃ x₄);
+  ≅-prod-cong = λ _ x₁ x₂ x₃ x₄ →
+                  liftConvTerm (prod-cong x₁ x₂ x₃ x₄);
   ≅-η-eq = λ x x₁ x₂ x₃ x₄ x₅ → liftConvTerm (η-eq x₁ x₂ x₃ x₄ x₅);
   ≅-Σ-η = λ x x₁ x₂ x₃ x₄ x₅ x₆ x₇ → (liftConvTerm (Σ-η x₂ x₃ x₄ x₅ x₆ x₇));
   ~-var = ~-var;

--- a/Definition/Conversion/EqRelInstance.agda
+++ b/Definition/Conversion/EqRelInstance.agda
@@ -94,7 +94,7 @@ record _⊢_~_∷_ (Γ : Con Term n) (k l A : Term n) : Set a where
     (app-cong
        (PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) B≡ΠHE
           ([~] _ (red D , whnfB′) x))
-       (convConvTerm x₁ F≡H)) }}
+       (convConv↑Term F≡H x₁)) }}
 
 ~-fst :
   ∀ {p r F G} →
@@ -300,7 +300,7 @@ opaque
 
 ~-to-conv : ∀ {k l A} →
       Γ ⊢ k ~ l ∷ A → Γ ⊢ k [conv↑] l ∷ A
-~-to-conv (↑ x x₁) = convConvTerm (lift~toConv↑ x₁) (sym x)
+~-to-conv (↑ x x₁) = convConv↑Term (sym x) (lift~toConv↑ x₁)
 
 
 -- Algorithmic equality instance of the generic equality relation.
@@ -319,7 +319,7 @@ eqRelInstance = record {
   ≅-trans = transConv;
   ≅ₜ-trans = transConvTerm;
   ~-trans = ~-trans;
-  ≅-conv = convConvTerm;
+  ≅-conv = flip convConv↑Term;
   ~-conv = ~-conv;
   ≅-wk = wkConv↑;
   ≅ₜ-wk = wkConv↑Term;

--- a/Definition/Conversion/FullReduction.agda
+++ b/Definition/Conversion/FullReduction.agda
@@ -108,7 +108,7 @@ mutual
       , (                                             $⟨ u′-nf ⟩
          Γ ∙ ℕ ∙ A ⊢nf u′ ∷ A [ suc (var x1) ]↑²      →⟨ ⊢nf∷-stable (reflConEq (⊢Γ ∙ ℕⱼ ⊢Γ) ∙ A≡A′) ⟩
          Γ ∙ ℕ ∙ A′ ⊢nf u′ ∷ A [ suc (var x1) ]↑²     →⟨ flip _⊢nf_∷_.convₙ $
-                                                         subst↑²TypeEq (ℕⱼ ⊢Γ) ⊢A′ A≡A′ (refl (sucⱼ (var₁ ⊢A′))) ⟩
+                                                         subst↑²TypeEq A≡A′ (refl (sucⱼ (var₁ ⊢A′))) ⟩
          Γ ∙ ℕ ∙ A′ ⊢nf u′ ∷ A′ [ suc (var x1) ]↑²    →⟨ (λ hyp → natrecₙ
                                                             A′-nf
                                                             (convₙ t′-nf (substTypeEq A≡A′ (refl (zeroⱼ ⊢Γ))))

--- a/Definition/Conversion/FullReduction.agda
+++ b/Definition/Conversion/FullReduction.agda
@@ -309,8 +309,10 @@ mutual
       case fullRedNe~↓ t~ of λ {
         (u , u-nf , t≡u) →
       u , neₙ Emptyₙ u-nf , t≡u }
-    (Unit-ins {s} t~) →
-      fullRedTermConv↓-Unit-ins t~ (Unit-with-η? s)
+    (Unitʷ-ins no-η t~) →
+      case fullRedNe~↓ t~ of λ
+        (u , u-nf , t≡u) →
+      u , neₙ (Unitʷₙ no-η) u-nf , t≡u
     (Σʷ-ins ⊢t∷ΣAB _ t~) →
       case fullRedNe~↓ t~ of λ {
         (v , v-ne , t≡v) →
@@ -417,26 +419,6 @@ mutual
         rfl
       , convₙ (rflₙ ⊢t) (Id-cong (refl ⊢A) (refl ⊢t) t≡u)
       , refl (rflⱼ′ t≡u) }
-
-  fullRedTermConv↓-Unit-ins :
-    Γ ⊢ t ~ t′ ↓ Unit s →
-    Unit-with-η s ⊎ s PE.≡ 𝕨 × ¬ Unitʷ-η →
-    ∃ λ u → Γ ⊢nf u ∷ Unit s × Γ ⊢ t ≡ u ∷ Unit s
-  fullRedTermConv↓-Unit-ins {s} t~ = λ where
-    (inj₁ η) →
-      case syntacticEqTerm (soundness~↓ t~) of λ
-        (_ , ⊢t , _) →
-      case wfTerm ⊢t of λ
-        ⊢Γ →
-      case ⊢∷Unit→Unit-allowed ⊢t of λ
-        Unit-ok →
-        star s
-      , starₙ ⊢Γ Unit-ok
-      , η-unit ⊢t (starⱼ ⊢Γ Unit-ok) η
-    (inj₂ (PE.refl , no-η)) →
-      case fullRedNe~↓ t~ of λ
-        (u , u-nf , t≡u) →
-      u , neₙ (Unitʷₙ no-η) u-nf , t≡u
 
 -- If A is a well-formed type, then A is definitionally equal to a
 -- type in η-long normal form.

--- a/Definition/Conversion/FullReduction.agda
+++ b/Definition/Conversion/FullReduction.agda
@@ -266,14 +266,14 @@ mutual
       case fullRedNe~↓ A~ of λ {
         (B , B-ne , A≡B) →
       B , univₙ (neₙ Uₙ B-ne) , univ A≡B }
-    (ΠΣ-cong ⊢A A↑ B↑ ok) →
+    (ΠΣ-cong A↑ B↑ ok) →
       case fullRedConv↑ A↑ of λ {
         (A′ , A′-nf , A≡A′) →
       case fullRedConv↑ B↑ of λ {
         (B′ , B′-nf , B≡B′) →
       ΠΣ⟨ _ ⟩ _ , _ ▷ A′ ▹ B′ ,
       ΠΣₙ A′-nf (⊢nf-stable (reflConEq (wfEq A≡A′) ∙ A≡A′) B′-nf) ok ,
-      ΠΣ-cong ⊢A A≡A′ B≡B′ ok }}
+      ΠΣ-cong′ A≡A′ B≡B′ ok }}
     (Id-cong A₁≡A₂ t₁≡t₂ u₁≡u₂) →
       case fullRedConv↑ A₁≡A₂ of λ {
         (A₁′ , ⊢A₁′ , A₁≡A₁′) →
@@ -357,11 +357,13 @@ mutual
       case fullRedTermConv↑ t↑ of λ {
         (u , u-nf , t≡u) →
       suc u , sucₙ u-nf , suc-cong t≡u }
-    (prod-cong {p = p} {q = q} {F = A} {G = B} {t = t} ⊢A ⊢B t↑ u↑ ok) →
+    (prod-cong {p} {q} {F = A} {G = B} {t} ⊢B t↑ u↑ ok) →
       case fullRedTermConv↑ t↑ of λ {
         (t′ , t′-nf , t≡t′) →
       case fullRedTermConv↑ u↑ of λ {
         (u′ , u′-nf , u≡u′) →
+      case syntacticEqTerm t≡t′ of λ
+        (⊢A , _) →
         prod! t′ u′
       , (                                      $⟨ u′-nf ⟩
          Γ ⊢nf u′ ∷ B [ t ]₀                   →⟨ flip _⊢nf_∷_.convₙ $

--- a/Definition/Conversion/Inversion.agda
+++ b/Definition/Conversion/Inversion.agda
@@ -886,13 +886,13 @@ opaque
     Γ ⊢ A [conv↓] B →
     Γ ⊢ A ~ B ↓ U ⊎ ¬ Neutral A × ¬ Neutral B
   inv-[conv↓]-ne′ = λ where
-    (ne A~B)          → inj₁ A~B
-    (U-refl _)        → inj₂ (¬-Neutral-U     , ¬-Neutral-U)
-    (ΠΣ-cong _ _ _ _) → inj₂ (¬-Neutral-ΠΣ    , ¬-Neutral-ΠΣ)
-    (Empty-refl _)    → inj₂ (¬-Neutral-Empty , ¬-Neutral-Empty)
-    (Unit-refl _ _)   → inj₂ (¬-Neutral-Unit  , ¬-Neutral-Unit)
-    (ℕ-refl _)        → inj₂ (¬-Neutral-ℕ     , ¬-Neutral-ℕ)
-    (Id-cong _ _ _)   → inj₂ (¬-Neutral-Id    , ¬-Neutral-Id)
+    (ne A~B)        → inj₁ A~B
+    (U-refl _)      → inj₂ (¬-Neutral-U     , ¬-Neutral-U)
+    (ΠΣ-cong _ _ _) → inj₂ (¬-Neutral-ΠΣ    , ¬-Neutral-ΠΣ)
+    (Empty-refl _)  → inj₂ (¬-Neutral-Empty , ¬-Neutral-Empty)
+    (Unit-refl _ _) → inj₂ (¬-Neutral-Unit  , ¬-Neutral-Unit)
+    (ℕ-refl _)      → inj₂ (¬-Neutral-ℕ     , ¬-Neutral-ℕ)
+    (Id-cong _ _ _) → inj₂ (¬-Neutral-Id    , ¬-Neutral-Id)
 
 opaque
 
@@ -921,11 +921,11 @@ opaque
         (_ , A-ne , B-ne) →
         (λ { PE.refl → ¬-Neutral-U A-ne })
       , (λ { PE.refl → ¬-Neutral-U B-ne })
-    (ΠΣ-cong _ _ _ _) → inj₂ ((λ ()) , (λ ()))
-    (Empty-refl _)    → inj₂ ((λ ()) , (λ ()))
-    (Unit-refl _ _)   → inj₂ ((λ ()) , (λ ()))
-    (ℕ-refl _)        → inj₂ ((λ ()) , (λ ()))
-    (Id-cong _ _ _)   → inj₂ ((λ ()) , (λ ()))
+    (ΠΣ-cong _ _ _) → inj₂ ((λ ()) , (λ ()))
+    (Empty-refl _)  → inj₂ ((λ ()) , (λ ()))
+    (Unit-refl _ _) → inj₂ ((λ ()) , (λ ()))
+    (ℕ-refl _)      → inj₂ ((λ ()) , (λ ()))
+    (Id-cong _ _ _) → inj₂ ((λ ()) , (λ ()))
 
 opaque
 
@@ -951,7 +951,7 @@ opaque
     ¬ (∃₅ λ b p q A₁ A₂ → A PE.≡ ΠΣ⟨ b ⟩ p , q ▷ A₁ ▹ A₂) ×
     ¬ (∃₅ λ b p q B₁ B₂ → B PE.≡ ΠΣ⟨ b ⟩ p , q ▷ B₁ ▹ B₂)
   inv-[conv↓]-ΠΣ′ = λ where
-    (ΠΣ-cong _ A₁≡B₁ A₂≡B₂ _) →
+    (ΠΣ-cong A₁≡B₁ A₂≡B₂ _) →
       inj₁ $
       _ , _ , _ , _ , _ , _ , _ , PE.refl , PE.refl , A₁≡B₁ , A₂≡B₂
     (ne A~B) →
@@ -996,11 +996,11 @@ opaque
         (_ , A-ne , B-ne) →
         (λ { PE.refl → ¬-Neutral-Empty A-ne })
       , (λ { PE.refl → ¬-Neutral-Empty B-ne })
-    (U-refl _)        → inj₂ ((λ ()) , (λ ()))
-    (ΠΣ-cong _ _ _ _) → inj₂ ((λ ()) , (λ ()))
-    (Unit-refl _ _)   → inj₂ ((λ ()) , (λ ()))
-    (ℕ-refl _)        → inj₂ ((λ ()) , (λ ()))
-    (Id-cong _ _ _)   → inj₂ ((λ ()) , (λ ()))
+    (U-refl _)      → inj₂ ((λ ()) , (λ ()))
+    (ΠΣ-cong _ _ _) → inj₂ ((λ ()) , (λ ()))
+    (Unit-refl _ _) → inj₂ ((λ ()) , (λ ()))
+    (ℕ-refl _)      → inj₂ ((λ ()) , (λ ()))
+    (Id-cong _ _ _) → inj₂ ((λ ()) , (λ ()))
 
 opaque
 
@@ -1029,11 +1029,11 @@ opaque
         (_ , A-ne , B-ne) →
         (λ { (_ , PE.refl) → ¬-Neutral-Unit A-ne })
       , (λ { (_ , PE.refl) → ¬-Neutral-Unit B-ne })
-    (U-refl _)        → inj₂ ((λ ()) , (λ ()))
-    (ΠΣ-cong _ _ _ _) → inj₂ ((λ ()) , (λ ()))
-    (Empty-refl _)    → inj₂ ((λ ()) , (λ ()))
-    (ℕ-refl _)        → inj₂ ((λ ()) , (λ ()))
-    (Id-cong _ _ _)   → inj₂ ((λ ()) , (λ ()))
+    (U-refl _)      → inj₂ ((λ ()) , (λ ()))
+    (ΠΣ-cong _ _ _) → inj₂ ((λ ()) , (λ ()))
+    (Empty-refl _)  → inj₂ ((λ ()) , (λ ()))
+    (ℕ-refl _)      → inj₂ ((λ ()) , (λ ()))
+    (Id-cong _ _ _) → inj₂ ((λ ()) , (λ ()))
 
 opaque
 
@@ -1061,11 +1061,11 @@ opaque
         (_ , A-ne , B-ne) →
         (λ { PE.refl → ¬-Neutral-ℕ A-ne })
       , (λ { PE.refl → ¬-Neutral-ℕ B-ne })
-    (U-refl _)        → inj₂ ((λ ()) , (λ ()))
-    (ΠΣ-cong _ _ _ _) → inj₂ ((λ ()) , (λ ()))
-    (Empty-refl _)    → inj₂ ((λ ()) , (λ ()))
-    (Unit-refl _ _)   → inj₂ ((λ ()) , (λ ()))
-    (Id-cong _ _ _)   → inj₂ ((λ ()) , (λ ()))
+    (U-refl _)      → inj₂ ((λ ()) , (λ ()))
+    (ΠΣ-cong _ _ _) → inj₂ ((λ ()) , (λ ()))
+    (Empty-refl _)  → inj₂ ((λ ()) , (λ ()))
+    (Unit-refl _ _) → inj₂ ((λ ()) , (λ ()))
+    (Id-cong _ _ _) → inj₂ ((λ ()) , (λ ()))
 
 opaque
 
@@ -1102,11 +1102,11 @@ opaque
         (_ , A-ne , B-ne) →
         (λ { (_ , _ , _ , PE.refl) → ¬-Neutral-Id A-ne })
       , (λ { (_ , _ , _ , PE.refl) → ¬-Neutral-Id B-ne })
-    (U-refl _)        → inj₂ ((λ ()) , (λ ()))
-    (ΠΣ-cong _ _ _ _) → inj₂ ((λ ()) , (λ ()))
-    (Empty-refl _)    → inj₂ ((λ ()) , (λ ()))
-    (Unit-refl _ _)   → inj₂ ((λ ()) , (λ ()))
-    (ℕ-refl _)        → inj₂ ((λ ()) , (λ ()))
+    (U-refl _)      → inj₂ ((λ ()) , (λ ()))
+    (ΠΣ-cong _ _ _) → inj₂ ((λ ()) , (λ ()))
+    (Empty-refl _)  → inj₂ ((λ ()) , (λ ()))
+    (Unit-refl _ _) → inj₂ ((λ ()) , (λ ()))
+    (ℕ-refl _)      → inj₂ ((λ ()) , (λ ()))
 
 opaque
 
@@ -1137,21 +1137,21 @@ opaque
     Γ ⊢ t [conv↓] u ∷ A →
     ∃ λ A → Γ ⊢ t ~ u ↓ A
   inv-[conv↓]∷-ne A-ne = λ where
-    (ne-ins _ _ _ t~u)    → _ , t~u
-    (univ _ _ _)          → ⊥-elim (¬-Neutral-U     A-ne)
-    (η-eq _ _ _ _ _)      → ⊥-elim (¬-Neutral-ΠΣ    A-ne)
-    (Σ-η _ _ _ _ _ _)     → ⊥-elim (¬-Neutral-ΠΣ    A-ne)
-    (Σʷ-ins _ _ _)        → ⊥-elim (¬-Neutral-ΠΣ    A-ne)
-    (prod-cong _ _ _ _ _) → ⊥-elim (¬-Neutral-ΠΣ    A-ne)
-    (Empty-ins _)         → ⊥-elim (¬-Neutral-Empty A-ne)
-    (Unitʷ-ins _ _)       → ⊥-elim (¬-Neutral-Unit  A-ne)
-    (η-unit _ _ _ _ _)    → ⊥-elim (¬-Neutral-Unit  A-ne)
-    (starʷ-refl _ _ _)    → ⊥-elim (¬-Neutral-Unit  A-ne)
-    (ℕ-ins _)             → ⊥-elim (¬-Neutral-ℕ     A-ne)
-    (zero-refl _)         → ⊥-elim (¬-Neutral-ℕ     A-ne)
-    (suc-cong _)          → ⊥-elim (¬-Neutral-ℕ     A-ne)
-    (Id-ins _ _)          → ⊥-elim (¬-Neutral-Id    A-ne)
-    (rfl-refl _)          → ⊥-elim (¬-Neutral-Id    A-ne)
+    (ne-ins _ _ _ t~u)  → _ , t~u
+    (univ _ _ _)        → ⊥-elim (¬-Neutral-U     A-ne)
+    (η-eq _ _ _ _ _)    → ⊥-elim (¬-Neutral-ΠΣ    A-ne)
+    (Σ-η _ _ _ _ _ _)   → ⊥-elim (¬-Neutral-ΠΣ    A-ne)
+    (Σʷ-ins _ _ _)      → ⊥-elim (¬-Neutral-ΠΣ    A-ne)
+    (prod-cong _ _ _ _) → ⊥-elim (¬-Neutral-ΠΣ    A-ne)
+    (Empty-ins _)       → ⊥-elim (¬-Neutral-Empty A-ne)
+    (Unitʷ-ins _ _)     → ⊥-elim (¬-Neutral-Unit  A-ne)
+    (η-unit _ _ _ _ _)  → ⊥-elim (¬-Neutral-Unit  A-ne)
+    (starʷ-refl _ _ _)  → ⊥-elim (¬-Neutral-Unit  A-ne)
+    (ℕ-ins _)           → ⊥-elim (¬-Neutral-ℕ     A-ne)
+    (zero-refl _)       → ⊥-elim (¬-Neutral-ℕ     A-ne)
+    (suc-cong _)        → ⊥-elim (¬-Neutral-ℕ     A-ne)
+    (Id-ins _ _)        → ⊥-elim (¬-Neutral-Id    A-ne)
+    (rfl-refl _)        → ⊥-elim (¬-Neutral-Id    A-ne)
 
 opaque
 
@@ -1201,7 +1201,7 @@ opaque
      Γ ⊢ t₂ [conv↑] u₂ ∷ B [ t₁ ]₀)
   inv-[conv↓]∷-Σʷ (Σʷ-ins _ _ t~u) =
     inj₁ (_ , _ , _ , _ , t~u)
-  inv-[conv↓]∷-Σʷ (prod-cong _ _ t₁≡u₁ t₂≡u₂ _) =
+  inv-[conv↓]∷-Σʷ (prod-cong _ t₁≡u₁ t₂≡u₂ _) =
     inj₂ (_ , _ , _ , _ , PE.refl , PE.refl , t₁≡u₁ , t₂≡u₂)
   inv-[conv↓]∷-Σʷ (ne-ins _ _ () _)
 

--- a/Definition/Conversion/Inversion.agda
+++ b/Definition/Conversion/Inversion.agda
@@ -1,0 +1,1294 @@
+------------------------------------------------------------------------
+-- Inversion lemmas related to the algorithmic equality relations
+------------------------------------------------------------------------
+
+-- Some inversion lemmas do not return all available information. If
+-- something can be easily recreated using the soundness lemmas, then
+-- it is at least sometimes omitted.
+
+{-# OPTIONS --no-infer-absurd-clauses #-}
+
+open import Definition.Typed.Restrictions
+open import Graded.Modality
+
+module Definition.Conversion.Inversion
+  {a} {M : Set a}
+  {𝕄 : Modality M}
+  (R : Type-restrictions 𝕄)
+  where
+
+open Type-restrictions R
+
+open import Definition.Conversion R
+open import Definition.Conversion.Whnf R
+
+open import Definition.Typed R
+open import Definition.Untyped M
+open import Definition.Untyped.Neutral M type-variant
+open import Definition.Untyped.Properties.Neutral M type-variant
+
+import Graded.Derived.Erased.Untyped 𝕄 as Erased
+
+open import Tools.Empty
+open import Tools.Function
+open import Tools.Fin
+open import Tools.Product
+import Tools.PropositionalEquality as PE
+open import Tools.Relation
+open import Tools.Sum
+
+private variable
+  x y                                                     : Fin _
+  Γ                                                       : Con Term _
+  A A₁ A₂ B B₁ B₂ C C₁ C₂ t t₁ t₂ t₃ t₄ u u₁ u₂ u₃ u₄ v w : Term _
+  b                                                       : BinderMode
+  s                                                       : Strength
+  p q r                                                   : M
+
+------------------------------------------------------------------------
+-- Inversion and similar lemmas for _⊢_~_↑_
+
+opaque
+
+  -- A kind of inversion lemma for var.
+
+  inv-~-var :
+    Γ ⊢ t ~ u ↑ A →
+    (∃ λ x → t PE.≡ var x × u PE.≡ var x) ⊎
+    ¬ (∃ λ x → t PE.≡ var x) × ¬ (∃ λ x → u PE.≡ var x)
+  inv-~-var = λ where
+    (var-refl _ PE.refl)       → inj₁ (_ , PE.refl , PE.refl)
+    (app-cong _ _)             → inj₂ ((λ ()) , (λ ()))
+    (fst-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (snd-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (prodrec-cong _ _ _)       → inj₂ ((λ ()) , (λ ()))
+    (emptyrec-cong _ _)        → inj₂ ((λ ()) , (λ ()))
+    (unitrec-cong _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (natrec-cong _ _ _ _)      → inj₂ ((λ ()) , (λ ()))
+    (J-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (K-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    ([]-cong-cong _ _ _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for var.
+
+  inv-var~ :
+    Γ ⊢ var x ~ u ↑ A →
+    u PE.≡ var x
+  inv-var~ (var-refl _ PE.refl) = PE.refl
+
+opaque
+
+  -- Inversion for var.
+
+  inv-~var :
+    Γ ⊢ t ~ var y ↑ A →
+    t PE.≡ var y
+  inv-~var (var-refl _ PE.refl) = PE.refl
+
+opaque
+
+  -- Inversion for U.
+
+  inv-U~ : ¬ Γ ⊢ U ~ u ↑ A
+  inv-U~ ()
+
+opaque
+
+  -- Inversion for U.
+
+  inv-~U : ¬ Γ ⊢ t ~ U ↑ A
+  inv-~U ()
+
+opaque
+
+  -- Inversion for ΠΣ.
+
+  inv-ΠΣ~ : ¬ Γ ⊢ ΠΣ⟨ b ⟩ p , q ▷ B₁ ▹ B₂ ~ u ↑ A
+  inv-ΠΣ~ ()
+
+opaque
+
+  -- Inversion for ΠΣ.
+
+  inv-~ΠΣ : ¬ Γ ⊢ t ~ ΠΣ⟨ b ⟩ p , q ▷ C₁ ▹ C₂ ↑ A
+  inv-~ΠΣ ()
+
+opaque
+
+  -- Inversion for lam.
+
+  inv-lam~ : ¬ Γ ⊢ lam p t ~ u ↑ A
+  inv-lam~ ()
+
+opaque
+
+  -- Inversion for lam.
+
+  inv-~lam : ¬ Γ ⊢ t ~ lam p u ↑ A
+  inv-~lam ()
+
+opaque
+
+  -- A kind of inversion lemma for _∘⟨_⟩_.
+
+  inv-~-∘ :
+    Γ ⊢ t ~ u ↑ A →
+    (∃₈ λ p q B C t₁ t₂ u₁ u₂ →
+     A PE.≡ C [ t₂ ]₀ × t PE.≡ t₁ ∘⟨ p ⟩ t₂ × u PE.≡ u₁ ∘⟨ p ⟩ u₂ ×
+     Γ ⊢ t₁ ~ u₁ ↓ Π p , q ▷ B ▹ C ×
+     Γ ⊢ t₂ [conv↑] u₂ ∷ B) ⊎
+    ¬ (∃₃ λ p t₁ t₂ → t PE.≡ t₁ ∘⟨ p ⟩ t₂) ×
+    ¬ (∃₃ λ p u₁ u₂ → u PE.≡ u₁ ∘⟨ p ⟩ u₂)
+  inv-~-∘ = λ where
+    (app-cong t₁~u₁ t₂≡u₂) →
+      inj₁ $
+      _ , _ , _ , _ , _ , _ , _ , _ ,
+      PE.refl , PE.refl , PE.refl , t₁~u₁ , t₂≡u₂
+    (var-refl _ _)             → inj₂ ((λ ()) , (λ ()))
+    (fst-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (snd-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (prodrec-cong _ _ _)       → inj₂ ((λ ()) , (λ ()))
+    (emptyrec-cong _ _)        → inj₂ ((λ ()) , (λ ()))
+    (unitrec-cong _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (natrec-cong _ _ _ _)      → inj₂ ((λ ()) , (λ ()))
+    (J-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (K-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    ([]-cong-cong _ _ _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for _∘⟨_⟩_.
+
+  inv-∘~ :
+    Γ ⊢ t₁ ∘⟨ p ⟩ t₂ ~ u ↑ A →
+    ∃₅ λ q B C u₁ u₂ →
+    A PE.≡ C [ t₂ ]₀ ×
+    u PE.≡ u₁ ∘⟨ p ⟩ u₂ ×
+    Γ ⊢ t₁ ~ u₁ ↓ Π p , q ▷ B ▹ C ×
+    Γ ⊢ t₂ [conv↑] u₂ ∷ B
+  inv-∘~ (app-cong t₁~u₁ t₂≡u₂) =
+    _ , _ , _ , _ , _ , PE.refl , PE.refl , t₁~u₁ , t₂≡u₂
+
+opaque
+
+  -- Inversion for _∘⟨_⟩_.
+
+  inv-~∘ :
+    Γ ⊢ t ~ u₁ ∘⟨ p ⟩ u₂ ↑ A →
+    ∃₅ λ q B C t₁ t₂ →
+    A PE.≡ C [ t₂ ]₀ ×
+    t PE.≡ t₁ ∘⟨ p ⟩ t₂ ×
+    Γ ⊢ t₁ ~ u₁ ↓ Π p , q ▷ B ▹ C ×
+    Γ ⊢ t₂ [conv↑] u₂ ∷ B
+  inv-~∘ (app-cong t₁~u₁ t₂≡u₂) =
+    _ , _ , _ , _ , _ , PE.refl , PE.refl , t₁~u₁ , t₂≡u₂
+
+opaque
+
+  -- Inversion for prod.
+
+  inv-prod~ : ¬ Γ ⊢ prod s p t₁ t₂ ~ u ↑ A
+  inv-prod~ ()
+
+opaque
+
+  -- Inversion for prod.
+
+  inv-~prod : ¬ Γ ⊢ t ~ prod s p u₁ u₂ ↑ A
+  inv-~prod ()
+
+opaque
+
+  -- A kind of inversion lemma for fst.
+
+  inv-~-fst :
+    Γ ⊢ t ~ u ↑ A →
+    (∃₅ λ p q B t′ u′ →
+     t PE.≡ fst p t′ × u PE.≡ fst p u′ ×
+     Γ ⊢ t′ ~ u′ ↓ Σˢ p , q ▷ A ▹ B) ⊎
+    ¬ (∃₂ λ p t′ → t PE.≡ fst p t′) × ¬ (∃₂ λ p u′ → u PE.≡ fst p u′)
+  inv-~-fst = λ where
+    (fst-cong t′~u′) →
+      inj₁ (_ , _ , _ , _ , _ , PE.refl , PE.refl , t′~u′)
+    (var-refl _ _)             → inj₂ ((λ ()) , (λ ()))
+    (app-cong _ _)             → inj₂ ((λ ()) , (λ ()))
+    (snd-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (prodrec-cong _ _ _)       → inj₂ ((λ ()) , (λ ()))
+    (emptyrec-cong _ _)        → inj₂ ((λ ()) , (λ ()))
+    (unitrec-cong _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (natrec-cong _ _ _ _)      → inj₂ ((λ ()) , (λ ()))
+    (J-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (K-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    ([]-cong-cong _ _ _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for fst.
+
+  inv-fst~ :
+    Γ ⊢ fst p t ~ u ↑ A →
+    ∃₃ λ q B u′ →
+    u PE.≡ fst p u′ ×
+    Γ ⊢ t ~ u′ ↓ Σˢ p , q ▷ A ▹ B
+  inv-fst~ (fst-cong t~u′) = _ , _ , _ , PE.refl , t~u′
+
+opaque
+
+  -- Inversion for fst.
+
+  inv-~fst :
+    Γ ⊢ t ~ fst p u ↑ A →
+    ∃₃ λ q B t′ →
+    t PE.≡ fst p t′ ×
+    Γ ⊢ t′ ~ u ↓ Σˢ p , q ▷ A ▹ B
+  inv-~fst (fst-cong t′~u) = _ , _ , _ , PE.refl , t′~u
+
+opaque
+
+  -- A kind of inversion lemma for snd.
+
+  inv-~-snd :
+    Γ ⊢ t ~ u ↑ A →
+    (∃₆ λ p q B C t′ u′ →
+     A PE.≡ C [ fst p t′ ]₀ × t PE.≡ snd p t′ × u PE.≡ snd p u′ ×
+     Γ ⊢ t′ ~ u′ ↓ Σˢ p , q ▷ B ▹ C) ⊎
+    ¬ (∃₂ λ p t′ → t PE.≡ snd p t′) × ¬ (∃₂ λ p u′ → u PE.≡ snd p u′)
+  inv-~-snd = λ where
+    (snd-cong t′~u′) →
+      inj₁ (_ , _ , _ , _ , _ , _ , PE.refl , PE.refl , PE.refl , t′~u′)
+    (var-refl _ _)             → inj₂ ((λ ()) , (λ ()))
+    (app-cong _ _)             → inj₂ ((λ ()) , (λ ()))
+    (fst-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (prodrec-cong _ _ _)       → inj₂ ((λ ()) , (λ ()))
+    (emptyrec-cong _ _)        → inj₂ ((λ ()) , (λ ()))
+    (unitrec-cong _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (natrec-cong _ _ _ _)      → inj₂ ((λ ()) , (λ ()))
+    (J-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (K-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    ([]-cong-cong _ _ _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for snd.
+
+  inv-snd~ :
+    Γ ⊢ snd p t ~ u ↑ A →
+    ∃₄ λ q B C u′ →
+    A PE.≡ C [ fst p t ]₀ ×
+    u PE.≡ snd p u′ ×
+    Γ ⊢ t ~ u′ ↓ Σˢ p , q ▷ B ▹ C
+  inv-snd~ (snd-cong t~u′) = _ , _ , _ , _ , PE.refl , PE.refl , t~u′
+
+opaque
+
+  -- Inversion for snd.
+
+  inv-~snd :
+    Γ ⊢ t ~ snd p u ↑ A →
+    ∃₄ λ q B C t′ →
+    A PE.≡ C [ fst p t′ ]₀ ×
+    t PE.≡ snd p t′ ×
+    Γ ⊢ t′ ~ u ↓ Σˢ p , q ▷ B ▹ C
+  inv-~snd (snd-cong t′~u) = _ , _ , _ , _ , PE.refl , PE.refl , t′~u
+
+opaque
+
+  -- A kind of inversion lemma for prodrec.
+
+  inv-~-prodrec :
+    Γ ⊢ t ~ u ↑ A →
+    (∃₄ λ r p q′ q → ∃₈ λ A₁ A₂ B C t₁ t₂ u₁ u₂ →
+     A PE.≡ B [ t₁ ]₀ ×
+     t PE.≡ prodrec r p q′ B t₁ t₂ ×
+     u PE.≡ prodrec r p q′ C u₁ u₂ ×
+     (Γ ∙ Σʷ p , q ▷ A₁ ▹ A₂ ⊢ B [conv↑] C) ×
+     Γ ⊢ t₁ ~ u₁ ↓ Σʷ p , q ▷ A₁ ▹ A₂ ×
+     Γ ∙ A₁ ∙ A₂ ⊢ t₂ [conv↑] u₂ ∷ B [ prodʷ p (var x1) (var x0) ]↑²) ⊎
+    ¬ (∃₆ λ r p q′ B t₁ t₂ → t PE.≡ prodrec r p q′ B t₁ t₂) ×
+    ¬ (∃₆ λ r p q′ C u₁ u₂ → u PE.≡ prodrec r p q′ C u₁ u₂)
+  inv-~-prodrec = λ where
+    (prodrec-cong B≡C t₁~u₁ t₂≡u₂) →
+      inj₁ $
+      _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ ,
+      PE.refl , PE.refl , PE.refl , B≡C , t₁~u₁ , t₂≡u₂
+    (var-refl _ _)             → inj₂ ((λ ()) , (λ ()))
+    (app-cong _ _)             → inj₂ ((λ ()) , (λ ()))
+    (fst-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (snd-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (emptyrec-cong _ _)        → inj₂ ((λ ()) , (λ ()))
+    (unitrec-cong _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (natrec-cong _ _ _ _)      → inj₂ ((λ ()) , (λ ()))
+    (J-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (K-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    ([]-cong-cong _ _ _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for prodrec.
+
+  inv-prodrec~ :
+    Γ ⊢ prodrec r p q B t₁ t₂ ~ u ↑ A →
+    ∃₆ λ q′ A₁ A₂ C u₁ u₂ →
+    A PE.≡ B [ t₁ ]₀ ×
+    u PE.≡ prodrec r p q C u₁ u₂ ×
+    (Γ ∙ Σʷ p , q′ ▷ A₁ ▹ A₂ ⊢ B [conv↑] C) ×
+    Γ ⊢ t₁ ~ u₁ ↓ Σʷ p , q′ ▷ A₁ ▹ A₂ ×
+    Γ ∙ A₁ ∙ A₂ ⊢ t₂ [conv↑] u₂ ∷ B [ prodʷ p (var x1) (var x0) ]↑²
+  inv-prodrec~ (prodrec-cong B≡C t₁~u₁ t₂≡u₂) =
+     _ , _ , _ , _ , _ , _ , PE.refl , PE.refl , B≡C , t₁~u₁ , t₂≡u₂
+
+opaque
+
+  -- Inversion for prodrec.
+
+  inv-~prodrec :
+    Γ ⊢ t ~ prodrec r p q C u₁ u₂ ↑ A →
+    ∃₆ λ q′ A₁ A₂ B t₁ t₂ →
+    A PE.≡ B [ t₁ ]₀ ×
+    t PE.≡ prodrec r p q B t₁ t₂ ×
+    (Γ ∙ Σʷ p , q′ ▷ A₁ ▹ A₂ ⊢ B [conv↑] C) ×
+    Γ ⊢ t₁ ~ u₁ ↓ Σʷ p , q′ ▷ A₁ ▹ A₂ ×
+    Γ ∙ A₁ ∙ A₂ ⊢ t₂ [conv↑] u₂ ∷ B [ prodʷ p (var x1) (var x0) ]↑²
+  inv-~prodrec (prodrec-cong B≡C t₁~u₁ t₂≡u₂) =
+     _ , _ , _ , _ , _ , _ , PE.refl , PE.refl , B≡C , t₁~u₁ , t₂≡u₂
+
+opaque
+
+  -- Inversion for Empty.
+
+  inv-Empty~ : ¬ Γ ⊢ Empty ~ u ↑ A
+  inv-Empty~ ()
+
+opaque
+
+  -- Inversion for Empty.
+
+  inv-~Empty : ¬ Γ ⊢ t ~ Empty ↑ A
+  inv-~Empty ()
+
+opaque
+
+  -- A kind of inversion lemma for emptyrec.
+
+  inv-~-emptyrec :
+    Γ ⊢ t ~ u ↑ A →
+    (∃₄ λ p B t′ u′ →
+     t PE.≡ emptyrec p A t′ × u PE.≡ emptyrec p B u′ ×
+     (Γ ⊢ A [conv↑] B) ×
+     Γ ⊢ t′ ~ u′ ↓ Empty) ⊎
+    ¬ (∃₃ λ p A t′ → t PE.≡ emptyrec p A t′) ×
+    ¬ (∃₃ λ p B u′ → u PE.≡ emptyrec p B u′)
+  inv-~-emptyrec = λ where
+    (emptyrec-cong A≡B t′~u′) →
+      inj₁ (_ , _ , _ , _ , PE.refl , PE.refl , A≡B , t′~u′)
+    (var-refl _ _)             → inj₂ ((λ ()) , (λ ()))
+    (app-cong _ _)             → inj₂ ((λ ()) , (λ ()))
+    (fst-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (snd-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (prodrec-cong _ _ _)       → inj₂ ((λ ()) , (λ ()))
+    (unitrec-cong _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (natrec-cong _ _ _ _)      → inj₂ ((λ ()) , (λ ()))
+    (J-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (K-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    ([]-cong-cong _ _ _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for emptyrec.
+
+  inv-emptyrec~ :
+    Γ ⊢ emptyrec p B t ~ u ↑ A →
+    ∃₂ λ C u′ →
+    A PE.≡ B ×
+    u PE.≡ emptyrec p C u′ ×
+    Γ ⊢ B [conv↑] C ×
+    Γ ⊢ t ~ u′ ↓ Empty
+  inv-emptyrec~ (emptyrec-cong B≡C t~u) =
+    _ , _ , PE.refl , PE.refl , B≡C , t~u
+
+opaque
+
+  -- Inversion for emptyrec.
+
+  inv-~emptyrec :
+    Γ ⊢ t ~ emptyrec p C u ↑ A →
+    ∃ λ t′ →
+    t PE.≡ emptyrec p A t′ ×
+    Γ ⊢ A [conv↑] C ×
+    Γ ⊢ t′ ~ u ↓ Empty
+  inv-~emptyrec (emptyrec-cong A≡C t~u) =
+    _ , PE.refl , A≡C , t~u
+
+opaque
+
+  -- Inversion for Unit.
+
+  inv-Unit~ : ¬ Γ ⊢ Unit s ~ u ↑ A
+  inv-Unit~ ()
+
+opaque
+
+  -- Inversion for Unit.
+
+  inv-~Unit : ¬ Γ ⊢ t ~ Unit s ↑ A
+  inv-~Unit ()
+
+opaque
+
+  -- Inversion for star.
+
+  inv-star~ : ¬ Γ ⊢ star s ~ u ↑ A
+  inv-star~ ()
+
+opaque
+
+  -- Inversion for star.
+
+  inv-~star : ¬ Γ ⊢ t ~ star s ↑ A
+  inv-~star ()
+
+opaque
+
+  -- A kind of inversion lemma for unitrec.
+
+  inv-~-unitrec :
+    Γ ⊢ t ~ u ↑ A →
+    (∃₈ λ p q B C t₁ t₂ u₁ u₂ →
+     A PE.≡ B [ t₁ ]₀ ×
+     t PE.≡ unitrec p q B t₁ t₂ ×
+     u PE.≡ unitrec p q C u₁ u₂ ×
+     (Γ ∙ Unitʷ ⊢ B [conv↑] C) ×
+     Γ ⊢ t₁ ~ u₁ ↓ Unitʷ ×
+     Γ ⊢ t₂ [conv↑] u₂ ∷ B [ starʷ ]₀ ×
+     ¬ Unitʷ-η) ⊎
+    ¬ (∃₅ λ p q B t₁ t₂ → t PE.≡ unitrec p q B t₁ t₂) ×
+    ¬ (∃₅ λ p q C u₁ u₂ → u PE.≡ unitrec p q C u₁ u₂)
+  inv-~-unitrec = λ where
+    (unitrec-cong B≡C t₁~u₁ t₂≡u₂ no-η) →
+      inj₁ $
+      _ , _ , _ , _ , _ , _ , _ , _ ,
+      PE.refl , PE.refl , PE.refl , B≡C , t₁~u₁ , t₂≡u₂ , no-η
+    (var-refl _ _)             → inj₂ ((λ ()) , (λ ()))
+    (app-cong _ _)             → inj₂ ((λ ()) , (λ ()))
+    (fst-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (snd-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (prodrec-cong _ _ _)       → inj₂ ((λ ()) , (λ ()))
+    (emptyrec-cong _ _)        → inj₂ ((λ ()) , (λ ()))
+    (natrec-cong _ _ _ _)      → inj₂ ((λ ()) , (λ ()))
+    (J-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (K-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    ([]-cong-cong _ _ _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for unitrec.
+
+  inv-unitrec~ :
+    Γ ⊢ unitrec p q B t₁ t₂ ~ u ↑ A →
+    ∃₃ λ C u₁ u₂ →
+    A PE.≡ B [ t₁ ]₀ ×
+    u PE.≡ unitrec p q C u₁ u₂ ×
+    (Γ ∙ Unitʷ ⊢ B [conv↑] C) ×
+    Γ ⊢ t₁ ~ u₁ ↓ Unitʷ ×
+    Γ ⊢ t₂ [conv↑] u₂ ∷ B [ starʷ ]₀ ×
+    ¬ Unitʷ-η
+  inv-unitrec~ (unitrec-cong B≡C t₁~u₁ t₂≡u₂ no-η) =
+    _ , _ , _ , PE.refl , PE.refl , B≡C , t₁~u₁ , t₂≡u₂ , no-η
+
+opaque
+
+  -- Inversion for unitrec.
+
+  inv-~unitrec :
+    Γ ⊢ t ~ unitrec p q C u₁ u₂ ↑ A →
+    ∃₃ λ B t₁ t₂ →
+    A PE.≡ B [ t₁ ]₀ ×
+    t PE.≡ unitrec p q B t₁ t₂ ×
+    (Γ ∙ Unitʷ ⊢ B [conv↑] C) ×
+    Γ ⊢ t₁ ~ u₁ ↓ Unitʷ ×
+    Γ ⊢ t₂ [conv↑] u₂ ∷ B [ starʷ ]₀ ×
+    ¬ Unitʷ-η
+  inv-~unitrec (unitrec-cong B≡C t₁~u₁ t₂≡u₂ no-η) =
+    _ , _ , _ , PE.refl , PE.refl , B≡C , t₁~u₁ , t₂≡u₂ , no-η
+
+opaque
+
+  -- Inversion for ℕ.
+
+  inv-ℕ~ : ¬ Γ ⊢ ℕ ~ u ↑ A
+  inv-ℕ~ ()
+
+opaque
+
+  -- Inversion for ℕ.
+
+  inv-~ℕ : ¬ Γ ⊢ t ~ ℕ ↑ A
+  inv-~ℕ ()
+
+opaque
+
+  -- Inversion for zero.
+
+  inv-zero~ : ¬ Γ ⊢ zero ~ u ↑ A
+  inv-zero~ ()
+
+opaque
+
+  -- Inversion for zero.
+
+  inv-~zero : ¬ Γ ⊢ t ~ zero ↑ A
+  inv-~zero ()
+
+opaque
+
+  -- Inversion for suc.
+
+  inv-suc~ : ¬ Γ ⊢ suc t ~ u ↑ A
+  inv-suc~ ()
+
+opaque
+
+  -- Inversion for suc.
+
+  inv-~suc : ¬ Γ ⊢ t ~ suc u ↑ A
+  inv-~suc ()
+
+opaque
+
+  -- A kind of inversion lemma for natrec.
+
+  inv-~-natrec :
+    Γ ⊢ t ~ u ↑ A →
+    (∃₃ λ p q r → ∃₈ λ B C t₁ t₂ t₃ u₁ u₂ u₃ →
+     A PE.≡ B [ t₃ ]₀ ×
+     t PE.≡ natrec p q r B t₁ t₂ t₃ ×
+     u PE.≡ natrec p q r C u₁ u₂ u₃ ×
+     (Γ ∙ ℕ ⊢ B [conv↑] C) ×
+     Γ ⊢ t₁ [conv↑] u₁ ∷ B [ zero ]₀ ×
+     Γ ∙ ℕ ∙ B ⊢ t₂ [conv↑] u₂ ∷ B [ suc (var x1) ]↑² ×
+     Γ ⊢ t₃ ~ u₃ ↓ ℕ) ⊎
+    ¬ (∃₇ λ p q r B t₁ t₂ t₃ → t PE.≡ natrec p q r B t₁ t₂ t₃) ×
+    ¬ (∃₇ λ p q r C u₁ u₂ u₃ → u PE.≡ natrec p q r C u₁ u₂ u₃)
+  inv-~-natrec = λ where
+    (natrec-cong B≡C t₁≡u₁ t₂≡u₂ t₃~u₃) →
+      inj₁ $
+      _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ ,
+      PE.refl , PE.refl , PE.refl , B≡C , t₁≡u₁ , t₂≡u₂ , t₃~u₃
+    (var-refl _ _)             → inj₂ ((λ ()) , (λ ()))
+    (app-cong _ _)             → inj₂ ((λ ()) , (λ ()))
+    (fst-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (snd-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (prodrec-cong _ _ _)       → inj₂ ((λ ()) , (λ ()))
+    (emptyrec-cong _ _)        → inj₂ ((λ ()) , (λ ()))
+    (unitrec-cong _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (J-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (K-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    ([]-cong-cong _ _ _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for natrec.
+
+  inv-natrec~ :
+    Γ ⊢ natrec p q r B t₁ t₂ t₃ ~ u ↑ A →
+    ∃₄ λ C u₁ u₂ u₃ →
+    A PE.≡ B [ t₃ ]₀ ×
+    u PE.≡ natrec p q r C u₁ u₂ u₃ ×
+    (Γ ∙ ℕ ⊢ B [conv↑] C) ×
+    Γ ⊢ t₁ [conv↑] u₁ ∷ B [ zero ]₀ ×
+    Γ ∙ ℕ ∙ B ⊢ t₂ [conv↑] u₂ ∷ B [ suc (var x1) ]↑² ×
+    Γ ⊢ t₃ ~ u₃ ↓ ℕ
+  inv-natrec~ (natrec-cong B≡C t₁≡u₁ t₂≡u₂ t₃~u₃) =
+    _ , _ , _ , _ , PE.refl , PE.refl , B≡C , t₁≡u₁ , t₂≡u₂ , t₃~u₃
+
+opaque
+
+  -- Inversion for natrec.
+
+  inv-~natrec :
+    Γ ⊢ t ~ natrec p q r C u₁ u₂ u₃ ↑ A →
+    ∃₄ λ B t₁ t₂ t₃ →
+    A PE.≡ B [ t₃ ]₀ ×
+    t PE.≡ natrec p q r B t₁ t₂ t₃ ×
+    (Γ ∙ ℕ ⊢ B [conv↑] C) ×
+    Γ ⊢ t₁ [conv↑] u₁ ∷ B [ zero ]₀ ×
+    Γ ∙ ℕ ∙ B ⊢ t₂ [conv↑] u₂ ∷ B [ suc (var x1) ]↑² ×
+    Γ ⊢ t₃ ~ u₃ ↓ ℕ
+  inv-~natrec (natrec-cong B≡C t₁≡u₁ t₂≡u₂ t₃~u₃) =
+    _ , _ , _ , _ , PE.refl , PE.refl , B≡C , t₁≡u₁ , t₂≡u₂ , t₃~u₃
+
+opaque
+
+  -- Inversion for Id.
+
+  inv-Id~ : ¬ Γ ⊢ Id B t₁ t₂ ~ u ↑ A
+  inv-Id~ ()
+
+opaque
+
+  -- Inversion for Id.
+
+  inv-~Id : ¬ Γ ⊢ t ~ Id C u₁ u₂ ↑ A
+  inv-~Id ()
+
+opaque
+
+  -- Inversion for rfl.
+
+  inv-rfl~ : ¬ Γ ⊢ rfl ~ u ↑ A
+  inv-rfl~ ()
+
+opaque
+
+  -- Inversion for rfl.
+
+  inv-~rfl : ¬ Γ ⊢ t ~ rfl ↑ A
+  inv-~rfl ()
+
+opaque
+
+  -- A kind of inversion lemma for J.
+
+  inv-~-J :
+    Γ ⊢ t ~ u ↑ A →
+    (∃₇ λ p q B₁ B₂ C₁ C₂ D → ∃₈ λ t₁ t₂ t₃ t₄ u₁ u₂ u₃ u₄ →
+     A PE.≡ B₂ [ t₃ , t₄ ]₁₀ ×
+     t PE.≡ J p q B₁ t₁ B₂ t₂ t₃ t₄ ×
+     u PE.≡ J p q C₁ u₁ C₂ u₂ u₃ u₄ ×
+     (Γ ⊢ B₁ [conv↑] C₁) ×
+     Γ ⊢ t₁ [conv↑] u₁ ∷ B₁ ×
+     (Γ ∙ B₁ ∙ Id (wk1 B₁) (wk1 t₁) (var x0) ⊢ B₂ [conv↑] C₂) ×
+     Γ ⊢ t₂ [conv↑] u₂ ∷ B₂ [ t₁ , rfl ]₁₀ ×
+     Γ ⊢ t₃ [conv↑] u₃ ∷ B₁ ×
+     Γ ⊢ t₄ ~ u₄ ↓ D ×
+     Γ ⊢ D ≡ Id B₁ t₁ t₃) ⊎
+    ¬ (∃₈ λ p q B₁ B₂ t₁ t₂ t₃ t₄ → t PE.≡ J p q B₁ t₁ B₂ t₂ t₃ t₄) ×
+    ¬ (∃₈ λ p q C₁ C₂ u₁ u₂ u₃ u₄ → u PE.≡ J p q C₁ u₁ C₂ u₂ u₃ u₄)
+  inv-~-J = λ where
+    (J-cong B₁≡C₁ t₁≡u₁ B₂≡C₂ t₂≡u₂ t₃≡u₃ t₄~u₄ D≡Id) →
+      inj₁ $
+      _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ ,
+      PE.refl , PE.refl , PE.refl ,
+      B₁≡C₁ , t₁≡u₁ , B₂≡C₂ , t₂≡u₂ , t₃≡u₃ , t₄~u₄ , D≡Id
+    (var-refl _ _)             → inj₂ ((λ ()) , (λ ()))
+    (app-cong _ _)             → inj₂ ((λ ()) , (λ ()))
+    (fst-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (snd-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (prodrec-cong _ _ _)       → inj₂ ((λ ()) , (λ ()))
+    (emptyrec-cong _ _)        → inj₂ ((λ ()) , (λ ()))
+    (unitrec-cong _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (natrec-cong _ _ _ _)      → inj₂ ((λ ()) , (λ ()))
+    (K-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    ([]-cong-cong _ _ _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for J.
+
+  inv-J~ :
+    Γ ⊢ J p q B₁ t₁ B₂ t₂ t₃ t₄ ~ u ↑ A →
+    ∃₇ λ C₁ C₂ D u₁ u₂ u₃ u₄ →
+    A PE.≡ B₂ [ t₃ , t₄ ]₁₀ ×
+    u PE.≡ J p q C₁ u₁ C₂ u₂ u₃ u₄ ×
+    (Γ ⊢ B₁ [conv↑] C₁) ×
+    Γ ⊢ t₁ [conv↑] u₁ ∷ B₁ ×
+    (Γ ∙ B₁ ∙ Id (wk1 B₁) (wk1 t₁) (var x0) ⊢ B₂ [conv↑] C₂) ×
+    Γ ⊢ t₂ [conv↑] u₂ ∷ B₂ [ t₁ , rfl ]₁₀ ×
+    Γ ⊢ t₃ [conv↑] u₃ ∷ B₁ ×
+    Γ ⊢ t₄ ~ u₄ ↓ D ×
+    Γ ⊢ D ≡ Id B₁ t₁ t₃
+  inv-J~ (J-cong B₁≡C₁ t₁≡u₁ B₂≡C₂ t₂≡u₂ t₃≡u₃ t₄~u₄ D≡) =
+    _ , _ , _ , _ , _ , _ , _ , PE.refl , PE.refl ,
+    B₁≡C₁ , t₁≡u₁ , B₂≡C₂ , t₂≡u₂ , t₃≡u₃ , t₄~u₄ , D≡
+
+opaque
+
+  -- Inversion for J.
+
+  inv-~J :
+    Γ ⊢ t ~ J p q C₁ u₁ C₂ u₂ u₃ u₄ ↑ A →
+    ∃₇ λ B₁ B₂ D t₁ t₂ t₃ t₄ →
+    A PE.≡ B₂ [ t₃ , t₄ ]₁₀ ×
+    t PE.≡ J p q B₁ t₁ B₂ t₂ t₃ t₄ ×
+    (Γ ⊢ B₁ [conv↑] C₁) ×
+    Γ ⊢ t₁ [conv↑] u₁ ∷ B₁ ×
+    (Γ ∙ B₁ ∙ Id (wk1 B₁) (wk1 t₁) (var x0) ⊢ B₂ [conv↑] C₂) ×
+    Γ ⊢ t₂ [conv↑] u₂ ∷ B₂ [ t₁ , rfl ]₁₀ ×
+    Γ ⊢ t₃ [conv↑] u₃ ∷ B₁ ×
+    Γ ⊢ t₄ ~ u₄ ↓ D ×
+    Γ ⊢ D ≡ Id B₁ t₁ t₃
+  inv-~J (J-cong B₁≡C₁ t₁≡u₁ B₂≡C₂ t₂≡u₂ t₃≡u₃ t₄~u₄ D≡) =
+    _ , _ , _ , _ , _ , _ , _ , PE.refl , PE.refl ,
+    B₁≡C₁ , t₁≡u₁ , B₂≡C₂ , t₂≡u₂ , t₃≡u₃ , t₄~u₄ , D≡
+
+opaque
+
+  -- A kind of inversion lemma for K.
+
+  inv-~-K :
+    Γ ⊢ t ~ u ↑ A →
+    (∃₆ λ p B₁ B₂ C₁ C₂ D → ∃₆ λ t₁ t₂ t₃ u₁ u₂ u₃ →
+     A PE.≡ B₂ [ t₃ ]₀ ×
+     t PE.≡ K p B₁ t₁ B₂ t₂ t₃ ×
+     u PE.≡ K p C₁ u₁ C₂ u₂ u₃ ×
+     (Γ ⊢ B₁ [conv↑] C₁) ×
+     Γ ⊢ t₁ [conv↑] u₁ ∷ B₁ ×
+     (Γ ∙ Id B₁ t₁ t₁ ⊢ B₂ [conv↑] C₂) ×
+     Γ ⊢ t₂ [conv↑] u₂ ∷ B₂ [ rfl ]₀ ×
+     Γ ⊢ t₃ ~ u₃ ↓ D ×
+     Γ ⊢ D ≡ Id B₁ t₁ t₁ ×
+     K-allowed) ⊎
+    ¬ (∃₆ λ p B₁ B₂ t₁ t₂ t₃ → t PE.≡ K p B₁ t₁ B₂ t₂ t₃) ×
+    ¬ (∃₆ λ p C₁ C₂ u₁ u₂ u₃ → u PE.≡ K p C₁ u₁ C₂ u₂ u₃)
+  inv-~-K = λ where
+    (K-cong B₁≡C₁ t₁≡u₁ B₂≡C₂ t₂≡u₂ t₃~u₃ D≡Id ok) →
+      inj₁ $
+      _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ , _ ,
+      PE.refl , PE.refl , PE.refl ,
+      B₁≡C₁ , t₁≡u₁ , B₂≡C₂ , t₂≡u₂ , t₃~u₃ , D≡Id , ok
+    (var-refl _ _)             → inj₂ ((λ ()) , (λ ()))
+    (app-cong _ _)             → inj₂ ((λ ()) , (λ ()))
+    (fst-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (snd-cong _)               → inj₂ ((λ ()) , (λ ()))
+    (prodrec-cong _ _ _)       → inj₂ ((λ ()) , (λ ()))
+    (emptyrec-cong _ _)        → inj₂ ((λ ()) , (λ ()))
+    (unitrec-cong _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    (natrec-cong _ _ _ _)      → inj₂ ((λ ()) , (λ ()))
+    (J-cong _ _ _ _ _ _ _)     → inj₂ ((λ ()) , (λ ()))
+    ([]-cong-cong _ _ _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for K.
+
+  inv-K~ :
+    Γ ⊢ K p B₁ t₁ B₂ t₂ t₃ ~ u ↑ A →
+    ∃₆ λ C₁ C₂ D u₁ u₂ u₃ →
+    A PE.≡ B₂ [ t₃ ]₀ ×
+    u PE.≡ K p C₁ u₁ C₂ u₂ u₃ ×
+    (Γ ⊢ B₁ [conv↑] C₁) ×
+    Γ ⊢ t₁ [conv↑] u₁ ∷ B₁ ×
+    (Γ ∙ Id B₁ t₁ t₁ ⊢ B₂ [conv↑] C₂) ×
+    Γ ⊢ t₂ [conv↑] u₂ ∷ B₂ [ rfl ]₀ ×
+    Γ ⊢ t₃ ~ u₃ ↓ D ×
+    Γ ⊢ D ≡ Id B₁ t₁ t₁ ×
+    K-allowed
+  inv-K~ (K-cong B₁≡C₁ t₁≡u₁ B₂≡C₂ t₂≡u₂ t₃~u₃ D≡ ok) =
+    _ , _ , _ , _ , _ , _ , PE.refl , PE.refl ,
+    B₁≡C₁ , t₁≡u₁ , B₂≡C₂ , t₂≡u₂ , t₃~u₃ , D≡ , ok
+
+opaque
+
+  -- Inversion for K.
+
+  inv-~K :
+    Γ ⊢ t ~ K p C₁ u₁ C₂ u₂ u₃ ↑ A →
+    ∃₆ λ B₁ B₂ D t₁ t₂ t₃ →
+    A PE.≡ B₂ [ t₃ ]₀ ×
+    t PE.≡ K p B₁ t₁ B₂ t₂ t₃ ×
+    (Γ ⊢ B₁ [conv↑] C₁) ×
+    Γ ⊢ t₁ [conv↑] u₁ ∷ B₁ ×
+    (Γ ∙ Id B₁ t₁ t₁ ⊢ B₂ [conv↑] C₂) ×
+    Γ ⊢ t₂ [conv↑] u₂ ∷ B₂ [ rfl ]₀ ×
+    Γ ⊢ t₃ ~ u₃ ↓ D ×
+    Γ ⊢ D ≡ Id B₁ t₁ t₁ ×
+    K-allowed
+  inv-~K (K-cong B₁≡C₁ t₁≡u₁ B₂≡C₂ t₂≡u₂ t₃~u₃ D≡ ok) =
+    _ , _ , _ , _ , _ , _ , PE.refl , PE.refl ,
+    B₁≡C₁ , t₁≡u₁ , B₂≡C₂ , t₂≡u₂ , t₃~u₃ , D≡ , ok
+
+opaque
+
+  -- A kind of inversion lemma for []-cong.
+
+  inv-~-[]-cong :
+    Γ ⊢ t ~ u ↑ A →
+    (∃₄ λ s B C D → ∃₆ λ t₁ t₂ t₃ u₁ u₂ u₃ →
+     let open Erased s in
+     A PE.≡ Id (Erased B) [ t₁ ] ([ t₂ ]) ×
+     t PE.≡ []-cong s B t₁ t₂ t₃ ×
+     u PE.≡ []-cong s C u₁ u₂ u₃ ×
+     (Γ ⊢ B [conv↑] C) ×
+     Γ ⊢ t₁ [conv↑] u₁ ∷ B ×
+     Γ ⊢ t₂ [conv↑] u₂ ∷ B ×
+     Γ ⊢ t₃ ~ u₃ ↓ D ×
+     Γ ⊢ D ≡ Id B t₁ t₂ ×
+     []-cong-allowed s) ⊎
+    ¬ (∃₅ λ s B t₁ t₂ t₃ → t PE.≡ []-cong s B t₁ t₂ t₃) ×
+    ¬ (∃₅ λ s C u₁ u₂ u₃ → u PE.≡ []-cong s C u₁ u₂ u₃)
+  inv-~-[]-cong = λ where
+    ([]-cong-cong B≡C t₁≡u₁ t₂≡u₂ t₃~u₃ D≡Id ok) →
+      inj₁ $
+      _ , _ , _ , _ , _ , _ , _ , _ , _ , _ ,
+      PE.refl , PE.refl , PE.refl ,
+      B≡C , t₁≡u₁ , t₂≡u₂ , t₃~u₃ , D≡Id , ok
+    (var-refl _ _)         → inj₂ ((λ ()) , (λ ()))
+    (app-cong _ _)         → inj₂ ((λ ()) , (λ ()))
+    (fst-cong _)           → inj₂ ((λ ()) , (λ ()))
+    (snd-cong _)           → inj₂ ((λ ()) , (λ ()))
+    (prodrec-cong _ _ _)   → inj₂ ((λ ()) , (λ ()))
+    (emptyrec-cong _ _)    → inj₂ ((λ ()) , (λ ()))
+    (unitrec-cong _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+    (natrec-cong _ _ _ _)  → inj₂ ((λ ()) , (λ ()))
+    (J-cong _ _ _ _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+    (K-cong _ _ _ _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for []-cong.
+
+  inv-[]-cong~ :
+    let open Erased s in
+    Γ ⊢ []-cong s B t₁ t₂ t₃ ~ u ↑ A →
+    ∃₅ λ C D u₁ u₂ u₃ →
+    A PE.≡ Id (Erased B) [ t₁ ] ([ t₂ ]) ×
+    u PE.≡ []-cong s C u₁ u₂ u₃ ×
+    (Γ ⊢ B [conv↑] C) ×
+    Γ ⊢ t₁ [conv↑] u₁ ∷ B ×
+    Γ ⊢ t₂ [conv↑] u₂ ∷ B ×
+    Γ ⊢ t₃ ~ u₃ ↓ D ×
+    Γ ⊢ D ≡ Id B t₁ t₂ ×
+    []-cong-allowed s
+  inv-[]-cong~ ([]-cong-cong B≡C t₁≡u₁ t₂≡u₂ t₃~u₃ D≡ ok) =
+    _ , _ , _ , _ , _ , PE.refl , PE.refl ,
+    B≡C , t₁≡u₁ , t₂≡u₂ , t₃~u₃ , D≡ , ok
+
+opaque
+
+  -- Inversion for []-cong.
+
+  inv-~[]-cong :
+    let open Erased s in
+    Γ ⊢ t ~ []-cong s C u₁ u₂ u₃ ↑ A →
+    ∃₅ λ B D t₁ t₂ t₃ →
+    A PE.≡ Id (Erased B) [ t₁ ] ([ t₂ ]) ×
+    t PE.≡ []-cong s B t₁ t₂ t₃ ×
+    (Γ ⊢ B [conv↑] C) ×
+    Γ ⊢ t₁ [conv↑] u₁ ∷ B ×
+    Γ ⊢ t₂ [conv↑] u₂ ∷ B ×
+    Γ ⊢ t₃ ~ u₃ ↓ D ×
+    Γ ⊢ D ≡ Id B t₁ t₂ ×
+    []-cong-allowed s
+  inv-~[]-cong ([]-cong-cong B≡C t₁≡u₁ t₂≡u₂ t₃~u₃ D≡ ok) =
+    _ , _ , _ , _ , _ , PE.refl , PE.refl ,
+    B≡C , t₁≡u₁ , t₂≡u₂ , t₃~u₃ , D≡ , ok
+
+------------------------------------------------------------------------
+-- Inversion and similar lemmas for _⊢_[conv↓]_
+
+opaque
+
+  -- A kind of inversion lemma for neutral terms.
+
+  inv-[conv↓]-ne′ :
+    Γ ⊢ A [conv↓] B →
+    Γ ⊢ A ~ B ↓ U ⊎ ¬ Neutral A × ¬ Neutral B
+  inv-[conv↓]-ne′ = λ where
+    (ne A~B)          → inj₁ A~B
+    (U-refl _)        → inj₂ (¬-Neutral-U     , ¬-Neutral-U)
+    (ΠΣ-cong _ _ _ _) → inj₂ (¬-Neutral-ΠΣ    , ¬-Neutral-ΠΣ)
+    (Empty-refl _)    → inj₂ (¬-Neutral-Empty , ¬-Neutral-Empty)
+    (Unit-refl _ _)   → inj₂ (¬-Neutral-Unit  , ¬-Neutral-Unit)
+    (ℕ-refl _)        → inj₂ (¬-Neutral-ℕ     , ¬-Neutral-ℕ)
+    (Id-cong _ _ _)   → inj₂ (¬-Neutral-Id    , ¬-Neutral-Id)
+
+opaque
+
+  -- Inversion for neutral terms.
+
+  inv-[conv↓]-ne :
+    Neutral A →
+    Γ ⊢ A [conv↓] B →
+    Γ ⊢ A ~ B ↓ U
+  inv-[conv↓]-ne A-ne A≡B = case inv-[conv↓]-ne′ A≡B of λ where
+    (inj₁ A~B)         → A~B
+    (inj₂ (¬A-ne , _)) → ⊥-elim (¬A-ne A-ne)
+
+opaque
+
+  -- A kind of inversion lemma for U.
+
+  inv-[conv↓]-U′ :
+    Γ ⊢ A [conv↓] B →
+    A PE.≡ U × B PE.≡ U ⊎ A PE.≢ U × B PE.≢ U
+  inv-[conv↓]-U′ = λ where
+    (U-refl _) → inj₁ (PE.refl , PE.refl)
+    (ne A~B) →
+      inj₂ $
+      case ne~↓ A~B of λ
+        (_ , A-ne , B-ne) →
+        (λ { PE.refl → ¬-Neutral-U A-ne })
+      , (λ { PE.refl → ¬-Neutral-U B-ne })
+    (ΠΣ-cong _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+    (Empty-refl _)    → inj₂ ((λ ()) , (λ ()))
+    (Unit-refl _ _)   → inj₂ ((λ ()) , (λ ()))
+    (ℕ-refl _)        → inj₂ ((λ ()) , (λ ()))
+    (Id-cong _ _ _)   → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for U.
+
+  inv-[conv↓]-U :
+    Γ ⊢ U [conv↓] A →
+    A PE.≡ U
+  inv-[conv↓]-U U≡A = case inv-[conv↓]-U′ U≡A of λ where
+    (inj₁ (_ , A≡U)) → A≡U
+    (inj₂ (U≢U , _)) → ⊥-elim (U≢U PE.refl)
+
+opaque
+
+  -- A kind of inversion lemma for Π and Σ.
+
+  inv-[conv↓]-ΠΣ′ :
+    Γ ⊢ A [conv↓] B →
+    (∃₇ λ b p q A₁ A₂ B₁ B₂ →
+     A PE.≡ ΠΣ⟨ b ⟩ p , q ▷ A₁ ▹ A₂ ×
+     B PE.≡ ΠΣ⟨ b ⟩ p , q ▷ B₁ ▹ B₂ ×
+     Γ ⊢ A₁ [conv↑] B₁ × Γ ∙ A₁ ⊢ A₂ [conv↑] B₂) ⊎
+    ¬ (∃₅ λ b p q A₁ A₂ → A PE.≡ ΠΣ⟨ b ⟩ p , q ▷ A₁ ▹ A₂) ×
+    ¬ (∃₅ λ b p q B₁ B₂ → B PE.≡ ΠΣ⟨ b ⟩ p , q ▷ B₁ ▹ B₂)
+  inv-[conv↓]-ΠΣ′ = λ where
+    (ΠΣ-cong _ A₁≡B₁ A₂≡B₂ _) →
+      inj₁ $
+      _ , _ , _ , _ , _ , _ , _ , PE.refl , PE.refl , A₁≡B₁ , A₂≡B₂
+    (ne A~B) →
+      inj₂ $
+      case ne~↓ A~B of λ
+        (_ , A-ne , B-ne) →
+        (λ { (_ , _ , _ , _ , _ , PE.refl) → ¬-Neutral-ΠΣ A-ne })
+      , (λ { (_ , _ , _ , _ , _ , PE.refl) → ¬-Neutral-ΠΣ B-ne })
+    (U-refl _)      → inj₂ ((λ ()) , (λ ()))
+    (Empty-refl _)  → inj₂ ((λ ()) , (λ ()))
+    (Unit-refl _ _) → inj₂ ((λ ()) , (λ ()))
+    (ℕ-refl _)      → inj₂ ((λ ()) , (λ ()))
+    (Id-cong _ _ _) → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for Π and Σ.
+
+  inv-[conv↓]-ΠΣ :
+    Γ ⊢ ΠΣ⟨ b ⟩ p , q ▷ A₁ ▹ A₂ [conv↓] B →
+    ∃₂ λ B₁ B₂ →
+    B PE.≡ ΠΣ⟨ b ⟩ p , q ▷ B₁ ▹ B₂ ×
+    Γ ⊢ A₁ [conv↑] B₁ × Γ ∙ A₁ ⊢ A₂ [conv↑] B₂
+  inv-[conv↓]-ΠΣ ΠΣ≡A = case inv-[conv↓]-ΠΣ′ ΠΣ≡A of λ where
+    (inj₁ (_ , _ , _ , _ , _ , _ , _ , PE.refl , rest)) →
+      _ , _ , rest
+    (inj₂ (ΠΣ≢ΠΣ , _)) →
+      ⊥-elim (ΠΣ≢ΠΣ (_ , _ , _ , _ , _ , PE.refl))
+
+opaque
+
+  -- A kind of inversion lemma for Empty.
+
+  inv-[conv↓]-Empty′ :
+    Γ ⊢ A [conv↓] B →
+    A PE.≡ Empty × B PE.≡ Empty ⊎ A PE.≢ Empty × B PE.≢ Empty
+  inv-[conv↓]-Empty′ = λ where
+    (Empty-refl _) → inj₁ (PE.refl , PE.refl)
+    (ne A~B) →
+      inj₂ $
+      case ne~↓ A~B of λ
+        (_ , A-ne , B-ne) →
+        (λ { PE.refl → ¬-Neutral-Empty A-ne })
+      , (λ { PE.refl → ¬-Neutral-Empty B-ne })
+    (U-refl _)        → inj₂ ((λ ()) , (λ ()))
+    (ΠΣ-cong _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+    (Unit-refl _ _)   → inj₂ ((λ ()) , (λ ()))
+    (ℕ-refl _)        → inj₂ ((λ ()) , (λ ()))
+    (Id-cong _ _ _)   → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for Empty.
+
+  inv-[conv↓]-Empty :
+    Γ ⊢ Empty [conv↓] A →
+    A PE.≡ Empty
+  inv-[conv↓]-Empty Empty≡A = case inv-[conv↓]-Empty′ Empty≡A of λ where
+    (inj₁ (_ , A≡Empty))     → A≡Empty
+    (inj₂ (Empty≢Empty , _)) → ⊥-elim (Empty≢Empty PE.refl)
+
+opaque
+
+  -- A kind of inversion lemma for Unit.
+
+  inv-[conv↓]-Unit′ :
+    Γ ⊢ A [conv↓] B →
+    (∃ λ s → A PE.≡ Unit s × B PE.≡ Unit s) ⊎
+    ¬ (∃ λ s → A PE.≡ Unit s) × ¬ (∃ λ s → B PE.≡ Unit s)
+  inv-[conv↓]-Unit′ = λ where
+    (Unit-refl _ _) → inj₁ (_ , PE.refl , PE.refl)
+    (ne A~B) →
+      inj₂ $
+      case ne~↓ A~B of λ
+        (_ , A-ne , B-ne) →
+        (λ { (_ , PE.refl) → ¬-Neutral-Unit A-ne })
+      , (λ { (_ , PE.refl) → ¬-Neutral-Unit B-ne })
+    (U-refl _)        → inj₂ ((λ ()) , (λ ()))
+    (ΠΣ-cong _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+    (Empty-refl _)    → inj₂ ((λ ()) , (λ ()))
+    (ℕ-refl _)        → inj₂ ((λ ()) , (λ ()))
+    (Id-cong _ _ _)   → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for Unit.
+
+  inv-[conv↓]-Unit :
+    Γ ⊢ Unit s [conv↓] A →
+    A PE.≡ Unit s
+  inv-[conv↓]-Unit Unit≡A = case inv-[conv↓]-Unit′ Unit≡A of λ where
+    (inj₁ (_ , PE.refl , A≡Unit)) → A≡Unit
+    (inj₂ (Unit≢Unit , _))        → ⊥-elim (Unit≢Unit (_ , PE.refl))
+
+opaque
+
+  -- A kind of inversion lemma for ℕ.
+
+  inv-[conv↓]-ℕ′ :
+    Γ ⊢ A [conv↓] B →
+    A PE.≡ ℕ × B PE.≡ ℕ ⊎ A PE.≢ ℕ × B PE.≢ ℕ
+  inv-[conv↓]-ℕ′ = λ where
+    (ℕ-refl _) → inj₁ (PE.refl , PE.refl)
+    (ne A~B) →
+      inj₂ $
+      case ne~↓ A~B of λ
+        (_ , A-ne , B-ne) →
+        (λ { PE.refl → ¬-Neutral-ℕ A-ne })
+      , (λ { PE.refl → ¬-Neutral-ℕ B-ne })
+    (U-refl _)        → inj₂ ((λ ()) , (λ ()))
+    (ΠΣ-cong _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+    (Empty-refl _)    → inj₂ ((λ ()) , (λ ()))
+    (Unit-refl _ _)   → inj₂ ((λ ()) , (λ ()))
+    (Id-cong _ _ _)   → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for ℕ.
+
+  inv-[conv↓]-ℕ :
+    Γ ⊢ ℕ [conv↓] A →
+    A PE.≡ ℕ
+  inv-[conv↓]-ℕ ℕ≡A = case inv-[conv↓]-ℕ′ ℕ≡A of λ where
+    (inj₁ (_ , A≡ℕ)) → A≡ℕ
+    (inj₂ (ℕ≢ℕ , _)) → ⊥-elim (ℕ≢ℕ PE.refl)
+
+opaque
+
+  -- A kind of inversion lemma for Id.
+
+  inv-[conv↓]-Id′ :
+    Γ ⊢ A [conv↓] B →
+    (∃₆ λ A′ t₁ t₂ B′ u₁ u₂ →
+     A PE.≡ Id A′ t₁ t₂ ×
+     B PE.≡ Id B′ u₁ u₂ ×
+    (Γ ⊢ A′ [conv↑] B′) ×
+    Γ ⊢ t₁ [conv↑] u₁ ∷ A′ ×
+    Γ ⊢ t₂ [conv↑] u₂ ∷ A′) ⊎
+    ¬ (∃₃ λ A′ t₁ t₂ → A PE.≡ Id A′ t₁ t₂) ×
+    ¬ (∃₃ λ B′ u₁ u₂ → B PE.≡ Id B′ u₁ u₂)
+  inv-[conv↓]-Id′ = λ where
+    (Id-cong A′≡B′ t₁≡u₁ t₂≡u₂) →
+      inj₁ $
+      _ , _ , _ , _ , _ , _ , PE.refl , PE.refl , A′≡B′ , t₁≡u₁ , t₂≡u₂
+    (ne A~B) →
+      inj₂ $
+      case ne~↓ A~B of λ
+        (_ , A-ne , B-ne) →
+        (λ { (_ , _ , _ , PE.refl) → ¬-Neutral-Id A-ne })
+      , (λ { (_ , _ , _ , PE.refl) → ¬-Neutral-Id B-ne })
+    (U-refl _)        → inj₂ ((λ ()) , (λ ()))
+    (ΠΣ-cong _ _ _ _) → inj₂ ((λ ()) , (λ ()))
+    (Empty-refl _)    → inj₂ ((λ ()) , (λ ()))
+    (Unit-refl _ _)   → inj₂ ((λ ()) , (λ ()))
+    (ℕ-refl _)        → inj₂ ((λ ()) , (λ ()))
+
+opaque
+
+  -- Inversion for Id.
+
+  inv-[conv↓]-Id :
+    Γ ⊢ Id A t₁ t₂ [conv↓] B →
+    ∃₃ λ B′ u₁ u₂ →
+    B PE.≡ Id B′ u₁ u₂ ×
+    (Γ ⊢ A [conv↑] B′) ×
+    Γ ⊢ t₁ [conv↑] u₁ ∷ A ×
+    Γ ⊢ t₂ [conv↑] u₂ ∷ A
+  inv-[conv↓]-Id Id≡A = case inv-[conv↓]-Id′ Id≡A of λ where
+    (inj₁ (_ , _ , _ , _ , _ , _ , PE.refl , rest)) →
+      _ , _ , _ , rest
+    (inj₂ (Id≢Id , _)) →
+      ⊥-elim (Id≢Id (_ , _ , _ , PE.refl))
+
+------------------------------------------------------------------------
+-- Inversion for _⊢_[conv↓]_∷_
+
+opaque
+
+  -- Inversion for neutral types.
+
+  inv-[conv↓]∷-ne :
+    Neutral A →
+    Γ ⊢ t [conv↓] u ∷ A →
+    ∃ λ A → Γ ⊢ t ~ u ↓ A
+  inv-[conv↓]∷-ne A-ne = λ where
+    (ne-ins _ _ _ t~u)    → _ , t~u
+    (univ _ _ _)          → ⊥-elim (¬-Neutral-U     A-ne)
+    (η-eq _ _ _ _ _)      → ⊥-elim (¬-Neutral-ΠΣ    A-ne)
+    (Σ-η _ _ _ _ _ _)     → ⊥-elim (¬-Neutral-ΠΣ    A-ne)
+    (Σʷ-ins _ _ _)        → ⊥-elim (¬-Neutral-ΠΣ    A-ne)
+    (prod-cong _ _ _ _ _) → ⊥-elim (¬-Neutral-ΠΣ    A-ne)
+    (Empty-ins _)         → ⊥-elim (¬-Neutral-Empty A-ne)
+    (Unitʷ-ins _ _)       → ⊥-elim (¬-Neutral-Unit  A-ne)
+    (η-unit _ _ _ _ _)    → ⊥-elim (¬-Neutral-Unit  A-ne)
+    (starʷ-refl _ _ _)    → ⊥-elim (¬-Neutral-Unit  A-ne)
+    (ℕ-ins _)             → ⊥-elim (¬-Neutral-ℕ     A-ne)
+    (zero-refl _)         → ⊥-elim (¬-Neutral-ℕ     A-ne)
+    (suc-cong _)          → ⊥-elim (¬-Neutral-ℕ     A-ne)
+    (Id-ins _ _)          → ⊥-elim (¬-Neutral-Id    A-ne)
+    (rfl-refl _)          → ⊥-elim (¬-Neutral-Id    A-ne)
+
+opaque
+
+  -- Inversion for U.
+
+  inv-[conv↓]∷-U :
+    Γ ⊢ A [conv↓] B ∷ U →
+    Γ ⊢ A [conv↓] B
+  inv-[conv↓]∷-U (univ _ _ A≡B)    = A≡B
+  inv-[conv↓]∷-U (ne-ins _ _ () _)
+
+opaque
+
+  -- Inversion for Π.
+
+  inv-[conv↓]∷-Π :
+    Γ ⊢ t [conv↓] u ∷ Π p , q ▷ A ▹ B →
+    Function t × Function u ×
+    Γ ∙ A ⊢ wk1 t ∘⟨ p ⟩ var x0 [conv↑] wk1 u ∘⟨ p ⟩ var x0 ∷ B
+  inv-[conv↓]∷-Π (η-eq _ _ t-fun u-fun t0≡u0) = t-fun , u-fun , t0≡u0
+  inv-[conv↓]∷-Π (ne-ins _ _ () _)
+
+opaque
+
+  -- Inversion for Σˢ.
+
+  inv-[conv↓]∷-Σˢ :
+    Γ ⊢ t [conv↓] u ∷ Σˢ p , q ▷ A ▹ B →
+    Product t × Product u ×
+    Γ ⊢ fst p t [conv↑] fst p u ∷ A ×
+    Γ ⊢ snd p t [conv↑] snd p u ∷ B [ fst p t ]₀
+  inv-[conv↓]∷-Σˢ (Σ-η _ _ t-prod u-prod fst≡fst snd≡snd) =
+    t-prod , u-prod , fst≡fst , snd≡snd
+  inv-[conv↓]∷-Σˢ (ne-ins _ _ () _)
+
+opaque
+
+  -- Inversion for Σʷ.
+
+  inv-[conv↓]∷-Σʷ :
+    Γ ⊢ t [conv↓] u ∷ Σʷ p , q ▷ A ▹ B →
+    (∃₄ λ p q A B → Γ ⊢ t ~ u ↓ Σʷ p , q ▷ A ▹ B) ⊎
+    (∃₄ λ t₁ t₂ u₁ u₂ →
+     t PE.≡ prodʷ p t₁ t₂ ×
+     u PE.≡ prodʷ p u₁ u₂ ×
+     Γ ⊢ t₁ [conv↑] u₁ ∷ A ×
+     Γ ⊢ t₂ [conv↑] u₂ ∷ B [ t₁ ]₀)
+  inv-[conv↓]∷-Σʷ (Σʷ-ins _ _ t~u) =
+    inj₁ (_ , _ , _ , _ , t~u)
+  inv-[conv↓]∷-Σʷ (prod-cong _ _ t₁≡u₁ t₂≡u₂ _) =
+    inj₂ (_ , _ , _ , _ , PE.refl , PE.refl , t₁≡u₁ , t₂≡u₂)
+  inv-[conv↓]∷-Σʷ (ne-ins _ _ () _)
+
+opaque
+
+  -- Inversion for Empty.
+
+  inv-[conv↓]∷-Empty :
+    Γ ⊢ t [conv↓] u ∷ Empty →
+    Γ ⊢ t ~ u ↓ Empty
+  inv-[conv↓]∷-Empty (Empty-ins t~u)   = t~u
+  inv-[conv↓]∷-Empty (ne-ins _ _ () _)
+
+opaque
+
+  -- Inversion for Unitˢ.
+
+  inv-[conv↓]∷-Unitˢ :
+    Γ ⊢ t [conv↓] u ∷ Unitˢ →
+    Whnf t × Whnf u
+  inv-[conv↓]∷-Unitˢ (η-unit _ _ t-whnf u-whnf _) = t-whnf , u-whnf
+  inv-[conv↓]∷-Unitˢ (ne-ins _ _ () _)
+
+opaque
+
+  -- Inversion for Unitʷ.
+
+  inv-[conv↓]∷-Unitʷ :
+    Γ ⊢ t [conv↓] u ∷ Unitʷ →
+    ¬ Unitʷ-η ×
+    (Γ ⊢ t ~ u ↓ Unitʷ ⊎
+     t PE.≡ starʷ × u PE.≡ starʷ) ⊎
+    Unitʷ-η × Whnf t × Whnf u
+  inv-[conv↓]∷-Unitʷ (Unitʷ-ins no-η t~u) =
+    inj₁ (no-η , inj₁ t~u)
+  inv-[conv↓]∷-Unitʷ (starʷ-refl _ _ no-η) =
+    inj₁ (no-η , inj₂ (PE.refl , PE.refl))
+  inv-[conv↓]∷-Unitʷ (η-unit _ _ t-whnf u-whnf (inj₂ η)) =
+    inj₂ (η , t-whnf , u-whnf)
+  inv-[conv↓]∷-Unitʷ (η-unit _ _ _ _ (inj₁ ()))
+  inv-[conv↓]∷-Unitʷ (ne-ins _ _ () _)
+
+opaque
+
+  -- Inversion for Unit.
+
+  inv-[conv↓]∷-Unit :
+    Γ ⊢ t [conv↓] u ∷ Unit s →
+    Unit-with-η s × Whnf t × Whnf u ⊎
+    ¬ Unit-with-η s ×
+    (Γ ⊢ t ~ u ↓ Unit s ⊎
+     t PE.≡ star s × u PE.≡ star s)
+  inv-[conv↓]∷-Unit {s = 𝕤} t≡u =
+    inj₁ (inj₁ PE.refl , inv-[conv↓]∷-Unitˢ t≡u)
+  inv-[conv↓]∷-Unit {s = 𝕨} t≡u =
+    case inv-[conv↓]∷-Unitʷ t≡u of λ where
+      (inj₂ (η , t-whnf , u-whnf)) →
+        inj₁ (inj₂ η , t-whnf , u-whnf)
+      (inj₁ (no-η , rest)) →
+        inj₂ ([ (λ ()) , no-η ] , rest)
+
+opaque
+
+  -- Inversion for ℕ.
+
+  inv-[conv↓]∷-ℕ :
+    Γ ⊢ t [conv↓] u ∷ ℕ →
+    Γ ⊢ t ~ u ↓ ℕ ⊎
+    (t PE.≡ zero × u PE.≡ zero) ⊎
+    ∃₂ λ t′ u′ → t PE.≡ suc t′ × u PE.≡ suc u′ ×
+    Γ ⊢ t′ [conv↑] u′ ∷ ℕ
+  inv-[conv↓]∷-ℕ (ℕ-ins t~u) =
+    inj₁ t~u
+  inv-[conv↓]∷-ℕ (zero-refl _) =
+    inj₂ (inj₁ (PE.refl , PE.refl))
+  inv-[conv↓]∷-ℕ (suc-cong t≡u) =
+    inj₂ (inj₂ (_ , _ , PE.refl , PE.refl , t≡u))
+  inv-[conv↓]∷-ℕ (ne-ins _ _ () _)
+
+opaque
+
+  -- Inversion for Id.
+
+  inv-[conv↓]∷-Id :
+    Γ ⊢ t [conv↓] u ∷ Id A v w →
+    (∃₃ λ A v w → Γ ⊢ t ~ u ↓ Id A v w) ⊎
+    t PE.≡ rfl × u PE.≡ rfl × Γ ⊢ v ≡ w ∷ A
+  inv-[conv↓]∷-Id (Id-ins _ t~u)    = inj₁ (_ , _ , _ , t~u)
+  inv-[conv↓]∷-Id (rfl-refl v≡w)    = inj₂ (PE.refl , PE.refl , v≡w)
+  inv-[conv↓]∷-Id (ne-ins _ _ () _)

--- a/Definition/Conversion/Lift.agda
+++ b/Definition/Conversion/Lift.agda
@@ -36,6 +36,7 @@ open import Tools.Function
 open import Tools.Nat
 open import Tools.Product
 import Tools.PropositionalEquality as PE
+open import Tools.Sum using (inj₁; inj₂)
 
 private
   variable
@@ -77,9 +78,21 @@ mutual
   lift~toConv↓′ (Emptyᵣ D) D₁ ([~] A (D₂ , whnfB) k~l)
                 rewrite PE.sym (whrDet* (red D , Emptyₙ) (D₁ , whnfB)) =
     Empty-ins ([~] A (D₂ , Emptyₙ) k~l)
-  lift~toConv↓′ (Unitᵣ (Unitₜ D _)) D₁ ([~] A (D₂ , whnfB) k~l)
-                rewrite PE.sym (whrDet* (red D , Unitₙ) (D₁ , whnfB)) =
-    Unit-ins ([~] A (D₂ , Unitₙ) k~l)
+  lift~toConv↓′
+    (Unitᵣ {s} (Unitₜ A′⇒*Unit _)) A′⇒*A
+    t~u↓@([~] _ (B⇒*A , A-whnf) t~u↑) =
+    case whrDet* (red A′⇒*Unit , Unitₙ) (A′⇒*A , A-whnf) of λ {
+      PE.refl →
+    case Unit-with-η? s of λ where
+      (inj₂ (PE.refl , no-η)) → Unitʷ-ins no-η t~u↓
+      (inj₁ η)                →
+        case ne~↑ t~u↑ of λ
+          (t-ne , u-ne) →
+        case syntacticEqTerm (soundness~↑ t~u↑) of λ
+          (_ , ⊢t , ⊢u) →
+        case subset* B⇒*A of λ
+          B≡Unit →
+        η-unit (conv ⊢t B≡Unit) (conv ⊢u B≡Unit) (ne t-ne) (ne u-ne) η }
   lift~toConv↓′ (ne′ H D neH H≡H) D₁ ([~] A (D₂ , whnfB) k~l)
                 rewrite PE.sym (whrDet* (red D , ne neH) (D₁ , whnfB)) =
     let _ , ⊢t , ⊢u = syntacticEqTerm (soundness~↑ k~l)

--- a/Definition/Conversion/Soundness.agda
+++ b/Definition/Conversion/Soundness.agda
@@ -102,8 +102,8 @@ mutual
   soundnessConv↓ (Empty-refl ⊢Γ) = refl (Emptyⱼ ⊢Γ)
   soundnessConv↓ (Unit-refl ⊢Γ ok) = refl (Unitⱼ ⊢Γ ok)
   soundnessConv↓ (ne x) = univ (soundness~↓ x)
-  soundnessConv↓ (ΠΣ-cong F c c₁ ok) =
-    ΠΣ-cong F (soundnessConv↑ c) (soundnessConv↑ c₁) ok
+  soundnessConv↓ (ΠΣ-cong A₁≡A₂ B₁≡B₂ ok) =
+    ΠΣ-cong′ (soundnessConv↑ A₁≡A₂) (soundnessConv↑ B₁≡B₂) ok
   soundnessConv↓ (Id-cong A₁≡A₂ t₁≡t₂ u₁≡u₂) =
     Id-cong (soundnessConv↑ A₁≡A₂) (soundnessConv↑Term t₁≡t₂)
       (soundnessConv↑Term u₁≡u₂)
@@ -136,8 +136,9 @@ mutual
   soundnessConv↓Term (zero-refl ⊢Γ) = refl (zeroⱼ ⊢Γ)
   soundnessConv↓Term (starʷ-refl ⊢Γ ok _) = refl (starⱼ ⊢Γ ok)
   soundnessConv↓Term (suc-cong c) = suc-cong (soundnessConv↑Term c)
-  soundnessConv↓Term (prod-cong x x₁ x₂ x₃ ok) =
-    prod-cong x x₁ (soundnessConv↑Term x₂) (soundnessConv↑Term x₃) ok
+  soundnessConv↓Term (prod-cong x₁ x₂ x₃ ok) =
+    prod-cong (⊢∙→⊢ (wf x₁)) x₁ (soundnessConv↑Term x₂)
+      (soundnessConv↑Term x₃) ok
   soundnessConv↓Term (η-eq x x₁ y y₁ c) =
     let ⊢ΠFG = syntacticTerm x
         ⊢F , _ = syntacticΠ ⊢ΠFG

--- a/Definition/Conversion/Soundness.agda
+++ b/Definition/Conversion/Soundness.agda
@@ -120,7 +120,7 @@ mutual
   soundnessConv↓Term : ∀ {a b A} → Γ ⊢ a [conv↓] b ∷ A → Γ ⊢ a ≡ b ∷ A
   soundnessConv↓Term (ℕ-ins x) = soundness~↓ x
   soundnessConv↓Term (Empty-ins x) = soundness~↓ x
-  soundnessConv↓Term (Unit-ins x) = soundness~↓ x
+  soundnessConv↓Term (Unitʷ-ins _ t~u) = soundness~↓ t~u
   soundnessConv↓Term (Σʷ-ins x x₁ x₂) =
     let a≡b = soundness~↓ x₂
         _ , neA , _ = ne~↓ x₂

--- a/Definition/Conversion/Stability.agda
+++ b/Definition/Conversion/Stability.agda
@@ -123,9 +123,11 @@ mutual
     in  Unit-refl ⊢Δ ok
   stabilityConv↓ Γ≡Δ (ne x) =
     ne (stability~↓ Γ≡Δ x)
-  stabilityConv↓ Γ≡Δ (ΠΣ-cong F A<>B A<>B₁ ok) =
-    ΠΣ-cong (stability Γ≡Δ F) (stabilityConv↑ Γ≡Δ A<>B)
-      (stabilityConv↑ (Γ≡Δ ∙ refl F) A<>B₁) ok
+  stabilityConv↓ Γ≡Δ (ΠΣ-cong A<>B A<>B₁ ok) =
+    ΠΣ-cong (stabilityConv↑ Γ≡Δ A<>B)
+      (stabilityConv↑
+         (Γ≡Δ ∙ refl (syntacticEq (soundnessConv↑ A<>B) .proj₁)) A<>B₁)
+      ok
   stabilityConv↓ Γ≡Δ (Id-cong A₁≡A₂ t₁≡t₂ u₁≡u₂) =
     Id-cong (stabilityConv↑ Γ≡Δ A₁≡A₂) (stabilityConv↑Term Γ≡Δ t₁≡t₂)
       (stabilityConv↑Term Γ≡Δ u₁≡u₂)
@@ -164,8 +166,8 @@ mutual
     let _ , ⊢Δ , _ = contextConvSubst Γ≡Δ
     in  starʷ-refl ⊢Δ ok no-η
   stabilityConv↓Term Γ≡Δ (suc-cong t<>u) = suc-cong (stabilityConv↑Term Γ≡Δ t<>u)
-  stabilityConv↓Term Γ≡Δ (prod-cong x x₁ x₂ x₃ ok) =
-    prod-cong (stability Γ≡Δ x) (stability (Γ≡Δ ∙ refl x) x₁)
+  stabilityConv↓Term Γ≡Δ (prod-cong x₁ x₂ x₃ ok) =
+    prod-cong (stability (Γ≡Δ ∙ refl (⊢∙→⊢ (wf x₁))) x₁)
       (stabilityConv↑Term Γ≡Δ x₂) (stabilityConv↑Term Γ≡Δ x₃) ok
   stabilityConv↓Term Γ≡Δ (η-eq x x₁ y y₁ t<>u) =
     let ⊢F , ⊢G = syntacticΠ (syntacticTerm x)

--- a/Definition/Conversion/Stability.agda
+++ b/Definition/Conversion/Stability.agda
@@ -149,8 +149,8 @@ mutual
     ℕ-ins (stability~↓ Γ≡Δ x)
   stabilityConv↓Term Γ≡Δ (Empty-ins x) =
     Empty-ins (stability~↓ Γ≡Δ x)
-  stabilityConv↓Term Γ≡Δ (Unit-ins x) =
-    Unit-ins (stability~↓ Γ≡Δ x)
+  stabilityConv↓Term Γ≡Δ (Unitʷ-ins ok t~u) =
+    Unitʷ-ins ok (stability~↓ Γ≡Δ t~u)
   stabilityConv↓Term Γ≡Δ (Σʷ-ins x x₁ x₂) =
     Σʷ-ins (stabilityTerm Γ≡Δ x) (stabilityTerm Γ≡Δ x₁) (stability~↓ Γ≡Δ x₂)
   stabilityConv↓Term Γ≡Δ (ne-ins t u neN x) =

--- a/Definition/Conversion/Symmetry.agda
+++ b/Definition/Conversion/Symmetry.agda
@@ -279,10 +279,10 @@ mutual
     let B , whnfB , A≡B , u~t = sym~↓ Γ≡Δ t~u
         B≡Empty = Empty≡A A≡B whnfB
     in  Empty-ins (PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) B≡Empty u~t)
-  symConv↓Term Γ≡Δ (Unit-ins t~u) =
+  symConv↓Term Γ≡Δ (Unitʷ-ins ok t~u) =
     let B , whnfB , A≡B , u~t = sym~↓ Γ≡Δ t~u
         B≡Unit = Unit≡A A≡B whnfB
-    in  Unit-ins (PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) B≡Unit u~t)
+    in  Unitʷ-ins ok (PE.subst (_⊢_~_↓_ _ _ _) B≡Unit u~t)
   symConv↓Term Γ≡Δ (Σʷ-ins t u t~u) =
     case sym~↓ Γ≡Δ t~u of λ (B , whnfB , A≡B , u~t) →
     case Σ≡A A≡B whnfB of λ where

--- a/Definition/Conversion/Symmetry.agda
+++ b/Definition/Conversion/Symmetry.agda
@@ -249,10 +249,9 @@ mutual
     let B , whnfB , U≡B , B~A = sym~↓ Γ≡Δ A~B
         B≡U = U≡A U≡B
     in  ne (PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) B≡U B~A)
-  symConv↓ Γ≡Δ (ΠΣ-cong x A<>B A<>B₁ ok) =
+  symConv↓ Γ≡Δ (ΠΣ-cong A<>B A<>B₁ ok) =
     let F≡H = soundnessConv↑ A<>B
-        _ , ⊢H = syntacticEq (stabilityEq Γ≡Δ F≡H)
-    in  ΠΣ-cong ⊢H (symConv↑ Γ≡Δ A<>B)
+    in  ΠΣ-cong (symConv↑ Γ≡Δ A<>B)
           (symConv↑ (Γ≡Δ ∙ F≡H) A<>B₁) ok
   symConv↓ Γ≡Δ (Id-cong A₁≡A₂ t₁≡t₂ u₁≡u₂) =
     case soundnessConv↑ A₁≡A₂ of λ {
@@ -300,14 +299,13 @@ mutual
     let _ , ⊢Δ , _ = contextConvSubst Γ≡Δ
     in  starʷ-refl ⊢Δ ok no-η
   symConv↓Term Γ≡Δ (suc-cong t<>u) = suc-cong (symConv↑Term Γ≡Δ t<>u)
-  symConv↓Term Γ≡Δ (prod-cong x x₁ x₂ x₃ ok) =
-    let Δ⊢F = stability Γ≡Δ x
-        Δ⊢G = stability (Γ≡Δ ∙ refl x) x₁
+  symConv↓Term Γ≡Δ (prod-cong x₁ x₂ x₃ ok) =
+    let Δ⊢G = stability (Γ≡Δ ∙ refl (⊢∙→⊢ (wf x₁))) x₁
         Δ⊢t′↑t = symConv↑Term Γ≡Δ x₂
         _ , ⊢Δ , _ = contextConvSubst Γ≡Δ
         Δ⊢u′↑u = symConv↑Term Γ≡Δ x₃
         Gt≡Gt′ = substTypeEq (refl Δ⊢G) (sym (soundnessConv↑Term Δ⊢t′↑t))
-    in  prod-cong Δ⊢F Δ⊢G Δ⊢t′↑t
+    in  prod-cong Δ⊢G Δ⊢t′↑t
           (convConv↑Term (reflConEq ⊢Δ) Gt≡Gt′ Δ⊢u′↑u) ok
   symConv↓Term Γ≡Δ (η-eq x₁ x₂ y y₁ t<>u) =
     let ⊢F , _ = syntacticΠ (syntacticTerm x₁)

--- a/Definition/Conversion/Symmetry.agda
+++ b/Definition/Conversion/Symmetry.agda
@@ -65,7 +65,7 @@ mutual
       (F≡F′ , G≡G′ , _ , _) →
     _ , substTypeEq G≡G′ (soundnessConv↑Term x) ,
     app-cong (PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) ΠF′G′≡B u~t)
-      (convConvTerm (symConv↑Term Γ≡Δ x) (stabilityEq Γ≡Δ F≡F′)) }}}}
+      (convConv↑Term (stabilityEq Γ≡Δ F≡F′) (symConv↑Term Γ≡Δ x)) }}}}
   sym~↑ Γ≡Δ (fst-cong p~r) =
     case sym~↓ Γ≡Δ p~r of λ (B , whnfB , A≡B , r~p) →
     case Σ≡A A≡B whnfB of λ where
@@ -88,10 +88,12 @@ mutual
         F≡G = stabilityEq (Γ≡Δ ∙ refl (ℕⱼ ⊢Γ)) (soundnessConv↑ x)
         F[0]≡G[0] = substTypeEq F≡G (refl (zeroⱼ ⊢Δ))
     in  _ , substTypeEq (soundnessConv↑ x) (soundness~↓ t~u)
-    ,   natrec-cong (symConv↑ (Γ≡Δ ∙ (refl (ℕⱼ ⊢Γ))) x)
-                    (convConvTerm (symConv↑Term Γ≡Δ x₁) F[0]≡G[0])
-                    (convConvTerm (symConv↑Term (Γ≡Δ ∙ refl (ℕⱼ ⊢Γ) ∙ soundnessConv↑ x) x₂) (sucCong′ F≡G))
-                    (PE.subst (λ x → _ ⊢ _ ~ _ ↓ x) B≡ℕ u~t)
+    ,   natrec-cong
+          (symConv↑ (Γ≡Δ ∙ refl (ℕⱼ ⊢Γ)) x)
+          (convConv↑Term F[0]≡G[0] (symConv↑Term Γ≡Δ x₁))
+          (convConv↑Term (sucCong′ F≡G)
+             (symConv↑Term (Γ≡Δ ∙ refl (ℕⱼ ⊢Γ) ∙ soundnessConv↑ x) x₂))
+          (PE.subst (_⊢_~_↓_ _ _ _) B≡ℕ u~t)
   sym~↑ {Γ = Γ} {Δ = Δ} Γ≡Δ
     (prodrec-cong {F = F} {G = G} C↑E g~h u↑v) =
     case sym~↓ Γ≡Δ g~h of λ (B , whnfB , ⊢Σ≡B , h~g) →
@@ -116,7 +118,7 @@ mutual
                           ok
             in  _ , substTypeEq C≡E g≡h
               , prodrec-cong E↑C h~g
-                  (convConv↑Term (reflConEq ⊢Δ ∙ ⊢F≡F′ ∙ ⊢G≡G′)
+                  (convConv↑Term′ (reflConEq ⊢Δ ∙ ⊢F≡F′ ∙ ⊢G≡G′)
                      C₊≡E₊ v↑u)
   sym~↑ Γ≡Δ (emptyrec-cong x t~u) =
     let ⊢Γ , ⊢Δ , _ = contextConvSubst Γ≡Δ
@@ -134,12 +136,12 @@ mutual
         l~k′ = PE.subst (λ x → _ ⊢ _ ~ _ ↓ x)
                         (Unit≡A Unit≡B whB)
                         l~k
-        ⊢Γ , ⊢Δ , _ = contextConvSubst Γ≡Δ
+        ⊢Γ , _ = contextConvSubst Γ≡Δ
         v<>u = symConv↑Term Γ≡Δ u<>v
         ⊢F≡H = soundnessConv↑ F<>H
         ⊢F₊≡H₊ = substTypeEq ⊢F≡H (refl (starⱼ ⊢Γ (inversion-Unit ⊢Unit)))
         ⊢Fk≡Hl = substTypeEq ⊢F≡H k≡l
-        v<>u′ = convConv↑Term (reflConEq ⊢Δ) (stabilityEq Γ≡Δ ⊢F₊≡H₊) v<>u
+        v<>u′ = convConv↑Term (stabilityEq Γ≡Δ ⊢F₊≡H₊) v<>u
     in  _ , ⊢Fk≡Hl , unitrec-cong H<>F l~k′ v<>u′ no-η
   sym~↑ Γ≡Δ (J-cong A₁≡A₂ t₁≡t₂ B₁≡B₂ u₁≡u₂ v₁≡v₂ w₁~w₂ C≡Id-t₁-v₁) =
     case sym~↓ Γ≡Δ w₁~w₂ of λ {
@@ -157,11 +159,11 @@ mutual
       _
     , J-result-cong ⊢B₁≡B₂ ⊢v₁≡v₂ (conv (soundness~↓ w₁~w₂) C≡Id-t₁-v₁)
     , J-cong (symConv↑ Γ≡Δ A₁≡A₂)
-        (convConv↑Term Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ t₁≡t₂))
+        (convConv↑Term′ Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ t₁≡t₂))
         (symConv↑ (J-motive-context-cong Γ≡Δ ⊢A₁≡A₂ ⊢t₁≡t₂) B₁≡B₂)
-        (convConv↑Term Γ≡Δ (J-motive-rfl-cong ⊢B₁≡B₂ ⊢t₁≡t₂)
+        (convConv↑Term′ Γ≡Δ (J-motive-rfl-cong ⊢B₁≡B₂ ⊢t₁≡t₂)
            (symConv↑Term Γ≡Γ u₁≡u₂))
-        (convConv↑Term Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ v₁≡v₂)) w₂~w₁
+        (convConv↑Term′ Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ v₁≡v₂)) w₂~w₁
         (stabilityEq Γ≡Δ $
          trans (trans (sym C≡D) C≡Id-t₁-v₁)
            (Id-cong ⊢A₁≡A₂ ⊢t₁≡t₂ ⊢v₁≡v₂)) }}}}}}
@@ -180,9 +182,9 @@ mutual
     , substTypeEq ⊢B₁≡B₂
         (conv (soundness~↓ v₁~v₂) C≡Id-t₁-t₁)
     , K-cong (symConv↑ Γ≡Δ A₁≡A₂)
-        (convConv↑Term Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ t₁≡t₂))
+        (convConv↑Term′ Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ t₁≡t₂))
         (symConv↑ (K-motive-context-cong Γ≡Δ ⊢A₁≡A₂ ⊢t₁≡t₂) B₁≡B₂)
-        (convConv↑Term Γ≡Δ (K-motive-rfl-cong ⊢B₁≡B₂)
+        (convConv↑Term′ Γ≡Δ (K-motive-rfl-cong ⊢B₁≡B₂)
            (symConv↑Term Γ≡Γ u₁≡u₂))
         v₂~v₁
         (stabilityEq Γ≡Δ $
@@ -206,8 +208,8 @@ mutual
     , Id-cong (Erased-cong Erased-ok ⊢A₁≡A₂) ([]-cong′ Erased-ok ⊢t₁≡t₂)
         ([]-cong′ Erased-ok ⊢u₁≡u₂)
     , []-cong-cong (symConv↑ Γ≡Δ A₁≡A₂)
-        (convConv↑Term Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ t₁≡t₂))
-        (convConv↑Term Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ u₁≡u₂))
+        (convConv↑Term′ Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ t₁≡t₂))
+        (convConv↑Term′ Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ u₁≡u₂))
         v₂~v₁
         (stabilityEq Γ≡Δ $
          trans (trans (sym B≡C) B≡Id-t₁-u₁)
@@ -259,8 +261,8 @@ mutual
     case reflConEq (wfEq ⊢A₁≡A₂) of λ {
       Γ≡Γ →
     Id-cong (symConv↑ Γ≡Δ A₁≡A₂)
-      (convConv↑Term Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ t₁≡t₂))
-      (convConv↑Term Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ u₁≡u₂)) }}
+      (convConv↑Term′ Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ t₁≡t₂))
+      (convConv↑Term′ Γ≡Δ ⊢A₁≡A₂ (symConv↑Term Γ≡Γ u₁≡u₂)) }}
 
   -- Symmetry of algorithmic equality of terms.
   symConv↑Term : ∀ {t u A} → ⊢ Γ ≡ Δ → Γ ⊢ t [conv↑] u ∷ A → Δ ⊢ u [conv↑] t ∷ A
@@ -302,11 +304,9 @@ mutual
   symConv↓Term Γ≡Δ (prod-cong x₁ x₂ x₃ ok) =
     let Δ⊢G = stability (Γ≡Δ ∙ refl (⊢∙→⊢ (wf x₁))) x₁
         Δ⊢t′↑t = symConv↑Term Γ≡Δ x₂
-        _ , ⊢Δ , _ = contextConvSubst Γ≡Δ
         Δ⊢u′↑u = symConv↑Term Γ≡Δ x₃
         Gt≡Gt′ = substTypeEq (refl Δ⊢G) (sym (soundnessConv↑Term Δ⊢t′↑t))
-    in  prod-cong Δ⊢G Δ⊢t′↑t
-          (convConv↑Term (reflConEq ⊢Δ) Gt≡Gt′ Δ⊢u′↑u) ok
+    in  prod-cong Δ⊢G Δ⊢t′↑t (convConv↑Term Gt≡Gt′ Δ⊢u′↑u) ok
   symConv↓Term Γ≡Δ (η-eq x₁ x₂ y y₁ t<>u) =
     let ⊢F , _ = syntacticΠ (syntacticTerm x₁)
     in  η-eq (stabilityTerm Γ≡Δ x₂) (stabilityTerm Γ≡Δ x₁)
@@ -319,7 +319,7 @@ mutual
         Δsnd≡₁ = symConv↑Term Γ≡Δ sndConv
         ΔGfstt≡Gfstu = stabilityEq Γ≡Δ (substTypeEq (refl ⊢G)
                                                     (soundnessConv↑Term fstConv))
-        Δsnd≡ = convConvTerm Δsnd≡₁ ΔGfstt≡Gfstu
+        Δsnd≡ = convConv↑Term ΔGfstt≡Gfstu Δsnd≡₁
     in  Σ-η Δ⊢r Δ⊢p rProd pProd Δfst≡ Δsnd≡
   symConv↓Term Γ≡Δ (η-unit [t] [u] tUnit uUnit ok) =
     let [t] = stabilityTerm Γ≡Δ [t]

--- a/Definition/Conversion/Transitivity.agda
+++ b/Definition/Conversion/Transitivity.agda
@@ -273,14 +273,14 @@ mutual
     ℕ-ins (proj₁ (trans~↓ x x₁))
   transConv↓Term A≡B (Empty-ins x) (Empty-ins x₁) =
     Empty-ins (proj₁ (trans~↓ x x₁))
-  transConv↓Term A≡B (Unit-ins x) (Unit-ins x₁) =
-    Unit-ins (proj₁ (trans~↓ x x₁))
-  transConv↓Term A≡B (Unit-ins x) (η-unit x₁ x₂ x₃ x₄ ok) =
+  transConv↓Term A≡B (Unitʷ-ins ok t~u) (Unitʷ-ins _ u~v) =
+    Unitʷ-ins ok (trans~↓ t~u u~v .proj₁)
+  transConv↓Term A≡B (Unitʷ-ins no-η _) (η-unit _ _ _ _ η) =
     case Unit-injectivity A≡B of λ {
       PE.refl →
-    let _ , ⊢t , _ =  syntacticEqTerm (soundness~↓ x)
-        _ , neT , _ = ne~↓ x
-    in  η-unit ⊢t x₂ (ne neT) x₄ ok }
+    case η of λ where
+      (inj₁ ())
+      (inj₂ η)  → ⊥-elim (no-η η) }
   transConv↓Term A≡B (Σʷ-ins t u x) (Σʷ-ins t′ u′ x₁) =
     Σʷ-ins t (conv u′ (sym A≡B)) (proj₁ (trans~↓ x x₁))
   transConv↓Term A≡B (ne-ins t u x x₁) (ne-ins t′ u′ x₂ x₃) =
@@ -333,7 +333,7 @@ mutual
   transConv↓Term A≡B (ℕ-ins x) (ne-ins t u x₂ x₃) = ⊥-elim (WF.ℕ≢ne x₂ A≡B)
   transConv↓Term A≡B (ℕ-ins x) (univ x₂ x₃ x₄) = ⊥-elim (WF.U≢ℕ (sym A≡B))
   transConv↓Term A≡B (ℕ-ins x) (Empty-ins x₁) = ⊥-elim (WF.ℕ≢Emptyⱼ A≡B)
-  transConv↓Term A≡B (ℕ-ins x) (Unit-ins x₁) = ⊥-elim (WF.ℕ≢Unitⱼ A≡B)
+  transConv↓Term A≡B (ℕ-ins _) (Unitʷ-ins _ _) = ⊥-elim (WF.ℕ≢Unitⱼ A≡B)
   transConv↓Term A≡B (ℕ-ins x) (Σʷ-ins x₁ x₂ x₃) = ⊥-elim (WF.ℕ≢Σ A≡B)
   transConv↓Term A≡B (ℕ-ins ([~] _ _ ())) (suc-cong x₂)
   transConv↓Term A≡B (ℕ-ins _) (prod-cong _ _ _ _ _) = ⊥-elim (WF.ℕ≢Σ A≡B)
@@ -344,7 +344,7 @@ mutual
   transConv↓Term A≡B (Empty-ins x) (ne-ins t u x₂ x₃) = ⊥-elim (WF.Empty≢neⱼ x₂ A≡B)
   transConv↓Term A≡B (Empty-ins x) (univ x₂ x₃ x₄) = ⊥-elim (WF.U≢Emptyⱼ (sym A≡B))
   transConv↓Term A≡B (Empty-ins x₁) (ℕ-ins x) = ⊥-elim (WF.ℕ≢Emptyⱼ (sym A≡B))
-  transConv↓Term A≡B (Empty-ins x₁) (Unit-ins x) = ⊥-elim (WF.Empty≢Unitⱼ A≡B)
+  transConv↓Term A≡B (Empty-ins _) (Unitʷ-ins _ _) = ⊥-elim (WF.Empty≢Unitⱼ A≡B)
   transConv↓Term A≡B (Empty-ins x) (Σʷ-ins x₁ x₂ x₃) = ⊥-elim (WF.Empty≢Σⱼ A≡B)
   transConv↓Term A≡B (Empty-ins ([~] _ _ ())) (suc-cong x₂)
   transConv↓Term A≡B (Empty-ins _) (prod-cong _ _ _ _ _) = ⊥-elim (WF.Empty≢Σⱼ A≡B)
@@ -352,17 +352,17 @@ mutual
   transConv↓Term A≡B (Empty-ins x₁) (Σ-η x₂ x₃ x₄ x₅ x₆ x₇) = ⊥-elim (WF.Empty≢Σⱼ A≡B)
   transConv↓Term A≡B (Empty-ins x₁) (η-unit _ _ _ _ _) = ⊥-elim (WF.Empty≢Unitⱼ A≡B)
   transConv↓Term A≡B (Empty-ins _) (Id-ins _ _) = ⊥-elim (WF.Id≢Empty (sym A≡B))
-  transConv↓Term A≡B (Unit-ins x) (ℕ-ins x₁) = ⊥-elim (WF.ℕ≢Unitⱼ (sym A≡B))
-  transConv↓Term A≡B (Unit-ins x) (Empty-ins x₁) = ⊥-elim (WF.Empty≢Unitⱼ (sym A≡B))
-  transConv↓Term A≡B (Unit-ins x) (Σʷ-ins x₁ x₂ x₃) = ⊥-elim (WF.Unit≢Σⱼ A≡B)
-  transConv↓Term A≡B (Unit-ins x) (ne-ins x₁ x₂ x₃ x₄) = ⊥-elim (WF.Unit≢neⱼ x₃ A≡B)
-  transConv↓Term A≡B (Unit-ins x) (univ x₁ x₂ x₃) = ⊥-elim (WF.U≢Unitⱼ (sym A≡B))
-  transConv↓Term A≡B (Unit-ins x) (η-eq x₁ x₂ x₃ x₄ x₅) = ⊥-elim (WF.Unit≢Πⱼ A≡B)
-  transConv↓Term A≡B (Unit-ins x) (Σ-η x₁ x₂ x₃ x₄ x₅ x₆) = ⊥-elim (WF.Unit≢Σⱼ A≡B)
-  transConv↓Term A≡B (Unit-ins x) (Id-ins x₁ x₂) = ⊥-elim (WF.Id≢Unit (sym A≡B))
+  transConv↓Term A≡B (Unitʷ-ins _ _) (ℕ-ins _) = ⊥-elim (WF.ℕ≢Unitⱼ (sym A≡B))
+  transConv↓Term A≡B (Unitʷ-ins _ _) (Empty-ins _) = ⊥-elim (WF.Empty≢Unitⱼ (sym A≡B))
+  transConv↓Term A≡B (Unitʷ-ins _ _) (Σʷ-ins _ _ _) = ⊥-elim (WF.Unit≢Σⱼ A≡B)
+  transConv↓Term A≡B (Unitʷ-ins _ _) (ne-ins _ _ B-ne _) = ⊥-elim (WF.Unit≢neⱼ B-ne A≡B)
+  transConv↓Term A≡B (Unitʷ-ins _ _) (univ _ _ _) = ⊥-elim (WF.U≢Unitⱼ (sym A≡B))
+  transConv↓Term A≡B (Unitʷ-ins _ _) (η-eq _ _ _ _ _) = ⊥-elim (WF.Unit≢Πⱼ A≡B)
+  transConv↓Term A≡B (Unitʷ-ins _ _) (Σ-η _ _ _ _ _ _) = ⊥-elim (WF.Unit≢Σⱼ A≡B)
+  transConv↓Term A≡B (Unitʷ-ins _ _) (Id-ins _ _) = ⊥-elim (WF.Id≢Unit (sym A≡B))
   transConv↓Term A≡B (Σʷ-ins x x₁ x₂) (ℕ-ins x₃) = ⊥-elim (WF.ℕ≢Σ (sym A≡B))
   transConv↓Term A≡B (Σʷ-ins x x₁ x₂) (Empty-ins x₃) = ⊥-elim (WF.Empty≢Σⱼ (sym A≡B))
-  transConv↓Term A≡B (Σʷ-ins x x₁ x₂) (Unit-ins x₃) = ⊥-elim (WF.Unit≢Σⱼ (sym A≡B))
+  transConv↓Term A≡B (Σʷ-ins _ _ _) (Unitʷ-ins _ _) = ⊥-elim (WF.Unit≢Σⱼ (sym A≡B))
   transConv↓Term A≡B (Σʷ-ins x x₁ x₂) (ne-ins x₃ x₄ x₅ x₆) = ⊥-elim (WF.Σ≢ne x₅ A≡B)
   transConv↓Term A≡B (Σʷ-ins x x₁ x₂) (univ x₃ x₄ x₅) = ⊥-elim (WF.U≢Σ (sym A≡B))
   transConv↓Term A≡B (Σʷ-ins x x₁ x₂) (η-eq x₃ x₄ x₅ x₆ x₇) = ⊥-elim (WF.Π≢Σⱼ (sym A≡B))
@@ -371,7 +371,7 @@ mutual
   transConv↓Term A≡B (Σʷ-ins _ _ _) (Id-ins _ _) = ⊥-elim (WF.Id≢ΠΣ (sym A≡B))
   transConv↓Term A≡B (ne-ins t u x x₁) (ℕ-ins x₂) = ⊥-elim (WF.ℕ≢ne x (sym A≡B))
   transConv↓Term A≡B (ne-ins t u x x₁) (Empty-ins x₂) = ⊥-elim (WF.Empty≢neⱼ x (sym A≡B))
-  transConv↓Term A≡B (ne-ins t u x x₁) (Unit-ins x₂) = ⊥-elim (WF.Unit≢neⱼ x (sym A≡B))
+  transConv↓Term A≡B (ne-ins _ _ A-ne _) (Unitʷ-ins _ _) = ⊥-elim (WF.Unit≢neⱼ A-ne (sym A≡B))
   transConv↓Term A≡B (ne-ins x x₁ x₂ x₃) (Σʷ-ins x₄ x₅ x₆) = ⊥-elim (WF.Σ≢ne x₂ (sym A≡B))
   transConv↓Term A≡B (ne-ins t u x x₁) (univ x₃ x₄ x₅) = ⊥-elim (WF.U≢ne x (sym A≡B))
   transConv↓Term A≡B (ne-ins t u x ([~] _ _ ())) (suc-cong x₃)
@@ -382,7 +382,7 @@ mutual
   transConv↓Term A≡B (ne-ins _ _ n _) (Id-ins _ _) = ⊥-elim (WF.Id≢ne n (sym A≡B))
   transConv↓Term A≡B (univ x x₁ x₂) (ℕ-ins x₃) = ⊥-elim (WF.U≢ℕ A≡B)
   transConv↓Term A≡B (univ x x₁ x₂) (Empty-ins x₃) = ⊥-elim (WF.U≢Emptyⱼ A≡B)
-  transConv↓Term A≡B (univ x x₁ x₂) (Unit-ins x₃) = ⊥-elim (WF.U≢Unitⱼ A≡B)
+  transConv↓Term A≡B (univ _ _ _) (Unitʷ-ins _ _) = ⊥-elim (WF.U≢Unitⱼ A≡B)
   transConv↓Term A≡B (univ x x₁ x₂) (Σʷ-ins x₃ x₄ x₅) = ⊥-elim (WF.U≢Σ A≡B)
   transConv↓Term A≡B (univ x x₁ x₂) (ne-ins t u x₃ x₄) = ⊥-elim (WF.U≢ne x₃ A≡B)
   transConv↓Term A≡B (univ x x₁ x₂) (suc-cong x₃) = ⊥-elim (WF.U≢ℕ A≡B)
@@ -405,7 +405,7 @@ mutual
   transConv↓Term A≡B (prod-cong _ _ _ _ _) (η-unit _ _ _ _ _) = ⊥-elim (WF.Unit≢Σⱼ (sym A≡B))
   transConv↓Term A≡B (η-eq x₁ x₂ y y₁ x₃) (ℕ-ins x₄) = ⊥-elim (WF.ℕ≢Π (sym A≡B))
   transConv↓Term A≡B (η-eq x₁ x₂ y y₁ x₃) (Empty-ins x₄) = ⊥-elim (WF.Empty≢Πⱼ (sym A≡B))
-  transConv↓Term A≡B (η-eq x₁ x₂ y y₁ x₃) (Unit-ins _) = ⊥-elim (WF.Unit≢Πⱼ (sym A≡B))
+  transConv↓Term A≡B (η-eq _ _ _ _ _) (Unitʷ-ins _ _) = ⊥-elim (WF.Unit≢Πⱼ (sym A≡B))
   transConv↓Term A≡B (η-eq x x₁ x₂ x₃ x₄) (Σʷ-ins x₅ x₆ x₇) = ⊥-elim (WF.Π≢Σⱼ A≡B)
   transConv↓Term A≡B (η-eq x₁ x₂ y y₁ x₃) (ne-ins t u x₄ x₅) = ⊥-elim (WF.Π≢ne x₄ A≡B)
   transConv↓Term A≡B (η-eq x₁ x₂ y y₁ x₃) (univ x₄ x₅ x₆) = ⊥-elim (WF.U≢Π (sym A≡B))
@@ -416,7 +416,7 @@ mutual
   transConv↓Term A≡B (η-eq _ _ _ _ _) (Id-ins _ _) = ⊥-elim (WF.Id≢ΠΣ (sym A≡B))
   transConv↓Term A≡B (Σ-η x₁ x₂ x₃ x₄ x₅ x₆) (ℕ-ins x₇) = ⊥-elim (WF.ℕ≢Σ (sym A≡B))
   transConv↓Term A≡B (Σ-η x₁ x₂ x₃ x₄ x₅ x₆) (Empty-ins x₇) = ⊥-elim (WF.Empty≢Σⱼ (sym A≡B))
-  transConv↓Term A≡B (Σ-η x₁ x₂ x₃ x₄ x₅ x₆) (Unit-ins x₇) = ⊥-elim (WF.Unit≢Σⱼ (sym A≡B))
+  transConv↓Term A≡B (Σ-η _ _ _ _ _ _) (Unitʷ-ins _ _) = ⊥-elim (WF.Unit≢Σⱼ (sym A≡B))
   transConv↓Term A≡B (Σ-η x x₁ x₂ x₃ x₄ x₅) (Σʷ-ins x₆ x₇ x₈) = ⊥-elim (WF.Σˢ≢Σʷⱼ A≡B)
   transConv↓Term A≡B (Σ-η x₁ x₂ x₃ x₄ x₅ x₆) (ne-ins x₇ x₈ x₉ x₁₀) = ⊥-elim (WF.Σ≢ne x₉ A≡B)
   transConv↓Term A≡B (Σ-η x₁ x₂ x₃ x₄ x₅ x₆) (univ x₇ x₈ x₉) = ⊥-elim (WF.U≢Σ (sym A≡B))
@@ -427,7 +427,7 @@ mutual
   transConv↓Term A≡B (Σ-η _ _ _ _ _ _) (Id-ins _ _) = ⊥-elim (WF.Id≢ΠΣ (sym A≡B))
   transConv↓Term A≡B (Id-ins _ _) (ℕ-ins _) = ⊥-elim (WF.Id≢ℕ A≡B)
   transConv↓Term A≡B (Id-ins _ _) (Empty-ins _) = ⊥-elim (WF.Id≢Empty A≡B)
-  transConv↓Term A≡B (Id-ins _ _) (Unit-ins _) = ⊥-elim (WF.Id≢Unit A≡B)
+  transConv↓Term A≡B (Id-ins _ _) (Unitʷ-ins _ _) = ⊥-elim (WF.Id≢Unit A≡B)
   transConv↓Term A≡B (Id-ins _ _) (Σʷ-ins _ _ _) = ⊥-elim (WF.Id≢ΠΣ A≡B)
   transConv↓Term A≡B (Id-ins _ _) (ne-ins _ _ n _) = ⊥-elim (WF.Id≢ne n A≡B)
   transConv↓Term A≡B (Id-ins _ _) (univ _ _ _) = ⊥-elim (WF.Id≢U A≡B)
@@ -436,16 +436,16 @@ mutual
   transConv↓Term A≡B (Id-ins _ _) (η-unit _ _ _ _ _) = ⊥-elim (WF.Id≢Unit A≡B)
   transConv↓Term A≡B (Σʷ-ins x x₁ ()) (suc-cong x₃)
   transConv↓Term _ (Σʷ-ins _ _ ()) (prod-cong _ _ _ _ _)
-  transConv↓Term A≡B (suc-cong x) (Unit-ins ())
+  transConv↓Term _ (suc-cong _) (Unitʷ-ins _ ())
   transConv↓Term A≡B (suc-cong x) (Σʷ-ins x₁ x₂ ())
   transConv↓Term _ (prod-cong _ _ _ _ _) (ℕ-ins ())
   transConv↓Term _ (prod-cong _ _ _ _ _) (Empty-ins ())
-  transConv↓Term _ (prod-cong _ _ _ _ _) (Unit-ins ())
+  transConv↓Term _ (prod-cong _ _ _ _ _) (Unitʷ-ins _ ())
   transConv↓Term _ (prod-cong _ _ _ _ _) (Σʷ-ins _ _ ())
   transConv↓Term _ (prod-cong _ _ _ _ _) (ne-ins _ _ _ ())
   transConv↓Term _ (prod-cong _ _ _ _ _) (Id-ins _ ())
-  transConv↓Term _ (Unit-ins ()) (suc-cong _)
-  transConv↓Term _ (Unit-ins ()) (prod-cong _ _ _ _ _)
+  transConv↓Term _ (Unitʷ-ins _ ()) (suc-cong _)
+  transConv↓Term _ (Unitʷ-ins _ ()) (prod-cong _ _ _ _ _)
 
 -- Transitivity of algorithmic equality of types of the same context.
 transConv : ∀ {A B C}

--- a/Definition/Conversion/Transitivity.agda
+++ b/Definition/Conversion/Transitivity.agda
@@ -214,9 +214,12 @@ mutual
   transConv↓ (ne x) (ne x₁) =
     let A~C , U≡U = trans~↓ x x₁
     in  ne A~C
-  transConv↓ (ΠΣ-cong x x₁ x₂ ok) (ΠΣ-cong x₃ x₄ x₅ _) =
-    ΠΣ-cong x (transConv↑ x₁ x₄)
-      (transConv↑′ (reflConEq (wf x) ∙ soundnessConv↑ x₁) x₂ x₅) ok
+  transConv↓ (ΠΣ-cong x₁ x₂ ok) (ΠΣ-cong x₄ x₅ _) =
+    ΠΣ-cong (transConv↑ x₁ x₄)
+      (transConv↑′
+         (reflConEq (wfEq (soundnessConv↑ x₁)) ∙ soundnessConv↑ x₁) x₂
+         x₅)
+      ok
   transConv↓ (Id-cong A₁≡A₂ t₁≡t₂ u₁≡u₂) (Id-cong A₂≡A₃ t₂≡t₃ u₂≡u₃) =
     case soundnessConv↑ A₁≡A₂ of λ {
       ⊢A₁≡A₂ →
@@ -227,13 +230,13 @@ mutual
   transConv↓ (ℕ-refl x) (ne ([~] _ _ ()))
   transConv↓ (Empty-refl x) (ne ([~] _ _ ()))
   transConv↓ (Unit-refl x x₁) (ne ([~] _ _ ()))
-  transConv↓ (ΠΣ-cong _ _ _ _) (ne ([~] _ _ ()))
+  transConv↓ (ΠΣ-cong _ _ _) (ne ([~] _ _ ()))
   transConv↓ (Id-cong _ _ _) (ne ([~] _ _ ()))
   transConv↓ (ne ([~] _ _ ())) (U-refl x₁)
   transConv↓ (ne ([~] _ _ ())) (ℕ-refl x₁)
   transConv↓ (ne ([~] _ _ ())) (Empty-refl x₁)
   transConv↓ (ne ([~] _ _ ())) (Unit-refl x₁ x₂)
-  transConv↓ (ne ([~] _ _ ())) (ΠΣ-cong _ _ _ _)
+  transConv↓ (ne ([~] _ _ ())) (ΠΣ-cong _ _ _)
   transConv↓ (ne ([~] _ _ ())) (Id-cong _ _ _)
 
   -- Transitivity of algorithmic equality of terms.
@@ -297,11 +300,11 @@ mutual
   transConv↓Term A≡B (suc-cong x) (suc-cong x₁) =
     suc-cong (transConv↑Term A≡B x x₁)
   transConv↓Term
-    A≡B (prod-cong x x₁ x₂ x₃ ok) (prod-cong x₄ x₅ x₆ x₇ _) =
+    A≡B (prod-cong x₁ x₂ x₃ ok) (prod-cong x₅ x₆ x₇ _) =
     let F≡F′ , G≡G′ , _ = Σ-injectivity A≡B
         t≡t′ = soundnessConv↑Term x₂
         Gt≡G′t′ = substTypeEq G≡G′ t≡t′
-    in  prod-cong x x₁ (transConv↑Term F≡F′ x₂ x₆)
+    in  prod-cong x₁ (transConv↑Term F≡F′ x₂ x₆)
           (transConv↑Term Gt≡G′t′ x₃ x₇) ok
   transConv↓Term A≡B (η-eq x₁ x₂ y y₁ x₃) (η-eq x₅ x₆ y₂ y₃ x₇) =
     case injectivity A≡B of λ {
@@ -336,7 +339,7 @@ mutual
   transConv↓Term A≡B (ℕ-ins _) (Unitʷ-ins _ _) = ⊥-elim (WF.ℕ≢Unitⱼ A≡B)
   transConv↓Term A≡B (ℕ-ins x) (Σʷ-ins x₁ x₂ x₃) = ⊥-elim (WF.ℕ≢Σ A≡B)
   transConv↓Term A≡B (ℕ-ins ([~] _ _ ())) (suc-cong x₂)
-  transConv↓Term A≡B (ℕ-ins _) (prod-cong _ _ _ _ _) = ⊥-elim (WF.ℕ≢Σ A≡B)
+  transConv↓Term A≡B (ℕ-ins _) (prod-cong _ _ _ _) = ⊥-elim (WF.ℕ≢Σ A≡B)
   transConv↓Term A≡B (ℕ-ins x) (η-eq x₃ x₄ y y₁ x₅) = ⊥-elim (WF.ℕ≢Π A≡B)
   transConv↓Term A≡B (ℕ-ins x₁) (Σ-η x₂ x₃ x₄ x₅ x₆ x₇) = ⊥-elim (WF.ℕ≢Σ A≡B)
   transConv↓Term A≡B (ℕ-ins x) (η-unit _ _ _ _ _) = ⊥-elim (WF.ℕ≢Unitⱼ A≡B)
@@ -347,7 +350,7 @@ mutual
   transConv↓Term A≡B (Empty-ins _) (Unitʷ-ins _ _) = ⊥-elim (WF.Empty≢Unitⱼ A≡B)
   transConv↓Term A≡B (Empty-ins x) (Σʷ-ins x₁ x₂ x₃) = ⊥-elim (WF.Empty≢Σⱼ A≡B)
   transConv↓Term A≡B (Empty-ins ([~] _ _ ())) (suc-cong x₂)
-  transConv↓Term A≡B (Empty-ins _) (prod-cong _ _ _ _ _) = ⊥-elim (WF.Empty≢Σⱼ A≡B)
+  transConv↓Term A≡B (Empty-ins _) (prod-cong _ _ _ _) = ⊥-elim (WF.Empty≢Σⱼ A≡B)
   transConv↓Term A≡B (Empty-ins x) (η-eq x₃ x₄ y y₁ x₅) = ⊥-elim (WF.Empty≢Πⱼ A≡B)
   transConv↓Term A≡B (Empty-ins x₁) (Σ-η x₂ x₃ x₄ x₅ x₆ x₇) = ⊥-elim (WF.Empty≢Σⱼ A≡B)
   transConv↓Term A≡B (Empty-ins x₁) (η-unit _ _ _ _ _) = ⊥-elim (WF.Empty≢Unitⱼ A≡B)
@@ -375,7 +378,7 @@ mutual
   transConv↓Term A≡B (ne-ins x x₁ x₂ x₃) (Σʷ-ins x₄ x₅ x₆) = ⊥-elim (WF.Σ≢ne x₂ (sym A≡B))
   transConv↓Term A≡B (ne-ins t u x x₁) (univ x₃ x₄ x₅) = ⊥-elim (WF.U≢ne x (sym A≡B))
   transConv↓Term A≡B (ne-ins t u x ([~] _ _ ())) (suc-cong x₃)
-  transConv↓Term A≡B (ne-ins _ _ x _) (prod-cong _ _ _ _ _) = ⊥-elim (WF.B≢ne BΣ! x (sym A≡B))
+  transConv↓Term A≡B (ne-ins _ _ x _) (prod-cong _ _ _ _) = ⊥-elim (WF.B≢ne BΣ! x (sym A≡B))
   transConv↓Term A≡B (ne-ins t u x x₁) (η-eq x₄ x₅ y y₁ x₆) = ⊥-elim (WF.Π≢ne x (sym A≡B))
   transConv↓Term A≡B (ne-ins t u x x₁) (Σ-η x₅ x₆ x₇ x₈ x₉ x₁₀) = ⊥-elim (WF.Σ≢ne x (sym A≡B))
   transConv↓Term A≡B (ne-ins t u x x₁) (η-unit _ _ _ _ _) = ⊥-elim (WF.Unit≢neⱼ x (sym A≡B))
@@ -386,7 +389,7 @@ mutual
   transConv↓Term A≡B (univ x x₁ x₂) (Σʷ-ins x₃ x₄ x₅) = ⊥-elim (WF.U≢Σ A≡B)
   transConv↓Term A≡B (univ x x₁ x₂) (ne-ins t u x₃ x₄) = ⊥-elim (WF.U≢ne x₃ A≡B)
   transConv↓Term A≡B (univ x x₁ x₂) (suc-cong x₃) = ⊥-elim (WF.U≢ℕ A≡B)
-  transConv↓Term A≡B (univ _ _ _) (prod-cong _ _ _ _ _) = ⊥-elim (WF.U≢B BΣ! A≡B)
+  transConv↓Term A≡B (univ _ _ _) (prod-cong _ _ _ _) = ⊥-elim (WF.U≢B BΣ! A≡B)
   transConv↓Term A≡B (univ x x₁ x₂) (η-eq x₄ x₅ y y₁ x₆) = ⊥-elim (WF.U≢Π A≡B)
   transConv↓Term A≡B (univ x₁ x₂ x₃) (Σ-η x₄ x₅ x₆ x₇ x₈ x₉) = ⊥-elim (WF.U≢Σ A≡B)
   transConv↓Term A≡B (univ x x₁ x₂) (η-unit _ _ _ _ _) = ⊥-elim (WF.U≢Unitⱼ A≡B)
@@ -399,10 +402,10 @@ mutual
   transConv↓Term A≡B (suc-cong x₁) (Σ-η x₂ x₃ x₄ x₅ x₆ x₇) = ⊥-elim (WF.ℕ≢Σ A≡B)
   transConv↓Term A≡B (suc-cong x) (η-unit _ _ _ _ _) = ⊥-elim (WF.ℕ≢Unitⱼ A≡B)
   transConv↓Term A≡B (suc-cong _) (Id-ins _ _) = ⊥-elim (WF.Id≢ℕ (sym A≡B))
-  transConv↓Term A≡B (prod-cong _ _ _ _ _) (univ _ _ _) = ⊥-elim (WF.U≢B BΣ! (sym A≡B))
-  transConv↓Term A≡B (prod-cong _ _ _ _ _) (η-eq _ _ _ _ _) = ⊥-elim (WF.Π≢Σⱼ (sym A≡B))
-  transConv↓Term A≡B (prod-cong _ _ _ _ _) (Σ-η _ _ _ _ _ _) = ⊥-elim (WF.Σˢ≢Σʷⱼ (sym A≡B))
-  transConv↓Term A≡B (prod-cong _ _ _ _ _) (η-unit _ _ _ _ _) = ⊥-elim (WF.Unit≢Σⱼ (sym A≡B))
+  transConv↓Term A≡B (prod-cong _ _ _ _) (univ _ _ _) = ⊥-elim (WF.U≢B BΣ! (sym A≡B))
+  transConv↓Term A≡B (prod-cong _ _ _ _) (η-eq _ _ _ _ _) = ⊥-elim (WF.Π≢Σⱼ (sym A≡B))
+  transConv↓Term A≡B (prod-cong _ _ _ _) (Σ-η _ _ _ _ _ _) = ⊥-elim (WF.Σˢ≢Σʷⱼ (sym A≡B))
+  transConv↓Term A≡B (prod-cong _ _ _ _) (η-unit _ _ _ _ _) = ⊥-elim (WF.Unit≢Σⱼ (sym A≡B))
   transConv↓Term A≡B (η-eq x₁ x₂ y y₁ x₃) (ℕ-ins x₄) = ⊥-elim (WF.ℕ≢Π (sym A≡B))
   transConv↓Term A≡B (η-eq x₁ x₂ y y₁ x₃) (Empty-ins x₄) = ⊥-elim (WF.Empty≢Πⱼ (sym A≡B))
   transConv↓Term A≡B (η-eq _ _ _ _ _) (Unitʷ-ins _ _) = ⊥-elim (WF.Unit≢Πⱼ (sym A≡B))
@@ -410,7 +413,7 @@ mutual
   transConv↓Term A≡B (η-eq x₁ x₂ y y₁ x₃) (ne-ins t u x₄ x₅) = ⊥-elim (WF.Π≢ne x₄ A≡B)
   transConv↓Term A≡B (η-eq x₁ x₂ y y₁ x₃) (univ x₄ x₅ x₆) = ⊥-elim (WF.U≢Π (sym A≡B))
   transConv↓Term A≡B (η-eq x₁ x₂ y y₁ x₃) (suc-cong x₄) = ⊥-elim (WF.ℕ≢Π (sym A≡B))
-  transConv↓Term A≡B (η-eq _ _ _ _ _) (prod-cong _ _ _ _ _) = ⊥-elim (WF.Π≢Σⱼ A≡B)
+  transConv↓Term A≡B (η-eq _ _ _ _ _) (prod-cong _ _ _ _) = ⊥-elim (WF.Π≢Σⱼ A≡B)
   transConv↓Term A≡B (η-eq x₂ x₃ x₄ x₅ x₆) (Σ-η x₇ x₈ x₉ x₁₀ x₁₁ x₁₂) = ⊥-elim (WF.Π≢Σⱼ A≡B)
   transConv↓Term A≡B (η-eq x₁ x₂ y y₁ x₃) (η-unit _ _ _ _ _) = ⊥-elim (WF.Unit≢Πⱼ (sym A≡B))
   transConv↓Term A≡B (η-eq _ _ _ _ _) (Id-ins _ _) = ⊥-elim (WF.Id≢ΠΣ (sym A≡B))
@@ -421,7 +424,7 @@ mutual
   transConv↓Term A≡B (Σ-η x₁ x₂ x₃ x₄ x₅ x₆) (ne-ins x₇ x₈ x₉ x₁₀) = ⊥-elim (WF.Σ≢ne x₉ A≡B)
   transConv↓Term A≡B (Σ-η x₁ x₂ x₃ x₄ x₅ x₆) (univ x₇ x₈ x₉) = ⊥-elim (WF.U≢Σ (sym A≡B))
   transConv↓Term A≡B (Σ-η x₁ x₂ x₃ x₄ x₅ x₆) (suc-cong x₇) = ⊥-elim (WF.ℕ≢Σ (sym A≡B))
-  transConv↓Term A≡B (Σ-η _ _ _ _ _ _) (prod-cong _ _ _ _ _) = ⊥-elim (WF.Σˢ≢Σʷⱼ A≡B)
+  transConv↓Term A≡B (Σ-η _ _ _ _ _ _) (prod-cong _ _ _ _) = ⊥-elim (WF.Σˢ≢Σʷⱼ A≡B)
   transConv↓Term A≡B (Σ-η x₁ x₂ x₃ x₄ x₅ x₆) (η-unit _ _ _ _ _) = ⊥-elim (WF.Unit≢Σⱼ (sym A≡B))
   transConv↓Term A≡B (Σ-η x₁ x₂ x₃ x₄ x₅ x₆) (η-eq x₈ x₉ x₁₀ x₁₁ x₁₂) = ⊥-elim (WF.Π≢Σⱼ (sym A≡B))
   transConv↓Term A≡B (Σ-η _ _ _ _ _ _) (Id-ins _ _) = ⊥-elim (WF.Id≢ΠΣ (sym A≡B))
@@ -435,17 +438,17 @@ mutual
   transConv↓Term A≡B (Id-ins _ _) (Σ-η _ _ _ _ _ _) = ⊥-elim (WF.Id≢ΠΣ A≡B)
   transConv↓Term A≡B (Id-ins _ _) (η-unit _ _ _ _ _) = ⊥-elim (WF.Id≢Unit A≡B)
   transConv↓Term A≡B (Σʷ-ins x x₁ ()) (suc-cong x₃)
-  transConv↓Term _ (Σʷ-ins _ _ ()) (prod-cong _ _ _ _ _)
+  transConv↓Term _ (Σʷ-ins _ _ ()) (prod-cong _ _ _ _)
   transConv↓Term _ (suc-cong _) (Unitʷ-ins _ ())
   transConv↓Term A≡B (suc-cong x) (Σʷ-ins x₁ x₂ ())
-  transConv↓Term _ (prod-cong _ _ _ _ _) (ℕ-ins ())
-  transConv↓Term _ (prod-cong _ _ _ _ _) (Empty-ins ())
-  transConv↓Term _ (prod-cong _ _ _ _ _) (Unitʷ-ins _ ())
-  transConv↓Term _ (prod-cong _ _ _ _ _) (Σʷ-ins _ _ ())
-  transConv↓Term _ (prod-cong _ _ _ _ _) (ne-ins _ _ _ ())
-  transConv↓Term _ (prod-cong _ _ _ _ _) (Id-ins _ ())
+  transConv↓Term _ (prod-cong _ _ _ _) (ℕ-ins ())
+  transConv↓Term _ (prod-cong _ _ _ _) (Empty-ins ())
+  transConv↓Term _ (prod-cong _ _ _ _) (Unitʷ-ins _ ())
+  transConv↓Term _ (prod-cong _ _ _ _) (Σʷ-ins _ _ ())
+  transConv↓Term _ (prod-cong _ _ _ _) (ne-ins _ _ _ ())
+  transConv↓Term _ (prod-cong _ _ _ _) (Id-ins _ ())
   transConv↓Term _ (Unitʷ-ins _ ()) (suc-cong _)
-  transConv↓Term _ (Unitʷ-ins _ ()) (prod-cong _ _ _ _ _)
+  transConv↓Term _ (Unitʷ-ins _ ()) (prod-cong _ _ _ _)
 
 -- Transitivity of algorithmic equality of types of the same context.
 transConv : ∀ {A B C}

--- a/Definition/Conversion/Transitivity.agda
+++ b/Definition/Conversion/Transitivity.agda
@@ -291,11 +291,11 @@ mutual
            (proj₁ (trans~↓ x₁ x₃))
   transConv↓Term A≡B (univ x x₁ x₂) (univ x₃ x₄ x₅) =
     univ x x₄ (transConv↓ x₂ x₅)
-  transConv↓Term A≡B (zero-refl x) conv↓ =
-    convConv↓Term (reflConEq x) (sym A≡B) ℕₙ conv↓
+  transConv↓Term A≡B (zero-refl _) conv↓ =
+    convConv↓Term (sym A≡B) ℕₙ conv↓
   transConv↓Term A≡B conv↓ (zero-refl _) = conv↓
-  transConv↓Term A≡B (starʷ-refl x ok _) conv↓ =
-    convConv↓Term (reflConEq x) (sym A≡B) Unitₙ conv↓
+  transConv↓Term A≡B (starʷ-refl _ ok _) conv↓ =
+    convConv↓Term (sym A≡B) Unitₙ conv↓
   transConv↓Term _ conv↓ (starʷ-refl _ _ _) = conv↓
   transConv↓Term A≡B (suc-cong x) (suc-cong x₁) =
     suc-cong (transConv↑Term A≡B x x₁)
@@ -327,8 +327,8 @@ mutual
     in  η-unit [t] [v] tUnit vWhnf ok
   transConv↓Term A≡B (Id-ins ⊢t t~u) (Id-ins _ u~v) =
     Id-ins ⊢t (trans~↓ t~u u~v .proj₁)
-  transConv↓Term A≡B (rfl-refl t≡u) rfl≡v =
-    convConv↓Term (reflConEq (wfEqTerm t≡u)) (sym A≡B) Idₙ rfl≡v
+  transConv↓Term A≡B (rfl-refl _) rfl≡v =
+    convConv↓Term (sym A≡B) Idₙ rfl≡v
   transConv↓Term _ t≡rfl (rfl-refl _) =
     t≡rfl
 

--- a/Definition/Conversion/Weakening.agda
+++ b/Definition/Conversion/Weakening.agda
@@ -187,8 +187,8 @@ mutual
     ℕ-ins (wk~↓ ρ ⊢Δ x)
   wkConv↓Term ρ ⊢Δ (Empty-ins x) =
     Empty-ins (wk~↓ ρ ⊢Δ x)
-  wkConv↓Term ρ ⊢Δ (Unit-ins x) =
-    Unit-ins (wk~↓ ρ ⊢Δ x)
+  wkConv↓Term ρ ⊢Δ (Unitʷ-ins ok t~u) =
+    Unitʷ-ins ok (wk~↓ ρ ⊢Δ t~u)
   wkConv↓Term ρ ⊢Δ (Σʷ-ins t u x) =
     Σʷ-ins (wkTerm ρ ⊢Δ t) (wkTerm ρ ⊢Δ u) (wk~↓ ρ ⊢Δ x)
   wkConv↓Term {ρ = ρ} [ρ] ⊢Δ (ne-ins t u x x₁) =

--- a/Definition/Conversion/Weakening.agda
+++ b/Definition/Conversion/Weakening.agda
@@ -17,6 +17,7 @@ open import Definition.Untyped M as U hiding (wk)
 open import Definition.Untyped.Neutral M type-variant
 open import Definition.Untyped.Properties M
 open import Definition.Typed R
+open import Definition.Typed.Properties R
 open import Definition.Typed.Weakening R
 open import Definition.Typed.Consequences.Syntactic R
 open import Definition.Conversion R
@@ -162,9 +163,9 @@ mutual
   wkConv↓ ρ ⊢Δ (Empty-refl x) = Empty-refl ⊢Δ
   wkConv↓ ρ ⊢Δ (Unit-refl x ok) = Unit-refl ⊢Δ ok
   wkConv↓ ρ ⊢Δ (ne x) = ne (wk~↓ ρ ⊢Δ x)
-  wkConv↓ ρ ⊢Δ (ΠΣ-cong x A<>B A<>B₁ ok) =
-    let ⊢ρF = wk ρ ⊢Δ x
-    in  ΠΣ-cong ⊢ρF (wkConv↑ ρ ⊢Δ A<>B)
+  wkConv↓ ρ ⊢Δ (ΠΣ-cong A<>B A<>B₁ ok) =
+    let ⊢ρF = wk ρ ⊢Δ (syntacticEq (soundnessConv↑ A<>B) .proj₁)
+    in  ΠΣ-cong (wkConv↑ ρ ⊢Δ A<>B)
           (wkConv↑ (lift ρ) (⊢Δ ∙ ⊢ρF) A<>B₁) ok
   wkConv↓ ρ ⊢Δ (Id-cong A₁≡A₂ t₁≡t₂ u₁≡u₂) =
     Id-cong (wkConv↑ ρ ⊢Δ A₁≡A₂) (wkConv↑Term ρ ⊢Δ t₁≡t₂)
@@ -198,10 +199,10 @@ mutual
   wkConv↓Term ρ ⊢Δ (zero-refl x) = zero-refl ⊢Δ
   wkConv↓Term ρ ⊢Δ (starʷ-refl _ ok no-η) = starʷ-refl ⊢Δ ok no-η
   wkConv↓Term ρ ⊢Δ (suc-cong t<>u) = suc-cong (wkConv↑Term ρ ⊢Δ t<>u)
-  wkConv↓Term ρ ⊢Δ (prod-cong {G = G} x x₁ x₂ x₃ ok) =
-    let ⊢ρF = wk ρ ⊢Δ x
+  wkConv↓Term ρ ⊢Δ (prod-cong {G = G} x₁ x₂ x₃ ok) =
+    let ⊢ρF = wk ρ ⊢Δ (⊢∙→⊢ (wf x₁))
         ⊢ρG = wk (lift ρ) (⊢Δ ∙ ⊢ρF) x₁
-    in  prod-cong ⊢ρF ⊢ρG (wkConv↑Term ρ ⊢Δ x₂)
+    in  prod-cong ⊢ρG (wkConv↑Term ρ ⊢Δ x₂)
           (PE.subst (λ x → _ ⊢ _ [conv↑] _ ∷ x) (wk-β G)
              (wkConv↑Term ρ ⊢Δ x₃))
           ok

--- a/Definition/Conversion/Whnf.agda
+++ b/Definition/Conversion/Whnf.agda
@@ -84,8 +84,9 @@ whnfConv↓Term (ℕ-ins x) = let _ , neT , neU = ne~↓ x
                            in ℕₙ , ne neT , ne neU
 whnfConv↓Term (Empty-ins x) = let _ , neT , neU = ne~↓ x
                               in Emptyₙ , ne neT , ne neU
-whnfConv↓Term (Unit-ins x) = let _ , neT , neU = ne~↓ x
-                             in Unitₙ , ne neT , ne neU
+whnfConv↓Term (Unitʷ-ins _ t~u) =
+  let _ , t-ne , u-ne = ne~↓ t~u in
+  Unitₙ , ne t-ne , ne u-ne
 whnfConv↓Term (Σʷ-ins x x₁ x₂) =
   let _ , neT , neU = ne~↓ x₂
   in  ΠΣₙ , ne neT , ne neU

--- a/Definition/Conversion/Whnf.agda
+++ b/Definition/Conversion/Whnf.agda
@@ -73,7 +73,7 @@ whnfConv↓ (Empty-refl x) = Emptyₙ , Emptyₙ
 whnfConv↓ (Unit-refl x _) = Unitₙ , Unitₙ
 whnfConv↓ (ne x) = let _ , neA , neB = ne~↓ x
                    in  ne neA , ne neB
-whnfConv↓ (ΠΣ-cong _ _ _ _) = ΠΣₙ , ΠΣₙ
+whnfConv↓ (ΠΣ-cong _ _ _) = ΠΣₙ , ΠΣₙ
 whnfConv↓ (Id-cong _ _ _) = Idₙ , Idₙ
 
 -- Extraction of WHNF from algorithmic equality of terms in WHNF.
@@ -97,7 +97,7 @@ whnfConv↓Term (univ x x₁ x₂) = Uₙ , whnfConv↓ x₂
 whnfConv↓Term (zero-refl x) = ℕₙ , zeroₙ , zeroₙ
 whnfConv↓Term (starʷ-refl _ _ _) = Unitₙ , starₙ , starₙ
 whnfConv↓Term (suc-cong x) = ℕₙ , sucₙ , sucₙ
-whnfConv↓Term (prod-cong _ _ _ _ _) = ΠΣₙ , prodₙ , prodₙ
+whnfConv↓Term (prod-cong _ _ _ _) = ΠΣₙ , prodₙ , prodₙ
 whnfConv↓Term (η-eq x₁ x₂ y y₁ x₃) = ΠΣₙ , functionWhnf y , functionWhnf y₁
 whnfConv↓Term (Σ-η _ _ pProd rProd _ _) = ΠΣₙ , productWhnf pProd , productWhnf rProd
 whnfConv↓Term (η-unit _ _ tWhnf uWhnf _) = Unitₙ , tWhnf , uWhnf

--- a/Definition/LogicalRelation/Irrelevance.agda
+++ b/Definition/LogicalRelation/Irrelevance.agda
@@ -18,6 +18,7 @@ open Type-restrictions R
 
 open import Definition.Untyped M hiding (Wk; K)
 open import Definition.Untyped.Neutral M type-variant
+open import Definition.Untyped.Properties M
 open import Definition.Typed R
 import Definition.Typed.Weakening R as Wk
 open import Definition.Typed.Properties R

--- a/Definition/LogicalRelation/Properties/Conversion.agda
+++ b/Definition/LogicalRelation/Properties/Conversion.agda
@@ -18,6 +18,7 @@ open Type-restrictions R
 
 open import Definition.Untyped M hiding (Wk; K)
 open import Definition.Untyped.Neutral M type-variant
+open import Definition.Untyped.Properties M
 open import Definition.Typed R
 open import Definition.Typed.RedSteps R
 open import Definition.Typed.Properties R

--- a/Definition/LogicalRelation/Properties/Symmetry.agda
+++ b/Definition/LogicalRelation/Properties/Symmetry.agda
@@ -18,6 +18,7 @@ open Type-restrictions R
 
 open import Definition.Untyped M hiding (K)
 open import Definition.Untyped.Neutral M type-variant
+open import Definition.Untyped.Properties M
 open import Definition.Typed R
 open import Definition.Typed.Properties R
 import Definition.Typed.Weakening R as W

--- a/Definition/LogicalRelation/Properties/Transitivity.agda
+++ b/Definition/LogicalRelation/Properties/Transitivity.agda
@@ -18,6 +18,7 @@ open Type-restrictions R
 
 open import Definition.Untyped M hiding (K)
 open import Definition.Untyped.Neutral M type-variant
+open import Definition.Untyped.Properties M
 open import Definition.Typed R
 open import Definition.Typed.Properties R
 import Definition.Typed.Weakening R as Weak

--- a/Definition/Typechecking/Decidable.agda
+++ b/Definition/Typechecking/Decidable.agda
@@ -277,7 +277,7 @@ mutual
     (yes (A , t⇉A)) → case isΠ (proj₁ (soundness⇉ ⊢Γ t⇉A)) of λ where
       (yes (p , _ , _ , _ , A⇒Π)) →
         let ⊢F , _ = inversion-ΠΣ (syntacticRed A⇒Π .proj₂) in
-        case dec⇇ ⊢Γ u ⊢F of λ where
+        case dec⇇ u ⊢F of λ where
           (yes u⇇F) → case p ≟ p′ of λ where
             (yes PE.refl) → yes (_ , appᵢ t⇉A (A⇒Π , ΠΣₙ) u⇇F)
             (no p≢p′) → no λ where
@@ -326,16 +326,15 @@ mutual
 
   dec⇉-natrec : ∀ {A z s n} → ⊢ Γ → Checkable A → Checkable z → Checkable s → Checkable n
               → Dec (∃ λ B → Γ ⊢ natrec p q r A z s n ⇉ B)
-  dec⇉-natrec ⊢Γ A z s n = case dec⇇ ⊢Γ n (ℕⱼ ⊢Γ) of λ where
+  dec⇉-natrec ⊢Γ A z s n = case dec⇇ n (ℕⱼ ⊢Γ) of λ where
     (yes n⇇ℕ) → case dec⇇Type (⊢Γ ∙ ℕⱼ ⊢Γ) A of λ where
       (yes A⇇Type) →
         let ⊢A = soundness⇇Type (⊢Γ ∙ ℕⱼ ⊢Γ) A⇇Type
             ⊢A₀ = substType ⊢A (zeroⱼ ⊢Γ)
-        in  case dec⇇ ⊢Γ z ⊢A₀ of λ where
+        in  case dec⇇ z ⊢A₀ of λ where
           (yes z⇇A₀) →
-            let ⊢Γ₊ = ⊢Γ ∙ ℕⱼ ⊢Γ ∙ ⊢A
-                ⊢A₊ = subst↑²Type ⊢A (sucⱼ (var₁ ⊢A))
-            in  case dec⇇ ⊢Γ₊ s ⊢A₊ of λ where
+            let ⊢A₊ = subst↑²Type ⊢A (sucⱼ (var₁ ⊢A)) in
+            case dec⇇ s ⊢A₊ of λ where
               (yes s⇇A₊) → yes (_ , natrecᵢ A⇇Type z⇇A₀ s⇇A₊ n⇇ℕ)
               (no ¬s⇇A₊) → no λ where
                 (_ , natrecᵢ x x₁ x₂ x₃) → ¬s⇇A₊ x₂ --¬s⇇A₊ x₂
@@ -359,7 +358,7 @@ mutual
               let ⊢ΓΣ = ⊢Γ ∙ ΠΣⱼ {p = p} ⊢F ⊢G ok
                   ⊢A = soundness⇇Type ⊢ΓΣ A⇇Type
                   ⊢A₊ = subst↑²Type-prod ⊢A ok
-              in  case dec⇇ (⊢Γ ∙ ⊢F ∙ ⊢G) u ⊢A₊ of λ where
+              in  case dec⇇ u ⊢A₊ of λ where
                 (yes u⇇A₊) → case p ≟ p′ of λ where
                   (yes PE.refl) →
                     yes (_ , prodrecᵢ A⇇Type t⇉B (B⇒Σ , ΠΣₙ) u⇇A₊)
@@ -387,7 +386,7 @@ mutual
 
   dec⇉-emptyrec : ⊢ Γ → Checkable A → Checkable t → Dec (∃ λ B → Γ ⊢ emptyrec p A t ⇉ B)
   dec⇉-emptyrec ⊢Γ A t = case dec⇇Type ⊢Γ A of λ where
-    (yes A⇇Type) → case dec⇇ ⊢Γ t (Emptyⱼ ⊢Γ) of λ where
+    (yes A⇇Type) → case dec⇇ t (Emptyⱼ ⊢Γ) of λ where
       (yes t⇇Empty) → yes (_ , emptyrecᵢ A⇇Type t⇇Empty)
       (no ¬t⇇Empty) → no λ where
         (_ , emptyrecᵢ x x₁) → ¬t⇇Empty x₁
@@ -399,9 +398,11 @@ mutual
   dec⇉-unitrec ⊢Γ A t u = case Unit-allowed? 𝕨 of λ where
     (yes ok) → case Unitⱼ ⊢Γ ok of λ
       ⊢Unit → case dec⇇Type (⊢Γ ∙ ⊢Unit) A of λ where
-        (yes A⇇Type) → case dec⇇ ⊢Γ t ⊢Unit of λ where
-          (yes t⇇Unit) → case dec⇇ ⊢Γ u (substType (soundness⇇Type (⊢Γ ∙ ⊢Unit) A⇇Type)
-                                                   (starⱼ ⊢Γ ok)) of λ where
+        (yes A⇇Type) → case dec⇇ t ⊢Unit of λ where
+          (yes t⇇Unit) → case dec⇇ u
+                                (substType
+                                   (soundness⇇Type (⊢Γ ∙ ⊢Unit) A⇇Type)
+                                   (starⱼ ⊢Γ ok)) of λ where
             (yes u⇇A₊) → yes (_ , unitrecᵢ A⇇Type t⇇Unit u⇇A₊)
             (no ¬u⇇A₊) → no λ where
               (_ , unitrecᵢ x x₁ x₂) → ¬u⇇A₊ x₂
@@ -411,7 +412,7 @@ mutual
           (_ , unitrecᵢ x x₁ x₂) → ¬A⇇Type x
     (no not-ok) → no λ where
       (_ , unitrecᵢ x x₁ x₂) →
-        let ⊢t = soundness⇇ ⊢Γ x₁
+        let ⊢t = soundness⇇ x₁
             ⊢Unit = syntacticTerm ⊢t
         in  not-ok (inversion-Unit ⊢Unit)
 
@@ -429,26 +430,25 @@ mutual
         (yes A) →
           case soundness⇇Type ⊢Γ A of λ {
             ⊢A →
-          case dec⇇ ⊢Γ t ⊢A of λ where
+          case dec⇇ t ⊢A of λ where
             (no ¬t) → no λ { (_ , Jᵢ _ t _ _ _ _) → ¬t t }
             (yes t) →
-              case soundness⇇ ⊢Γ t of λ {
+              case soundness⇇ t of λ {
                 ⊢t →
               case ⊢Γ ∙ ⊢A ∙ Idⱼ (wkTerm₁ ⊢A ⊢t) (var₀ ⊢A) of λ {
                 ⊢Γ∙A∙Id-t-0 →
               case dec⇇Type ⊢Γ∙A∙Id-t-0 B of λ where
                 (no ¬B) → no λ { (_ , Jᵢ _ _ B _ _ _) → ¬B B }
                 (yes B) →
-                  case dec⇇ ⊢Γ u
+                  case dec⇇ u
                          (substType₂ (soundness⇇Type ⊢Γ∙A∙Id-t-0 B) ⊢t $
                           PE.subst (_⊢_∷_ _ _) ≡Id-wk1-wk1-0[]₀ $
                           rflⱼ ⊢t) of λ where
                     (no ¬u) → no λ { (_ , Jᵢ _ _ _ u _ _) → ¬u u }
-                    (yes u) → case dec⇇ ⊢Γ v ⊢A of λ where
+                    (yes u) → case dec⇇ v ⊢A of λ where
                       (no ¬v) → no λ { (_ , Jᵢ _ _ _ _ v _) → ¬v v }
                       (yes v) →
-                        case dec⇇ ⊢Γ w
-                               (Idⱼ ⊢t (soundness⇇ ⊢Γ v)) of λ where
+                        case dec⇇ w (Idⱼ ⊢t (soundness⇇ v)) of λ where
                           (no ¬w) → no λ { (_ , Jᵢ _ _ _ _ _ w) → ¬w w }
                           (yes w) → yes (_ , Jᵢ A t B u v w) }}}
 
@@ -463,21 +463,21 @@ mutual
           (yes A) →
             case soundness⇇Type ⊢Γ A of λ {
               ⊢A →
-            case dec⇇ ⊢Γ t ⊢A of λ where
+            case dec⇇ t ⊢A of λ where
               (no ¬t) → no λ { (_ , Kᵢ _ t _ _ _ _) → ¬t t }
               (yes t) →
-                case soundness⇇ ⊢Γ t of λ {
+                case soundness⇇ t of λ {
                   ⊢t →
                 case ⊢Γ ∙ Idⱼ ⊢t ⊢t of λ {
                   ⊢Γ∙Id-t-t →
                 case dec⇇Type ⊢Γ∙Id-t-t B of λ where
                   (no ¬B) → no λ { (_ , Kᵢ _ _ B _ _ _) → ¬B B }
                   (yes B) →
-                    case dec⇇ ⊢Γ u
+                    case dec⇇ u
                            (substType (soundness⇇Type ⊢Γ∙Id-t-t B)
                               (rflⱼ ⊢t)) of λ where
                       (no ¬u) → no λ { (_ , Kᵢ _ _ _ u _ _) → ¬u u }
-                      (yes u) → case dec⇇ ⊢Γ v (Idⱼ ⊢t ⊢t) of λ where
+                      (yes u) → case dec⇇ v (Idⱼ ⊢t ⊢t) of λ where
                         (no ¬v) → no λ { (_ , Kᵢ _ _ _ _ v _) → ¬v v }
                         (yes v) → yes (_ , Kᵢ A t B u v ok) }}}
 
@@ -581,12 +581,12 @@ mutual
       (yes A) →
         case soundness⇇Type ⊢Γ A of λ {
           ⊢A →
-        case dec⇇ ⊢Γ t ⊢A of λ where
+        case dec⇇ t ⊢A of λ where
           (no ¬t) → no λ where
             (Idᶜ _ t _)                  → ¬t t
             (univᶜ (infᶜ (Idᵢ _ t _) _)) → ¬t t
           (yes t) →
-            case dec⇇ ⊢Γ u ⊢A of λ where
+            case dec⇇ u ⊢A of λ where
               (no ¬u) → no λ where
                 (Idᶜ _ _ u)                  → ¬u u
                 (univᶜ (infᶜ (Idᵢ _ _ u) _)) → ¬u u
@@ -631,10 +631,10 @@ mutual
   dec⇉ : ⊢ Γ → Inferable t → Dec (∃ λ A → Γ ⊢ t ⇉ A)
   dec⇉ ⊢Γ Uᵢ = no λ where (A , ())
   dec⇉ ⊢Γ (ΠΣᵢ {b = b} {p = p} {q = q} F G) =
-    case dec⇇ ⊢Γ F (Uⱼ ⊢Γ) of λ where
+    case dec⇇ F (Uⱼ ⊢Γ) of λ where
       (yes F⇇U) →
-        let ⊢F = soundness⇇ ⊢Γ F⇇U
-        in  case dec⇇ (⊢Γ ∙ univ ⊢F) G (Uⱼ (⊢Γ ∙ univ ⊢F)) of λ where
+        let ⊢F = soundness⇇ F⇇U
+        in  case dec⇇ G (Uⱼ (⊢Γ ∙ univ ⊢F)) of λ where
           (yes G⇇U) → case ΠΣ-allowed? b p q of λ where
             (yes ok)    → yes (_ , ΠΣᵢ F⇇U G⇇U ok)
             (no not-ok) → no λ where
@@ -650,7 +650,7 @@ mutual
   dec⇉ ⊢Γ (prodrecᵢ A t u) = dec⇉-prodrec ⊢Γ A t u
   dec⇉ ⊢Γ ℕᵢ = yes (U , ℕᵢ)
   dec⇉ ⊢Γ zeroᵢ = yes (ℕ , zeroᵢ)
-  dec⇉ ⊢Γ (sucᵢ t) = case dec⇇ ⊢Γ t (ℕⱼ ⊢Γ) of λ where
+  dec⇉ ⊢Γ (sucᵢ t) = case dec⇇ t (ℕⱼ ⊢Γ) of λ where
     (yes t⇇ℕ) → yes (_ , sucᵢ t⇇ℕ)
     (no ¬t⇇ℕ) → no λ where
       (_ , sucᵢ x) → ¬t⇇ℕ x
@@ -667,15 +667,15 @@ mutual
   dec⇉ ⊢Γ Emptyᵢ = yes (U , Emptyᵢ)
   dec⇉ ⊢Γ (emptyrecᵢ A t) = dec⇉-emptyrec ⊢Γ A t
   dec⇉ ⊢Γ (Idᵢ A t u) =
-    case dec⇇ ⊢Γ A (Uⱼ ⊢Γ) of λ where
+    case dec⇇ A (Uⱼ ⊢Γ) of λ where
       (no ¬A) → no λ { (_ , Idᵢ A _ _) → ¬A A }
       (yes A) →
-        case univ (soundness⇇ ⊢Γ A) of λ {
+        case univ (soundness⇇ A) of λ {
           ⊢A →
-        case dec⇇ ⊢Γ t ⊢A of λ where
+        case dec⇇ t ⊢A of λ where
           (no ¬t) → no λ { (_ , Idᵢ _ t _) → ¬t t }
           (yes t) →
-            case dec⇇ ⊢Γ u ⊢A of λ where
+            case dec⇇ u ⊢A of λ where
               (no ¬u) → no λ { (_ , Idᵢ _ _ u) → ¬u u }
               (yes u) → yes (_ , Idᵢ A t u) }
   dec⇉ ⊢Γ (Jᵢ A t B u v w) =
@@ -690,25 +690,24 @@ mutual
         (yes A) →
           case soundness⇇Type ⊢Γ A of λ {
             ⊢A →
-          case dec⇇ ⊢Γ t ⊢A of λ where
+          case dec⇇ t ⊢A of λ where
             (no ¬t) → no λ { (_ , []-congᵢ _ t _ _ _) → ¬t t }
             (yes t) →
-              case dec⇇ ⊢Γ u ⊢A of λ where
+              case dec⇇ u ⊢A of λ where
                 (no ¬u) → no λ { (_ , []-congᵢ _ _ u _ _) → ¬u u }
                 (yes u) →
-                  case dec⇇ ⊢Γ v
-                         (Idⱼ (soundness⇇ ⊢Γ t)
-                            (soundness⇇ ⊢Γ u)) of λ where
+                  case dec⇇ v
+                         (Idⱼ (soundness⇇ t) (soundness⇇ u)) of λ where
                     (no ¬v) → no λ { (_ , []-congᵢ _ _ _ v _) → ¬v v }
                     (yes v) → yes (_ , []-congᵢ A t u v ok) }
 
   -- Decidability of bi-directional type checking
 
-  dec⇇ : ⊢ Γ → Checkable t → Γ ⊢ A → Dec (Γ ⊢ t ⇇ A)
-  dec⇇ ⊢Γ (lamᶜ {p = p′} t) ⊢A = case isΠ ⊢A of λ where
+  dec⇇ : Checkable t → Γ ⊢ A → Dec (Γ ⊢ t ⇇ A)
+  dec⇇ (lamᶜ {p = p′} t) ⊢A = case isΠ ⊢A of λ where
     (yes (p , _ , _ , _ , A⇒Π)) →
-      let ⊢F , ⊢G , _ = inversion-ΠΣ (syntacticRed A⇒Π .proj₂) in
-      case dec⇇ (⊢Γ ∙ ⊢F) t ⊢G of λ where
+      let _ , ⊢G , _ = inversion-ΠΣ (syntacticRed A⇒Π .proj₂) in
+      case dec⇇ t ⊢G of λ where
         (yes t⇇G) → case p ≟ p′ of λ where
           (yes PE.refl) → yes (lamᶜ (A⇒Π , ΠΣₙ) t⇇G)
           (no p≢p′) → no λ where
@@ -719,12 +718,12 @@ mutual
             PE.refl → ¬t⇇G x₁
     (no ¬isΠ) → no λ where
       (lamᶜ x _) → ¬isΠ (_ , _ , _ , _ , proj₁ x)
-  dec⇇ ⊢Γ (prodᶜ {p = p′} {m = m′} t u) ⊢A = case isΣ ⊢A of λ where
+  dec⇇ (prodᶜ {p = p′} {m = m′} t u) ⊢A = case isΣ ⊢A of λ where
     (yes (m , p , _ , _ , _ , A⇒Σ)) →
       let ⊢F , ⊢G , _ = inversion-ΠΣ (syntacticRed A⇒Σ .proj₂) in
-      case dec⇇ ⊢Γ t ⊢F of λ where
-        (yes t⇇F) → case dec⇇ ⊢Γ u
-                           (substType ⊢G (soundness⇇ ⊢Γ t⇇F)) of λ where
+      case dec⇇ t ⊢F of λ where
+        (yes t⇇F) → case dec⇇ u
+                           (substType ⊢G (soundness⇇ t⇇F)) of λ where
           (yes u⇇Gₜ) → case p ≟ p′ of λ where
             (yes PE.refl) → case decStrength m m′ of λ where
               (yes PE.refl) → yes (prodᶜ (A⇒Σ , ΠΣₙ) t⇇F u⇇Gₜ)
@@ -745,7 +744,7 @@ mutual
             PE.refl → ¬t⇇F x₁
     (no ¬isΣ) →
       no λ { (prodᶜ x _ _) → ¬isΣ (_ , _ , _ , _ , _ , proj₁ x) }
-  dec⇇ ⊢Γ rflᶜ ⊢A =
+  dec⇇ rflᶜ ⊢A =
     case is-Id ⊢A of λ where
       (no is-not-Id) → no λ where
         (rflᶜ (A⇒*Id-t-u , _) t≡u) → is-not-Id (_ , _ , _ , A⇒*Id-t-u)
@@ -761,8 +760,9 @@ mutual
               t≢u t′≡u′ }
             (infᶜ () _)
           (yes t≡u) → yes (rflᶜ (A⇒*Id-t-u , Idₙ) t≡u)
-  dec⇇ ⊢Γ (infᶜ t) ⊢A = case dec⇉ ⊢Γ t of λ where
-    (yes (B , t⇉B)) → case decEq (proj₁ (soundness⇉ ⊢Γ t⇉B)) ⊢A of λ where
+  dec⇇ (infᶜ t) ⊢A = case dec⇉ (wf ⊢A) t of λ where
+    (yes (B , t⇉B)) → case decEq (soundness⇉ (wf ⊢A) t⇉B .proj₁)
+                             ⊢A of λ where
       (yes B≡A) → yes (infᶜ t⇉B B≡A)
       (no B≢A) → no λ where
         (infᶜ x x₁) → case deterministic⇉ t⇉B x of λ where

--- a/Definition/Typechecking/Decidable.agda
+++ b/Definition/Typechecking/Decidable.agda
@@ -341,7 +341,7 @@ mutual
         in  case dec⇇ ⊢Γ z ⊢A₀ of λ where
           (yes z⇇A₀) →
             let ⊢Γ₊ = ⊢Γ ∙ ℕⱼ ⊢Γ ∙ ⊢A
-                ⊢A₊ =  subst↑²Type (ℕⱼ ⊢Γ) ⊢A ⊢A (sucⱼ (var₁ ⊢A))
+                ⊢A₊ = subst↑²Type ⊢A (sucⱼ (var₁ ⊢A))
             in  case dec⇇ ⊢Γ₊ s ⊢A₊ of λ where
               (yes s⇇A₊) → yes (_ , natrecᵢ A⇇Type z⇇A₀ s⇇A₊ n⇇ℕ)
               (no ¬s⇇A₊) → no λ where

--- a/Definition/Typechecking/Decidable.agda
+++ b/Definition/Typechecking/Decidable.agda
@@ -2,6 +2,8 @@
 -- Decidability of bi-derectional typechecking.
 ------------------------------------------------------------------------
 
+{-# OPTIONS --no-infer-absurd-clauses #-}
+
 open import Definition.Typechecking.Decidable.Assumptions
 open import Definition.Typed.Restrictions
 open import Graded.Modality
@@ -22,6 +24,7 @@ open import Definition.Typechecking.Deterministic R
 open import Definition.Typed R
 open import Definition.Typed.Properties R
 open import Definition.Typed.Weakening R as W
+open import Definition.Typed.Consequences.DerivedRules R
 open import Definition.Typed.Consequences.Inequality R
 open import Definition.Typed.Consequences.Inversion R
 open import Definition.Typed.Consequences.Syntactic R
@@ -34,20 +37,22 @@ open import Definition.Untyped.Neutral M type-variant as U
 
 open import Tools.Fin
 open import Tools.Function
-open import Tools.Nat using (Nat)
+open import Tools.Nat using (Nat; 1+)
 open import Tools.Product
 import Tools.PropositionalEquality as PE
 open import Tools.Relation
 
 private
   variable
+    P : Set a
     n : Nat
     Γ : Con Term n
     t u v w A B : Term n
     p q r : M
 
 dec⇉-var : (x : Fin n) → ∃ λ A → x ∷ A ∈ Γ
-dec⇉-var {Γ = Γ ∙ A} x0 = _ , here
+dec⇉-var {Γ = ε}     ()
+dec⇉-var {Γ = Γ ∙ A} x0     = _ , here
 dec⇉-var {Γ = Γ ∙ B} (x +1) =
   let A , x∷A∈Γ = dec⇉-var x
   in  _ , there x∷A∈Γ
@@ -66,130 +71,91 @@ mutual
   -- Decidability of terms being inferable
 
   dec-Inferable : (t : Term n) → Dec (Inferable t)
-  dec-Inferable (var x) = yes varᵢ
-  dec-Inferable U = yes Uᵢ
-  dec-Inferable (ΠΣ⟨ b ⟩ p , q ▷ F ▹ G) =
-    case dec-Checkable F of λ where
-      (yes F′) → case dec-Checkable G of λ where
-        (yes G′) → yes (ΠΣᵢ F′ G′)
-        (no ¬G′) → no λ where
-          (ΠΣᵢ x x₁) → ¬G′ x₁
-      (no ¬F′) → no λ where
-        (ΠΣᵢ x x₁) → ¬F′ x
-  dec-Inferable (lam p t) = no λ ()
-  dec-Inferable (t ∘⟨ p ⟩ u) = case dec-Inferable t of λ where
-    (yes t′) → case dec-Checkable u of λ where
-      (yes u′) → yes (∘ᵢ t′ u′)
-      (no ¬u′) → no λ where
-        (∘ᵢ x x₁) → ¬u′ x₁
-    (no ¬t′) → no λ where
-      (∘ᵢ x x₁) → ¬t′ x
-  dec-Inferable (prod! t u) = no λ ()
-  dec-Inferable (fst p t) = case dec-Inferable t of λ where
-    (yes t′) → yes (fstᵢ t′)
-    (no ¬t′) → no λ where
-      (fstᵢ x) → ¬t′ x
-  dec-Inferable (snd p t) = case dec-Inferable t of λ where
-    (yes t′) → yes (sndᵢ t′)
-    (no ¬t′) → no λ where
-      (sndᵢ x) → ¬t′ x
-  dec-Inferable (prodrec r p q A t u) = case dec-Checkable A of λ where
-    (yes A′) → case dec-Inferable t of λ where
-      (yes t′) → case dec-Checkable u of λ where
-        (yes u′) → yes (prodrecᵢ A′ t′ u′)
-        (no ¬u′) → no λ where
-          (prodrecᵢ x x₁ x₂) → ¬u′ x₂
-      (no ¬t′) → no λ where
-        (prodrecᵢ x x₁ x₂) → ¬t′ x₁
-    (no ¬A′) → no λ where
-      (prodrecᵢ x x₁ x₂) → ¬A′ x
-  dec-Inferable ℕ = yes ℕᵢ
-  dec-Inferable zero = yes zeroᵢ
-  dec-Inferable (suc t) = case dec-Checkable t of λ where
-    (yes t′) → yes (sucᵢ t′)
-    (no ¬t′) → no λ where
-      (sucᵢ x) → ¬t′ x
-  dec-Inferable (natrec p q r A z s n) = case dec-Checkable A of λ where
-    (yes A′) → case dec-Checkable z of λ where
-      (yes z′) → case dec-Checkable s of λ where
-        (yes s′) → case dec-Checkable n of λ where
-          (yes n′) → yes (natrecᵢ A′ z′ s′ n′)
-          (no ¬n′) →  no λ where
-            (natrecᵢ x x₁ x₂ x₃) → ¬n′ x₃
-        (no ¬s′) →  no λ where
-          (natrecᵢ x x₁ x₂ x₃) → ¬s′ x₂
-      (no ¬z′) →  no λ where
-        (natrecᵢ x x₁ x₂ x₃) → ¬z′ x₁
-    (no ¬A′) → no λ where
-      (natrecᵢ x x₁ x₂ x₃) → ¬A′ x
-  dec-Inferable Unit! = yes Unitᵢ
-  dec-Inferable star! = yes starᵢ
-  dec-Inferable (unitrec p q A t u) = case dec-Checkable A of λ where
-    (yes A′) → case dec-Checkable t of λ where
-      (yes t′) → case dec-Checkable u of λ where
-        (yes u′) → yes (unitrecᵢ A′ t′ u′)
-        (no ¬u′) → no λ where
-          (unitrecᵢ x x₁ x₂) → ¬u′ x₂
-      (no ¬t′) → no λ where
-        (unitrecᵢ x x₁ x₂) → ¬t′ x₁
-    (no ¬A′) → no λ where
-      (unitrecᵢ x x₁ x₂) → ¬A′ x
-  dec-Inferable Empty = yes Emptyᵢ
-  dec-Inferable (emptyrec p A t) = case dec-Checkable A of λ where
-    (yes A′) → case dec-Checkable t of λ where
-      (yes t′) → yes (emptyrecᵢ A′ t′)
-      (no ¬t′) →  no λ where
-        (emptyrecᵢ x x₁) → ¬t′ x₁
-    (no ¬A′) → no λ where
-      (emptyrecᵢ x x₁) → ¬A′ x
-  dec-Inferable (Id A t u) = case dec-Checkable A of λ where
-    (no ¬A) → no λ where
-      (Idᵢ A _ _) → ¬A A
-    (yes A) → case dec-Checkable t of λ where
-      (no ¬t) → no λ where
-        (Idᵢ _ t _) → ¬t t
-      (yes t) → case dec-Checkable u of λ where
-        (no ¬u) → no λ where
-          (Idᵢ _ _ u) → ¬u u
-        (yes u) → yes (Idᵢ A t u)
+  dec-Inferable (var _) =
+    yes varᵢ
+  dec-Inferable U =
+    yes Uᵢ
+  dec-Inferable (ΠΣ⟨ b ⟩ p , q ▷ A ▹ B) =
+    case dec-Checkable A ×-dec dec-Checkable B of λ where
+      (yes (A , B)) → yes (ΠΣᵢ A B)
+      (no not)      → no λ { (ΠΣᵢ A B) → not (A , B) }
+  dec-Inferable (lam _ _) =
+    no λ ()
+  dec-Inferable (t ∘⟨ _ ⟩ u) =
+    case dec-Inferable t ×-dec dec-Checkable u of λ where
+      (yes (t , u)) → yes (∘ᵢ t u)
+      (no not)      → no λ { (∘ᵢ t u) → not (t , u) }
+  dec-Inferable (prod! _ _) =
+    no λ ()
+  dec-Inferable (fst _ t) =
+    case dec-Inferable t of λ where
+      (yes t)  → yes (fstᵢ t)
+      (no not) → no λ { (fstᵢ t) → not t }
+  dec-Inferable (snd _ t) =
+    case dec-Inferable t of λ where
+      (yes t)  → yes (sndᵢ t)
+      (no not) → no λ { (sndᵢ t) → not t }
+  dec-Inferable (prodrec _ _ _ A t u) =
+    case dec-Checkable A ×-dec dec-Inferable t ×-dec
+         dec-Checkable u of λ where
+    (yes (A , t , u)) → yes (prodrecᵢ A t u)
+    (no not)          → no λ { (prodrecᵢ A t u) → not (A , t , u) }
+  dec-Inferable ℕ =
+    yes ℕᵢ
+  dec-Inferable zero =
+    yes zeroᵢ
+  dec-Inferable (suc t) =
+    case dec-Checkable t of λ where
+      (yes t)  → yes (sucᵢ t)
+      (no not) → no λ { (sucᵢ t) → not t }
+  dec-Inferable (natrec _ _ _ A t u v) =
+    case dec-Checkable A ×-dec dec-Checkable t ×-dec
+         dec-Checkable u ×-dec dec-Checkable v of λ where
+      (yes (A , t , u , v)) → yes (natrecᵢ A t u v)
+      (no not)              →
+        no λ { (natrecᵢ A t u v) → not (A , t , u , v) }
+  dec-Inferable Unit! =
+    yes Unitᵢ
+  dec-Inferable star! =
+    yes starᵢ
+  dec-Inferable (unitrec _ _ A t u) =
+    case dec-Checkable A ×-dec dec-Checkable t ×-dec
+         dec-Checkable u of λ where
+      (yes (A , t , u)) → yes (unitrecᵢ A t u)
+      (no not)          → no λ { (unitrecᵢ A t u) → not (A , t , u) }
+  dec-Inferable Empty =
+    yes Emptyᵢ
+  dec-Inferable (emptyrec p A t) =
+    case dec-Checkable A ×-dec dec-Checkable t of λ where
+      (yes (A , t)) → yes (emptyrecᵢ A t)
+      (no not)      → no λ { (emptyrecᵢ A t) → not (A , t) }
+  dec-Inferable (Id A t u) =
+    case dec-Checkable A ×-dec dec-Checkable t ×-dec
+         dec-Checkable u of λ where
+      (yes (A , t , u)) → yes (Idᵢ A t u)
+      (no not)          → no λ { (Idᵢ A t u) → not (A , t , u) }
   dec-Inferable rfl =
     no λ ()
   dec-Inferable (J _ _ A t B u v w) =
-    case dec-Checkable A of λ where
-      (no ¬A) → no λ { (Jᵢ A _ _ _ _ _) → ¬A A }
-      (yes A) → case dec-Checkable t of λ where
-        (no ¬t) → no λ { (Jᵢ _ t _ _ _ _) → ¬t t }
-        (yes t) → case dec-Checkable B of λ where
-          (no ¬B) → no λ { (Jᵢ _ _ B _ _ _) → ¬B B }
-          (yes B) → case dec-Checkable u of λ where
-            (no ¬u) → no λ { (Jᵢ _ _ _ u _ _) → ¬u u }
-            (yes u) → case dec-Checkable v of λ where
-              (no ¬v) → no λ { (Jᵢ _ _ _ _ v _) → ¬v v }
-              (yes v) → case dec-Checkable w of λ where
-                (no ¬w) → no λ { (Jᵢ _ _ _ _ _ w) → ¬w w }
-                (yes w) → yes (Jᵢ A t B u v w)
+    case dec-Checkable A ×-dec dec-Checkable t ×-dec
+         dec-Checkable B ×-dec dec-Checkable u ×-dec
+         dec-Checkable v ×-dec dec-Checkable w of λ where
+      (yes (A , t , B , u , v , w)) → yes (Jᵢ A t B u v w)
+      (no not)                      →
+        no λ { (Jᵢ A t B u v w) → not (A , t , B , u , v , w) }
   dec-Inferable (K _ A t B u v) =
-    case dec-Checkable A of λ where
-      (no ¬A) → no λ { (Kᵢ A _ _ _ _) → ¬A A }
-      (yes A) → case dec-Checkable t of λ where
-        (no ¬t) → no λ { (Kᵢ _ t _ _ _) → ¬t t }
-        (yes t) → case dec-Checkable B of λ where
-          (no ¬B) → no λ { (Kᵢ _ _ B _ _) → ¬B B }
-          (yes B) → case dec-Checkable u of λ where
-            (no ¬u) → no λ { (Kᵢ _ _ _ u _) → ¬u u }
-            (yes u) → case dec-Checkable v of λ where
-              (no ¬v) → no λ { (Kᵢ _ _ _ _ v) → ¬v v }
-              (yes v) → yes (Kᵢ A t B u v)
+    case dec-Checkable A ×-dec dec-Checkable t ×-dec
+         dec-Checkable B ×-dec dec-Checkable u ×-dec
+         dec-Checkable v of λ where
+      (yes (A , t , B , u , v)) → yes (Kᵢ A t B u v)
+      (no not)                  →
+        no λ { (Kᵢ A t B u v) → not (A , t , B , u , v) }
   dec-Inferable ([]-cong s A t u v) =
-    case dec-Checkable A of λ where
-      (no ¬A) → no λ { ([]-congᵢ A _ _ _) → ¬A A }
-      (yes A) → case dec-Checkable t of λ where
-        (no ¬t) → no λ { ([]-congᵢ _ t _ _) → ¬t t }
-        (yes t) → case dec-Checkable u of λ where
-          (no ¬u) → no λ { ([]-congᵢ _ _ u _) → ¬u u }
-          (yes u) → case dec-Checkable v of λ where
-            (no ¬v) → no λ { ([]-congᵢ _ _ _ v) → ¬v v }
-            (yes v) → yes ([]-congᵢ A t u v)
+    case dec-Checkable A ×-dec dec-Checkable t ×-dec
+         dec-Checkable u ×-dec dec-Checkable v of λ where
+      (yes (A , t , u , v)) → yes ([]-congᵢ A t u v)
+      (no not)              →
+        no λ { ([]-congᵢ A t u v) → not (A , t , u , v) }
 
   -- Decidability of terms being checkable
 
@@ -199,14 +165,16 @@ mutual
     helper : (t : Term n) → Dec (Inferable t) → Dec (Checkable t)
     helper (lam _ t) _ =
       case dec-Checkable t of λ where
-        (no ¬t) → no λ { (lamᶜ t) → ¬t t }
-        (yes t) → yes (lamᶜ t)
+        (yes t)  → yes (lamᶜ t)
+        (no not) → no λ where
+          (lamᶜ t)  → not t
+          (infᶜ ())
     helper (prod! t u) _ =
-      case dec-Checkable t of λ where
-        (no ¬t) → no λ { (prodᶜ t _) → ¬t t }
-        (yes t) → case dec-Checkable u of λ where
-          (no ¬u) → no λ { (prodᶜ _ u) → ¬u u }
-          (yes u) → yes (prodᶜ t u)
+      case dec-Checkable t ×-dec dec-Checkable u of λ where
+        (yes (t , u)) → yes (prodᶜ t u)
+        (no not)      → no λ where
+          (prodᶜ t u) → not (t , u)
+          (infᶜ ())
     helper rfl _ =
       yes rflᶜ
     helper (var _) = λ where
@@ -270,285 +238,295 @@ mutual
       (yes t) → yes (infᶜ t)
       (no ¬t) → no λ { (infᶜ t) → ¬t t }
 
+private opaque
+
+  -- A variant of isΠΣ.
+
+  isΠΣ-with-cont :
+    {Γ : Con Term n}
+    {P : BinderMode → M → M → Term n → Term (1+ n) → Set a} →
+    Γ ⊢ A →
+    (∀ {b p q B C} →
+     Γ ⊢ B → Γ ∙ B ⊢ C → ΠΣ-allowed b p q →
+     Γ ⊢ A ⇒* ΠΣ⟨ b ⟩ p , q ▷ B ▹ C → Dec (P b p q B C)) →
+    Dec
+      (∃ λ ((b , p , q , B , C , _) :
+            ∃₅ λ b p q B C → Γ ⊢ A ⇒* ΠΣ⟨ b ⟩ p , q ▷ B ▹ C) →
+       P b p q B C)
+  isΠΣ-with-cont {P} ⊢A cont =
+    Σ-dec (isΠΣ ⊢A)
+      (λ (_ , _ , _ , _ , _ , A⇒*ΠΣ₁) (_ , _ , _ , _ , _ , A⇒*ΠΣ₂) →
+         case whrDet* (A⇒*ΠΣ₁ , ΠΣₙ) (A⇒*ΠΣ₂ , ΠΣₙ) of λ {
+           PE.refl →
+         idᶠ })
+      (λ (_ , _ , _ , _ , _ , A⇒*ΠΣ) →
+         let ⊢B , ⊢C , ok = inversion-ΠΣ (syntacticRed A⇒*ΠΣ .proj₂) in
+         cont ⊢B ⊢C ok A⇒*ΠΣ)
+
 mutual
-
-  dec⇉-app : ⊢ Γ → Inferable t → Checkable u → Dec (∃ λ A → Γ ⊢ t ∘⟨ p ⟩ u ⇉ A)
-  dec⇉-app {p = p′} ⊢Γ t u = case dec⇉ ⊢Γ t of λ where
-    (yes (A , t⇉A)) → case isΠ (proj₁ (soundness⇉ ⊢Γ t⇉A)) of λ where
-      (yes (p , _ , _ , _ , A⇒Π)) →
-        let ⊢F , _ = inversion-ΠΣ (syntacticRed A⇒Π .proj₂) in
-        case dec⇇ u ⊢F of λ where
-          (yes u⇇F) → case p ≟ p′ of λ where
-            (yes PE.refl) → yes (_ , appᵢ t⇉A (A⇒Π , ΠΣₙ) u⇇F)
-            (no p≢p′) → no λ where
-              (_ , appᵢ x x₁ x₂) → case deterministic⇉ x t⇉A of λ where
-                PE.refl → case whrDet* (A⇒Π , ΠΣₙ) x₁ of λ where
-                  PE.refl → p≢p′ PE.refl
-          (no ¬u⇇F) → no λ where
-            (_ , appᵢ x x₁ x₂) → case deterministic⇉ x t⇉A of λ where
-               PE.refl → case whrDet* (A⇒Π , ΠΣₙ) x₁ of λ where
-                 PE.refl → ¬u⇇F x₂
-      (no ¬isΠ) → no λ where
-        (_ , appᵢ x x₁ x₂) → case deterministic⇉ x t⇉A of λ where
-          PE.refl → ¬isΠ (_ , _ , _ , _ , proj₁ x₁)
-    (no ¬t⇉A) → no λ where
-      (_ , appᵢ x x₁ x₂) → ¬t⇉A (_ , x)
-
-  dec⇉-fst : ⊢ Γ → Inferable t → Dec (∃ λ A → Γ ⊢ fst p t ⇉ A)
-  dec⇉-fst {p = p′} ⊢Γ t = case dec⇉ ⊢Γ t of λ where
-    (yes (A , t⇉A)) → case isΣˢ (proj₁ (soundness⇉ ⊢Γ t⇉A)) of λ where
-      (yes (p , _ , _ , _ , A⇒Σ)) → case p ≟ p′ of λ where
-        (yes PE.refl) → yes (_ , fstᵢ t⇉A (A⇒Σ , U.ΠΣₙ))
-        (no p≢p′) → no λ where
-          (_ , fstᵢ x x₁) → case deterministic⇉ x t⇉A of λ where
-             PE.refl → case whrDet* (A⇒Σ , ΠΣₙ) x₁ of λ where
-               PE.refl → p≢p′ PE.refl
-      (no ¬isΣ) → no λ where
-        (_ , fstᵢ x x₁) → case deterministic⇉ x t⇉A of λ where
-          PE.refl → ¬isΣ (_ , _ , _ , _ , proj₁ x₁)
-    (no ¬t⇉A) → no λ where
-      (_ , fstᵢ x x₁) → ¬t⇉A (_ , x)
-
-  dec⇉-snd : ⊢ Γ → Inferable t → Dec (∃ λ A → Γ ⊢ snd p t ⇉ A)
-  dec⇉-snd {p = p′} ⊢Γ t = case dec⇉ ⊢Γ t of λ where
-    (yes (A , t⇉A)) → case isΣˢ (proj₁ (soundness⇉ ⊢Γ t⇉A)) of λ where
-      (yes (p , _ , _ , _ , A⇒Σ)) → case p ≟ p′ of λ where
-        (yes PE.refl) → yes (_ , sndᵢ t⇉A (A⇒Σ , U.ΠΣₙ))
-        (no p≢p′) → no λ where
-          (_ , sndᵢ x x₁) → case deterministic⇉ x t⇉A of λ where
-             PE.refl → case whrDet* (A⇒Σ , ΠΣₙ) x₁ of λ where
-               PE.refl → p≢p′ PE.refl
-      (no ¬isΣ) → no λ where
-        (_ , sndᵢ x x₁) → case deterministic⇉ x t⇉A of λ where
-          PE.refl → ¬isΣ (_ , _ , _ , _ , proj₁ x₁)
-    (no ¬t⇉A) → no λ where
-      (_ , sndᵢ x x₁) → ¬t⇉A (_ , x)
-
-  dec⇉-natrec : ∀ {A z s n} → ⊢ Γ → Checkable A → Checkable z → Checkable s → Checkable n
-              → Dec (∃ λ B → Γ ⊢ natrec p q r A z s n ⇉ B)
-  dec⇉-natrec ⊢Γ A z s n = case dec⇇ n (ℕⱼ ⊢Γ) of λ where
-    (yes n⇇ℕ) → case dec⇇Type (⊢Γ ∙ ℕⱼ ⊢Γ) A of λ where
-      (yes A⇇Type) →
-        let ⊢A = soundness⇇Type (⊢Γ ∙ ℕⱼ ⊢Γ) A⇇Type
-            ⊢A₀ = substType ⊢A (zeroⱼ ⊢Γ)
-        in  case dec⇇ z ⊢A₀ of λ where
-          (yes z⇇A₀) →
-            let ⊢A₊ = subst↑²Type ⊢A (sucⱼ (var₁ ⊢A)) in
-            case dec⇇ s ⊢A₊ of λ where
-              (yes s⇇A₊) → yes (_ , natrecᵢ A⇇Type z⇇A₀ s⇇A₊ n⇇ℕ)
-              (no ¬s⇇A₊) → no λ where
-                (_ , natrecᵢ x x₁ x₂ x₃) → ¬s⇇A₊ x₂ --¬s⇇A₊ x₂
-          (no ¬z⇇A₀) → no λ where
-            (_ , natrecᵢ x x₁ x₂ x₃) → ¬z⇇A₀ x₁
-      (no ¬A⇇Type) → no λ where
-        (_ , natrecᵢ x x₁ x₂ x₃) → ¬A⇇Type x
-    (no ¬n⇇ℕ) → no λ where
-      (_ , natrecᵢ x x₁ x₂ x₃) → ¬n⇇ℕ x₃
-
-  dec⇉-prodrec : ⊢ Γ → Checkable A → Inferable t → Checkable u
-               → Dec (∃ λ B → Γ ⊢ prodrec r p q A t u ⇉ B)
-  dec⇉-prodrec {r = r} {p = p′} {q = q} ⊢Γ A t u =
-    case dec⇉ ⊢Γ t of λ where
-      (yes (B , t⇉B)) → case isΣʷ (proj₁ (soundness⇉ ⊢Γ t⇉B)) of λ where
-        (yes (p , _ , _ , _ , B⇒Σ)) →
-          case inversion-ΠΣ (syntacticRed B⇒Σ .proj₂) of λ {
-            (⊢F , ⊢G , ok) →
-          case dec⇇Type (⊢Γ ∙ ΠΣⱼ ⊢F ⊢G ok) A of λ where
-            (yes A⇇Type) →
-              let ⊢ΓΣ = ⊢Γ ∙ ΠΣⱼ {p = p} ⊢F ⊢G ok
-                  ⊢A = soundness⇇Type ⊢ΓΣ A⇇Type
-                  ⊢A₊ = subst↑²Type-prod ⊢A ok
-              in  case dec⇇ u ⊢A₊ of λ where
-                (yes u⇇A₊) → case p ≟ p′ of λ where
-                  (yes PE.refl) →
-                    yes (_ , prodrecᵢ A⇇Type t⇉B (B⇒Σ , ΠΣₙ) u⇇A₊)
-                  (no p≢p′) → no λ where
-                    (_ , prodrecᵢ _ x₁ x₂ _) →
-                      case deterministic⇉ t⇉B x₁ of λ where
-                        PE.refl → case whrDet* (B⇒Σ , ΠΣₙ) x₂ of λ where
-                          PE.refl → p≢p′ PE.refl
-                (no ¬u⇇A₊) → no λ where
-                  (_ , prodrecᵢ _ x₁ x₂ x₃) →
-                    case deterministic⇉ t⇉B x₁ of λ where
-                       PE.refl → case whrDet* (B⇒Σ , ΠΣₙ) x₂ of λ where
-                         PE.refl → ¬u⇇A₊ x₃
-            (no ¬A⇇Type) → no λ where
-              (_ , prodrecᵢ x x₁ x₂ _) →
-                case deterministic⇉ t⇉B x₁ of λ where
-                  PE.refl → case whrDet* (B⇒Σ , ΠΣₙ) x₂ of λ where
-                    PE.refl → ¬A⇇Type x }
-        (no ¬isΣ) → no λ where
-          (_ , prodrecᵢ _ x₁ x₂ _) →
-            case deterministic⇉ t⇉B x₁ of λ where
-              PE.refl → ¬isΣ (_ , _ , _ , _ , proj₁ x₂)
-      (no ¬t⇉B) → no λ where
-        (_ , prodrecᵢ x x₁ x₂ x₃) → ¬t⇉B (_ , x₁)
-
-  dec⇉-emptyrec : ⊢ Γ → Checkable A → Checkable t → Dec (∃ λ B → Γ ⊢ emptyrec p A t ⇉ B)
-  dec⇉-emptyrec ⊢Γ A t = case dec⇇Type ⊢Γ A of λ where
-    (yes A⇇Type) → case dec⇇ t (Emptyⱼ ⊢Γ) of λ where
-      (yes t⇇Empty) → yes (_ , emptyrecᵢ A⇇Type t⇇Empty)
-      (no ¬t⇇Empty) → no λ where
-        (_ , emptyrecᵢ x x₁) → ¬t⇇Empty x₁
-    (no ¬A⇇Type) → no λ where
-      (_ , emptyrecᵢ x x₁) → ¬A⇇Type x
-
-  dec⇉-unitrec : ⊢ Γ → Checkable A → Checkable t
-              → Checkable u → Dec (∃ λ B → Γ ⊢ unitrec p q A t u ⇉ B)
-  dec⇉-unitrec ⊢Γ A t u = case Unit-allowed? 𝕨 of λ where
-    (yes ok) → case Unitⱼ ⊢Γ ok of λ
-      ⊢Unit → case dec⇇Type (⊢Γ ∙ ⊢Unit) A of λ where
-        (yes A⇇Type) → case dec⇇ t ⊢Unit of λ where
-          (yes t⇇Unit) → case dec⇇ u
-                                (substType
-                                   (soundness⇇Type (⊢Γ ∙ ⊢Unit) A⇇Type)
-                                   (starⱼ ⊢Γ ok)) of λ where
-            (yes u⇇A₊) → yes (_ , unitrecᵢ A⇇Type t⇇Unit u⇇A₊)
-            (no ¬u⇇A₊) → no λ where
-              (_ , unitrecᵢ x x₁ x₂) → ¬u⇇A₊ x₂
-          (no ¬t⇇Unit) → no λ where
-            (_ , unitrecᵢ x x₁ x₂) → ¬t⇇Unit x₁
-        (no ¬A⇇Type) → no λ where
-          (_ , unitrecᵢ x x₁ x₂) → ¬A⇇Type x
-    (no not-ok) → no λ where
-      (_ , unitrecᵢ x x₁ x₂) →
-        let ⊢t = soundness⇇ x₁
-            ⊢Unit = syntacticTerm ⊢t
-        in  not-ok (inversion-Unit ⊢Unit)
 
   private
 
     -- Some lemmas used below.
+
+    dec⇉-with-cont :
+      {Γ : Con Term n} {P : Term n → Set a} →
+      ⊢ Γ → Inferable t → (∀ {A} → Γ ⊢ A → Dec (P A)) →
+      Dec (Σ (∃ λ A → Γ ⊢ t ⇉ A) (P ∘→ proj₁))
+    dec⇉-with-cont ⊢Γ t cont =
+      Σ-dec (dec⇉ ⊢Γ t)
+        (λ (_ , t₁) (_ , t₂) →
+           case deterministic⇉ t₁ t₂ of λ { PE.refl → idᶠ })
+        (cont ∘→ proj₁ ∘→ soundness⇉ ⊢Γ ∘→ proj₂)
+
+    dec⇇-with-cont :
+      Checkable t → Γ ⊢ A → (Γ ⊢ t ∷ A → Dec P) → Dec (Γ ⊢ t ⇇ A × P)
+    dec⇇-with-cont t ⊢A cont =
+      dec⇇ t ⊢A ×-dec′ cont ∘→ soundness⇇
+
+    dec⇇Type-with-cont :
+      ⊢ Γ → Checkable A → (Γ ⊢ A → Dec P) → Dec (Γ ⊢ A ⇇Type × P)
+    dec⇇Type-with-cont ⊢Γ A cont =
+      dec⇇Type ⊢Γ A ×-dec′ cont ∘→ soundness⇇Type ⊢Γ
+
+    dec⇉-app :
+      ⊢ Γ → Inferable t → Checkable u →
+      Dec (∃ λ A → Γ ⊢ t ∘⟨ p ⟩ u ⇉ A)
+    dec⇉-app {p} ⊢Γ t u =
+      case
+        (dec⇉-with-cont ⊢Γ t λ ⊢A →
+         isΠΣ-with-cont ⊢A λ {b = b} {p = p′} ⊢B _ _ _ →
+         decBinderMode b BMΠ ×-dec p ≟ p′ ×-dec dec⇇ u ⊢B)
+        of λ where
+        (yes
+           ((_ , t) , (_ , _ , _ , _ , _ , A) ,
+            PE.refl , PE.refl , u)) →
+          yes (_ , appᵢ t (A , ΠΣₙ) u)
+        (no not) →
+          no λ { (_ , appᵢ t (A , _) u) →
+          not
+            ( (_ , t)
+            , (_ , _ , _ , _ , _ , A)
+            , PE.refl , PE.refl , u
+            ) }
+
+    dec⇉-fst : ⊢ Γ → Inferable t → Dec (∃ λ A → Γ ⊢ fst p t ⇉ A)
+    dec⇉-fst {p} ⊢Γ t =
+      case
+        (dec⇉-with-cont ⊢Γ t λ ⊢A →
+         isΠΣ-with-cont ⊢A λ {b = b} {p = p′} ⊢B _ _ _ →
+         decBinderMode b (BMΣ 𝕤) ×-dec p ≟ p′)
+        of λ where
+        (yes
+           ((_ , t) , (_ , _ , _ , _ , _ , A) ,
+            PE.refl , PE.refl)) →
+          yes (_ , fstᵢ t (A , U.ΠΣₙ))
+        (no not) →
+          no λ { (_ , fstᵢ t (A , _)) →
+          not
+            ( (_ , t)
+            , (_ , _ , _ , _ , _ , A)
+            , PE.refl , PE.refl
+            ) }
+
+    dec⇉-snd : ⊢ Γ → Inferable t → Dec (∃ λ A → Γ ⊢ snd p t ⇉ A)
+    dec⇉-snd {p} ⊢Γ t =
+      case
+        (dec⇉-with-cont ⊢Γ t λ ⊢A →
+         isΠΣ-with-cont ⊢A λ {b = b} {p = p′} ⊢B _ _ _ →
+         decBinderMode b (BMΣ 𝕤) ×-dec p ≟ p′)
+        of λ where
+        (yes ((_ , t) , (_ , _ , _ , _ , _ , A) , PE.refl , PE.refl)) →
+          yes (_ , sndᵢ t (A , U.ΠΣₙ))
+        (no not) →
+          no λ { (_ , sndᵢ t (A , _)) →
+          not
+            ( (_ , t)
+            , (_ , _ , _ , _ , _ , A)
+            , PE.refl , PE.refl
+            ) }
+
+    dec⇉-natrec :
+      ⊢ Γ → Checkable A → Checkable t → Checkable u → Checkable v →
+      Dec (∃ λ B → Γ ⊢ natrec p q r A t u v ⇉ B)
+    dec⇉-natrec ⊢Γ A t u v =
+      case
+        (dec⇇Type-with-cont (⊢Γ ∙[ ℕⱼ ]) A λ ⊢A →
+         dec⇇ t (substType ⊢A (zeroⱼ ⊢Γ)) ×-dec
+         dec⇇ u (subst↑²Type ⊢A (sucⱼ (var₁ ⊢A))) ×-dec
+         dec⇇ v (ℕⱼ ⊢Γ))
+        of λ where
+        (yes (A , t , u , v)) → yes (_ , natrecᵢ A t u v)
+        (no not)              →
+          no λ { (_ , natrecᵢ A t u v) → not (A , t , u , v) }
+
+    dec⇉-prodrec :
+      ⊢ Γ → Checkable A → Inferable t → Checkable u →
+      Dec (∃ λ B → Γ ⊢ prodrec r p q A t u ⇉ B)
+    dec⇉-prodrec {p} ⊢Γ A t u =
+      case
+        (dec⇉-with-cont ⊢Γ t λ ⊢B →
+         isΠΣ-with-cont ⊢B λ {b = b} {p = p′} _ ⊢D ok _ →
+         decBinderMode b (BMΣ 𝕨) ×-dec′ λ b≡ →
+         p ≟ p′ ×-dec
+         dec⇇Type-with-cont (⊢→⊢∙ (ΠΣⱼ′ ⊢D ok)) A λ ⊢A →
+         dec⇇ u
+           (subst↑²Type-prod
+              (PE.subst (λ b → _ ∙ ΠΣ⟨ b ⟩ _ , _ ▷ _ ▹ _ ⊢ _) b≡ ⊢A)
+              (PE.subst (λ b → ΠΣ-allowed b _ _) b≡ ok)))
+        of λ where
+        (yes
+           ((_ , t) , (_ , _ , _ , _ , _ , A⇒*) ,
+            PE.refl , PE.refl , A , u)) →
+          yes (_ , prodrecᵢ A t (A⇒* , ΠΣₙ) u)
+        (no not) →
+          no λ { (_ , prodrecᵢ A t (A⇒* , _) u) →
+          not
+            ( (_ , t)
+            , (_ , _ , _ , _ , _ , A⇒*)
+            , PE.refl , PE.refl , A , u
+            ) }
+
+    dec⇉-emptyrec :
+      ⊢ Γ → Checkable A → Checkable t →
+      Dec (∃ λ B → Γ ⊢ emptyrec p A t ⇉ B)
+    dec⇉-emptyrec ⊢Γ A t =
+      case dec⇇Type ⊢Γ A ×-dec dec⇇ t (Emptyⱼ ⊢Γ) of λ where
+        (yes (A , t)) → yes (_ , emptyrecᵢ A t)
+        (no not)      → no λ { (_ , emptyrecᵢ A t) → not (A , t) }
+
+    dec⇉-unitrec :
+      ⊢ Γ → Checkable A → Checkable t → Checkable u →
+      Dec (∃ λ B → Γ ⊢ unitrec p q A t u ⇉ B)
+    dec⇉-unitrec ⊢Γ A t u =
+      case
+        (Unit-allowed? 𝕨 ×-dec′ λ ok →
+         let ⊢Unit = Unitⱼ ⊢Γ ok in
+         dec⇇Type-with-cont (⊢→⊢∙ ⊢Unit) A λ ⊢A →
+         dec⇇ t ⊢Unit ×-dec
+         dec⇇ u (substType ⊢A (starⱼ ⊢Γ ok)))
+        of λ where
+        (yes (_ , A , t , u)) → yes (_ , unitrecᵢ A t u)
+        (no not)              →
+          no λ { (_ , unitrecᵢ A t u) →
+          not (⊢∷Unit→Unit-allowed (soundness⇇ t) , A , t , u) }
 
     dec⇉-J :
       ⊢ Γ → Checkable A → Checkable t → Checkable B → Checkable u →
       Checkable v → Checkable w →
       Dec (∃ λ C → Γ ⊢ J p q A t B u v w ⇉ C)
     dec⇉-J ⊢Γ A t B u v w =
-      case dec⇇Type ⊢Γ A of λ where
-        (no ¬A) → no λ { (_ , Jᵢ A _ _ _ _ _) → ¬A A }
-        (yes A) →
-          case soundness⇇Type ⊢Γ A of λ {
-            ⊢A →
-          case dec⇇ t ⊢A of λ where
-            (no ¬t) → no λ { (_ , Jᵢ _ t _ _ _ _) → ¬t t }
-            (yes t) →
-              case soundness⇇ t of λ {
-                ⊢t →
-              case ⊢Γ ∙ ⊢A ∙ Idⱼ (wkTerm₁ ⊢A ⊢t) (var₀ ⊢A) of λ {
-                ⊢Γ∙A∙Id-t-0 →
-              case dec⇇Type ⊢Γ∙A∙Id-t-0 B of λ where
-                (no ¬B) → no λ { (_ , Jᵢ _ _ B _ _ _) → ¬B B }
-                (yes B) →
-                  case dec⇇ u
-                         (substType₂ (soundness⇇Type ⊢Γ∙A∙Id-t-0 B) ⊢t $
-                          PE.subst (_⊢_∷_ _ _) ≡Id-wk1-wk1-0[]₀ $
-                          rflⱼ ⊢t) of λ where
-                    (no ¬u) → no λ { (_ , Jᵢ _ _ _ u _ _) → ¬u u }
-                    (yes u) → case dec⇇ v ⊢A of λ where
-                      (no ¬v) → no λ { (_ , Jᵢ _ _ _ _ v _) → ¬v v }
-                      (yes v) →
-                        case dec⇇ w (Idⱼ ⊢t (soundness⇇ v)) of λ where
-                          (no ¬w) → no λ { (_ , Jᵢ _ _ _ _ _ w) → ¬w w }
-                          (yes w) → yes (_ , Jᵢ A t B u v w) }}}
+      case
+        (dec⇇Type-with-cont ⊢Γ A λ ⊢A →
+         dec⇇-with-cont t ⊢A λ ⊢t →
+         dec⇇Type-with-cont
+           (⊢→⊢∙ (Idⱼ (wkTerm₁ ⊢A ⊢t) (var₀ ⊢A))) B λ ⊢B →
+         dec⇇ u
+           (substType₂ ⊢B ⊢t $
+            PE.subst (_⊢_∷_ _ _) ≡Id-wk1-wk1-0[]₀ $
+            rflⱼ ⊢t) ×-dec
+         dec⇇-with-cont v ⊢A λ ⊢v →
+         dec⇇ w (Idⱼ ⊢t ⊢v))
+        of λ where
+        (yes (A , t , B , u , v , w)) → yes (_ , Jᵢ A t B u v w)
+        (no not)                      →
+          no λ { (_ , Jᵢ A t B u v w) → not (A , t , B , u , v , w) }
 
     dec⇉-K :
       ⊢ Γ → Checkable A → Checkable t → Checkable B → Checkable u →
-      Checkable v → Dec (∃ λ C → Γ ⊢ K p A t B u v ⇉ C)
+      Checkable v →
+      Dec (∃ λ C → Γ ⊢ K p A t B u v ⇉ C)
     dec⇉-K ⊢Γ A t B u v =
-      case K-allowed? of λ where
-        (no not-ok) → no λ { (_ , Kᵢ _ _ _ _ _ ok) → not-ok ok }
-        (yes ok)    → case dec⇇Type ⊢Γ A of λ where
-          (no ¬A) → no λ { (_ , Kᵢ A _ _ _ _ _) → ¬A A }
-          (yes A) →
-            case soundness⇇Type ⊢Γ A of λ {
-              ⊢A →
-            case dec⇇ t ⊢A of λ where
-              (no ¬t) → no λ { (_ , Kᵢ _ t _ _ _ _) → ¬t t }
-              (yes t) →
-                case soundness⇇ t of λ {
-                  ⊢t →
-                case ⊢Γ ∙ Idⱼ ⊢t ⊢t of λ {
-                  ⊢Γ∙Id-t-t →
-                case dec⇇Type ⊢Γ∙Id-t-t B of λ where
-                  (no ¬B) → no λ { (_ , Kᵢ _ _ B _ _ _) → ¬B B }
-                  (yes B) →
-                    case dec⇇ u
-                           (substType (soundness⇇Type ⊢Γ∙Id-t-t B)
-                              (rflⱼ ⊢t)) of λ where
-                      (no ¬u) → no λ { (_ , Kᵢ _ _ _ u _ _) → ¬u u }
-                      (yes u) → case dec⇇ v (Idⱼ ⊢t ⊢t) of λ where
-                        (no ¬v) → no λ { (_ , Kᵢ _ _ _ _ v _) → ¬v v }
-                        (yes v) → yes (_ , Kᵢ A t B u v ok) }}}
+      case
+        (K-allowed? ×-dec′ λ ok →
+         dec⇇Type-with-cont ⊢Γ A λ ⊢A →
+         dec⇇-with-cont t ⊢A λ ⊢t →
+         dec⇇Type-with-cont (⊢→⊢∙ (Idⱼ ⊢t ⊢t)) B λ ⊢B →
+         dec⇇ u (substType ⊢B (rflⱼ ⊢t)) ×-dec
+         dec⇇ v (Idⱼ ⊢t ⊢t))
+        of λ where
+        (yes (ok , A , t , B , u , v)) → yes (_ , Kᵢ A t B u v ok)
+        (no not)                       →
+          no λ { (_ , Kᵢ A t B u v ok) → not (ok , A , t , B , u , v) }
 
   -- Decidability of checking that an inferable term is a type
 
   dec⇉Type : ⊢ Γ → Inferable A → Dec (Γ ⊢ A ⇇Type)
-  dec⇉Type ⊢Γ Uᵢ = yes Uᶜ
-  dec⇉Type ⊢Γ (ΠΣᵢ {b = b} {p = p} {q = q} F G) =
-    case dec⇇Type ⊢Γ F of λ where
-      (yes F⇇Type) →
-        case dec⇇Type (⊢Γ ∙ soundness⇇Type ⊢Γ F⇇Type) G of λ where
-          (yes G⇇Type) → case ΠΣ-allowed? b p q of λ where
-            (yes ok)    → yes (ΠΣᶜ F⇇Type G⇇Type ok)
-            (no not-ok) → no λ where
-              (ΠΣᶜ _ _ ok)                  → not-ok ok
-              (univᶜ (infᶜ (ΠΣᵢ _ _ ok) _)) → not-ok ok
-          (no ¬G⇇Type) → no λ where
-            (ΠΣᶜ _ x _)                  → ¬G⇇Type x
-            (univᶜ (infᶜ (ΠΣᵢ _ x _) _)) → ¬G⇇Type (univᶜ x)
-      (no ¬F⇇Type) → no λ where
-        (ΠΣᶜ x _ _)                  → ¬F⇇Type x
-        (univᶜ (infᶜ (ΠΣᵢ x _ _) _)) → ¬F⇇Type (univᶜ x)
+  dec⇉Type _ Uᵢ = yes Uᶜ
+  dec⇉Type ⊢Γ (ΠΣᵢ {b} {p} {q} A B) =
+    case
+      (ΠΣ-allowed? b p q ×-dec
+       dec⇇Type-with-cont ⊢Γ A λ ⊢A →
+       dec⇇Type (⊢→⊢∙ ⊢A) B)
+      of λ where
+      (yes (ok , A , B)) → yes (ΠΣᶜ A B ok)
+      (no not)           → no λ where
+        (ΠΣᶜ A B ok)                  → not (ok , A , B)
+        (univᶜ (infᶜ (ΠΣᵢ A B ok) _)) → not (ok , univᶜ A , univᶜ B)
   dec⇉Type ⊢Γ (varᵢ {x = x}) = case dec⇇-var x (Uⱼ ⊢Γ) of λ where
     (yes x⇇U) → yes (univᶜ x⇇U)
     (no ¬x⇇U) → no λ where
       (univᶜ x) → ¬x⇇U x
-  dec⇉Type ⊢Γ (∘ᵢ t u) = case dec⇉-app ⊢Γ t u of λ where
-    (yes (A , tu⇉A)) → case decEq (proj₁ (soundness⇉ ⊢Γ tu⇉A)) (Uⱼ ⊢Γ) of λ where
-      (yes A≡U) → yes (univᶜ (infᶜ tu⇉A A≡U))
-      (no A≢U) → no λ where
-        (univᶜ (infᶜ x x₁)) → case deterministic⇉ tu⇉A x of λ where
-          PE.refl → A≢U x₁
-    (no ¬t′) → no λ where
-      (univᶜ (infᶜ x x₁)) → ¬t′ (_ , x)
-  dec⇉Type ⊢Γ (fstᵢ t) = case dec⇉-fst ⊢Γ t of λ where
-    (yes (A , t₁⇉A)) → case decEq (proj₁ (soundness⇉ ⊢Γ t₁⇉A)) (Uⱼ ⊢Γ) of λ where
-      (yes A≡U) → yes (univᶜ (infᶜ t₁⇉A A≡U))
-      (no A≢U) → no λ where
-        (univᶜ (infᶜ x x₁)) → case deterministic⇉ t₁⇉A x of λ where
-          PE.refl → A≢U x₁
-    (no ¬t₁⇉A) → no λ where
-      (univᶜ (infᶜ x x₁)) → ¬t₁⇉A (_ , x)
-  dec⇉Type ⊢Γ (sndᵢ t) = case dec⇉-snd ⊢Γ t of λ where
-    (yes (A , t₂⇉A)) → case decEq (proj₁ (soundness⇉ ⊢Γ t₂⇉A)) (Uⱼ ⊢Γ) of λ where
-      (yes A≡U) → yes (univᶜ (infᶜ t₂⇉A A≡U))
-      (no A≢U) → no λ where
-        (univᶜ (infᶜ x x₁)) → case deterministic⇉ t₂⇉A x of λ where
-          PE.refl → A≢U x₁
-    (no ¬t₂⇉A) → no λ where
-      (univᶜ (infᶜ x x₁)) → ¬t₂⇉A (_ , x)
-  dec⇉Type ⊢Γ (prodrecᵢ B t u) = case dec⇉-prodrec ⊢Γ B t u of λ where
-    (yes (A , pr⇉A)) → case decEq (proj₁ (soundness⇉ ⊢Γ pr⇉A)) (Uⱼ ⊢Γ) of λ where
-      (yes A≡U) → yes (univᶜ (infᶜ pr⇉A A≡U))
-      (no A≢U) → no λ where
-        (univᶜ (infᶜ x x₁)) → case deterministic⇉ pr⇉A x of λ where
-          PE.refl → A≢U x₁
-    (no ¬pr⇉A) → no λ where
-      (univᶜ (infᶜ x x₁)) → ¬pr⇉A (_ , x)
+  dec⇉Type ⊢Γ (∘ᵢ t u) =
+    case
+      (Σ-dec (dec⇉-app ⊢Γ t u)
+         (λ (_ , t∘u₁) (_ , t∘u₂) →
+            case deterministic⇉ t∘u₁ t∘u₂ of λ { PE.refl → idᶠ })
+         λ (_ , t∘u) →
+       decEq (soundness⇉ ⊢Γ t∘u .proj₁) (Uⱼ ⊢Γ))
+      of λ where
+      (yes ((_ , t∘u) , A≡U)) → yes (univᶜ (infᶜ t∘u A≡U))
+      (no not)                →
+        no λ { (univᶜ (infᶜ t∘u A≡U)) → not ((_ , t∘u) , A≡U) }
+  dec⇉Type ⊢Γ (fstᵢ t) =
+    case
+      (Σ-dec (dec⇉-fst ⊢Γ t)
+         (λ (_ , fst-t₁) (_ , fst-t₂) →
+            case deterministic⇉ fst-t₁ fst-t₂ of λ { PE.refl → idᶠ })
+         λ (_ , fst-t) →
+       decEq (soundness⇉ ⊢Γ fst-t .proj₁) (Uⱼ ⊢Γ))
+      of λ where
+      (yes ((_ , fst-t) , A≡U)) → yes (univᶜ (infᶜ fst-t A≡U))
+      (no not)                  →
+        no λ { (univᶜ (infᶜ fst-t A≡U)) → not ((_ , fst-t) , A≡U) }
+  dec⇉Type ⊢Γ (sndᵢ t) =
+    case
+      (Σ-dec (dec⇉-snd ⊢Γ t)
+         (λ (_ , snd-t₁) (_ , snd-t₂) →
+            case deterministic⇉ snd-t₁ snd-t₂ of λ { PE.refl → idᶠ })
+         λ (_ , snd-t) →
+       decEq (soundness⇉ ⊢Γ snd-t .proj₁) (Uⱼ ⊢Γ))
+      of λ where
+      (yes ((_ , snd-t) , A≡U)) → yes (univᶜ (infᶜ snd-t A≡U))
+      (no not)                  →
+        no λ { (univᶜ (infᶜ snd-t A≡U)) → not ((_ , snd-t) , A≡U) }
+  dec⇉Type ⊢Γ (prodrecᵢ B t u) =
+    case
+      (Σ-dec (dec⇉-prodrec ⊢Γ B t u)
+         (λ (_ , pr₁) (_ , pr₂) →
+            case deterministic⇉ pr₁ pr₂ of λ { PE.refl → idᶠ })
+         λ (_ , pr) →
+       decEq (soundness⇉ ⊢Γ pr .proj₁) (Uⱼ ⊢Γ))
+      of λ where
+      (yes ((_ , pr) , A≡U)) → yes (univᶜ (infᶜ pr A≡U))
+      (no not)               →
+        no λ { (univᶜ (infᶜ pr A≡U)) → not ((_ , pr) , A≡U) }
   dec⇉Type ⊢Γ ℕᵢ = yes ℕᶜ
   dec⇉Type ⊢Γ zeroᵢ = no λ where
     (univᶜ (infᶜ zeroᵢ x₁)) → U≢ℕ (sym x₁)
   dec⇉Type ⊢Γ (sucᵢ x) = no λ where
     (univᶜ (infᶜ (sucᵢ x) x₁)) → U≢ℕ (sym x₁)
-  dec⇉Type ⊢Γ (natrecᵢ B z s n) = case dec⇉-natrec ⊢Γ B z s n of λ where
-    (yes (A , pr⇉A)) → case decEq (proj₁ (soundness⇉ ⊢Γ pr⇉A)) (Uⱼ ⊢Γ) of λ where
-      (yes A≡U) → yes (univᶜ (infᶜ pr⇉A A≡U))
-      (no A≢U) → no λ where
-        (univᶜ (infᶜ x x₁)) → case deterministic⇉ pr⇉A x of λ where
-          PE.refl → A≢U x₁
-    (no ¬pr⇉A) → no λ where
-      (univᶜ (infᶜ x x₁)) → ¬pr⇉A (_ , x)
+  dec⇉Type ⊢Γ (natrecᵢ B t u v) =
+    case
+      (Σ-dec (dec⇉-natrec ⊢Γ B t u v)
+         (λ (_ , nr₁) (_ , nr₂) →
+            case deterministic⇉ nr₁ nr₂ of λ { PE.refl → idᶠ })
+         λ (_ , nr) →
+       decEq (soundness⇉ ⊢Γ nr .proj₁) (Uⱼ ⊢Γ))
+      of λ where
+      (yes ((_ , nr) , A≡U)) → yes (univᶜ (infᶜ nr A≡U))
+      (no not)               →
+        no λ { (univᶜ (infᶜ nr A≡U)) → not ((_ , nr) , A≡U) }
   dec⇉Type ⊢Γ (Unitᵢ {s = s}) = case Unit-allowed? s of λ where
     (yes ok)    → yes (Unitᶜ ok)
     (no not-ok) → no λ where
@@ -556,61 +534,60 @@ mutual
       (univᶜ (infᶜ (Unitᵢ ok) _)) → not-ok ok
   dec⇉Type ⊢Γ starᵢ = no λ where
     (univᶜ (infᶜ (starᵢ _) x)) → U≢Unitⱼ (sym x)
-  dec⇉Type ⊢Γ (unitrecᵢ A t u) = case dec⇉-unitrec ⊢Γ A t u of λ where
-    (yes (_ , ur⇉A)) → case decEq (proj₁ (soundness⇉ ⊢Γ ur⇉A)) (Uⱼ ⊢Γ) of λ where
-      (yes A≡U) → yes (univᶜ (infᶜ ur⇉A A≡U))
-      (no A≢U) → no λ where
-        (univᶜ (infᶜ x x₁)) → case deterministic⇉ ur⇉A x of λ where
-          PE.refl → A≢U x₁
-    (no ¬ur⇉A) → no λ where
-      (univᶜ (infᶜ x x₁)) → ¬ur⇉A (_ , x)
+  dec⇉Type ⊢Γ (unitrecᵢ B t u) =
+    case
+      (Σ-dec (dec⇉-unitrec ⊢Γ B t u)
+         (λ (_ , ur₁) (_ , ur₂) →
+            case deterministic⇉ ur₁ ur₂ of λ { PE.refl → idᶠ })
+         λ (_ , ur) →
+       decEq (soundness⇉ ⊢Γ ur .proj₁) (Uⱼ ⊢Γ))
+      of λ where
+      (yes ((_ , ur) , A≡U)) → yes (univᶜ (infᶜ ur A≡U))
+      (no not)               →
+        no λ { (univᶜ (infᶜ ur A≡U)) → not ((_ , ur) , A≡U) }
   dec⇉Type ⊢Γ Emptyᵢ = yes Emptyᶜ
-  dec⇉Type ⊢Γ (emptyrecᵢ B t) = case dec⇉-emptyrec ⊢Γ B t of λ where
-    (yes (A , pr⇉A)) → case decEq (proj₁ (soundness⇉ ⊢Γ pr⇉A)) (Uⱼ ⊢Γ) of λ where
-      (yes A≡U) → yes (univᶜ (infᶜ pr⇉A A≡U))
-      (no A≢U) → no λ where
-        (univᶜ (infᶜ x x₁)) → case deterministic⇉ pr⇉A x of λ where
-          PE.refl → A≢U x₁
-    (no ¬pr⇉A) → no λ where
-      (univᶜ (infᶜ x x₁)) → ¬pr⇉A (_ , x)
+  dec⇉Type ⊢Γ (emptyrecᵢ B t) =
+    case
+      (Σ-dec (dec⇉-emptyrec ⊢Γ B t)
+         (λ (_ , er₁) (_ , er₂) →
+            case deterministic⇉ er₁ er₂ of λ { PE.refl → idᶠ })
+         λ (_ , er) →
+       decEq (soundness⇉ ⊢Γ er .proj₁) (Uⱼ ⊢Γ))
+      of λ where
+      (yes ((_ , er) , A≡U)) → yes (univᶜ (infᶜ er A≡U))
+      (no not)               →
+        no λ { (univᶜ (infᶜ er A≡U)) → not ((_ , er) , A≡U) }
   dec⇉Type ⊢Γ (Idᵢ A t u) =
-    case dec⇇Type ⊢Γ A of λ where
-      (no ¬A) → no λ where
-        (Idᶜ A _ _)                  → ¬A A
-        (univᶜ (infᶜ (Idᵢ A _ _) _)) → ¬A (univᶜ A)
-      (yes A) →
-        case soundness⇇Type ⊢Γ A of λ {
-          ⊢A →
-        case dec⇇ t ⊢A of λ where
-          (no ¬t) → no λ where
-            (Idᶜ _ t _)                  → ¬t t
-            (univᶜ (infᶜ (Idᵢ _ t _) _)) → ¬t t
-          (yes t) →
-            case dec⇇ u ⊢A of λ where
-              (no ¬u) → no λ where
-                (Idᶜ _ _ u)                  → ¬u u
-                (univᶜ (infᶜ (Idᵢ _ _ u) _)) → ¬u u
-              (yes u) → yes (Idᶜ A t u) }
+    case
+      (dec⇇Type-with-cont ⊢Γ A λ ⊢A →
+       dec⇇ t ⊢A ×-dec dec⇇ u ⊢A)
+      of λ where
+      (yes (A , t , u)) → yes (Idᶜ A t u)
+      (no not)          → no λ where
+        (Idᶜ A t u)                  → not (A , t , u)
+        (univᶜ (infᶜ (Idᵢ A t u) _)) → not (univᶜ A , t , u)
   dec⇉Type ⊢Γ (Jᵢ A t B u v w) =
-    case dec⇉-J ⊢Γ A t B u v w of λ where
-      (no ¬⊢J)       → no λ { (univᶜ (infᶜ ⊢J _)) → ¬⊢J (_ , ⊢J) }
-      (yes (_ , ⊢J)) →
-        case decEq (soundness⇉ ⊢Γ ⊢J .proj₁) (Uⱼ ⊢Γ) of λ where
-          (no C≢U) → no λ { (univᶜ (infᶜ ⊢J′ C′≡U)) →
-            case deterministic⇉ ⊢J ⊢J′ of λ {
-              PE.refl →
-            C≢U C′≡U }}
-          (yes C≡U) → yes (univᶜ (infᶜ ⊢J C≡U))
+    case
+      (Σ-dec (dec⇉-J ⊢Γ A t B u v w)
+         (λ (_ , J₁) (_ , J₂) →
+            case deterministic⇉ J₁ J₂ of λ { PE.refl → idᶠ })
+         λ (_ , J′) →
+       decEq (soundness⇉ ⊢Γ J′ .proj₁) (Uⱼ ⊢Γ))
+      of λ where
+      (yes ((_ , J′) , A≡U)) → yes (univᶜ (infᶜ J′ A≡U))
+      (no not)               →
+        no λ { (univᶜ (infᶜ J′ A≡U)) → not ((_ , J′) , A≡U) }
   dec⇉Type ⊢Γ (Kᵢ A t B u v) =
-    case dec⇉-K ⊢Γ A t B u v of λ where
-      (no ¬⊢K)       → no λ { (univᶜ (infᶜ ⊢K _)) → ¬⊢K (_ , ⊢K) }
-      (yes (_ , ⊢K)) →
-        case decEq (soundness⇉ ⊢Γ ⊢K .proj₁) (Uⱼ ⊢Γ) of λ where
-          (no C≢U) → no λ { (univᶜ (infᶜ ⊢K′ C′≡U)) →
-            case deterministic⇉ ⊢K ⊢K′ of λ {
-              PE.refl →
-            C≢U C′≡U }}
-          (yes C≡U) → yes (univᶜ (infᶜ ⊢K C≡U))
+    case
+      (Σ-dec (dec⇉-K ⊢Γ A t B u v)
+         (λ (_ , K₁) (_ , K₂) →
+            case deterministic⇉ K₁ K₂ of λ { PE.refl → idᶠ })
+         λ (_ , K′) →
+       decEq (soundness⇉ ⊢Γ K′ .proj₁) (Uⱼ ⊢Γ))
+      of λ where
+      (yes ((_ , K′) , A≡U)) → yes (univᶜ (infᶜ K′ A≡U))
+      (no not)               →
+        no λ { (univᶜ (infᶜ K′ A≡U)) → not ((_ , K′) , A≡U) }
   dec⇉Type _ ([]-congᵢ _ _ _ _) =
     no λ { (univᶜ (infᶜ ([]-congᵢ _ _ _ _ _) Id≡U)) → Id≢U Id≡U }
 
@@ -619,8 +596,10 @@ mutual
   dec⇇Type : ⊢ Γ → Checkable A → Dec (Γ ⊢ A ⇇Type)
   dec⇇Type ⊢Γ (lamᶜ t) = no λ where
     (univᶜ (lamᶜ x x₁)) → U.U≢B BΠ! (whnfRed* (proj₁ x) Uₙ)
+    (univᶜ (infᶜ () _))
   dec⇇Type ⊢Γ (prodᶜ t u) = no λ where
     (univᶜ (prodᶜ x x₁ x₂)) → U.U≢B BΣ! (whnfRed* (proj₁ x) Uₙ)
+    (univᶜ (infᶜ () _))
   dec⇇Type ⊢Γ rflᶜ = no λ where
     (univᶜ (rflᶜ (U⇒*Id , _) _)) → case whnfRed* U⇒*Id Uₙ of λ ()
     (univᶜ (infᶜ () _))
@@ -629,21 +608,16 @@ mutual
   -- Decidability of bi-directional type inference
 
   dec⇉ : ⊢ Γ → Inferable t → Dec (∃ λ A → Γ ⊢ t ⇉ A)
-  dec⇉ ⊢Γ Uᵢ = no λ where (A , ())
-  dec⇉ ⊢Γ (ΠΣᵢ {b = b} {p = p} {q = q} F G) =
-    case dec⇇ F (Uⱼ ⊢Γ) of λ where
-      (yes F⇇U) →
-        let ⊢F = soundness⇇ F⇇U
-        in  case dec⇇ G (Uⱼ (⊢Γ ∙ univ ⊢F)) of λ where
-          (yes G⇇U) → case ΠΣ-allowed? b p q of λ where
-            (yes ok)    → yes (_ , ΠΣᵢ F⇇U G⇇U ok)
-            (no not-ok) → no λ where
-              (_ , ΠΣᵢ _ _ ok) → not-ok ok
-          (no ¬G⇇U) → no λ where
-            (_ , ΠΣᵢ _ x _) → ¬G⇇U x
-      (no ¬F⇇U) → no λ where
-        (_ , ΠΣᵢ x _ _) → ¬F⇇U x
-  dec⇉ ⊢Γ varᵢ = yes (_ , varᵢ (proj₂ (dec⇉-var _)))
+  dec⇉ _ Uᵢ = no λ { (_ , ()) }
+  dec⇉ ⊢Γ (ΠΣᵢ {b} {p} {q} A B) =
+    case
+      (ΠΣ-allowed? b p q ×-dec
+       dec⇇-with-cont A (Uⱼ ⊢Γ) λ ⊢A →
+       dec⇇ B (Uⱼ (⊢→⊢∙ (univ ⊢A))))
+      of λ where
+      (yes (ok , A , B)) → yes (_ , ΠΣᵢ A B ok)
+      (no not)           → no λ { (_ , ΠΣᵢ A B ok) → not (ok , A , B) }
+  dec⇉ ⊢Γ varᵢ = yes (_ , varᵢ (dec⇉-var _ .proj₂))
   dec⇉ ⊢Γ (∘ᵢ t u) = dec⇉-app ⊢Γ t u
   dec⇉ ⊢Γ (fstᵢ t) = dec⇉-fst ⊢Γ t
   dec⇉ ⊢Γ (sndᵢ t) = dec⇉-snd ⊢Γ t
@@ -667,107 +641,86 @@ mutual
   dec⇉ ⊢Γ Emptyᵢ = yes (U , Emptyᵢ)
   dec⇉ ⊢Γ (emptyrecᵢ A t) = dec⇉-emptyrec ⊢Γ A t
   dec⇉ ⊢Γ (Idᵢ A t u) =
-    case dec⇇ A (Uⱼ ⊢Γ) of λ where
-      (no ¬A) → no λ { (_ , Idᵢ A _ _) → ¬A A }
-      (yes A) →
-        case univ (soundness⇇ A) of λ {
-          ⊢A →
-        case dec⇇ t ⊢A of λ where
-          (no ¬t) → no λ { (_ , Idᵢ _ t _) → ¬t t }
-          (yes t) →
-            case dec⇇ u ⊢A of λ where
-              (no ¬u) → no λ { (_ , Idᵢ _ _ u) → ¬u u }
-              (yes u) → yes (_ , Idᵢ A t u) }
+    case
+      (dec⇇-with-cont A (Uⱼ ⊢Γ) λ ⊢A →
+       let ⊢A = univ ⊢A in
+       dec⇇ t ⊢A ×-dec dec⇇ u ⊢A)
+      of λ where
+      (yes (A , t , u)) → yes (_ , Idᵢ A t u)
+      (no not)          → no λ { (_ , Idᵢ A t u) → not (A , t , u) }
   dec⇉ ⊢Γ (Jᵢ A t B u v w) =
     dec⇉-J ⊢Γ A t B u v w
   dec⇉ ⊢Γ (Kᵢ A t B u v) =
     dec⇉-K ⊢Γ A t B u v
-  dec⇉ ⊢Γ ([]-congᵢ {s = s} A t u v) =
-    case []-cong-allowed? s of λ where
-      (no not-ok) → no λ { (_ , []-congᵢ _ _ _ _ ok) → not-ok ok }
-      (yes ok)    → case dec⇇Type ⊢Γ A of λ where
-        (no ¬A) → no λ { (_ , []-congᵢ A _ _ _ _) → ¬A A }
-        (yes A) →
-          case soundness⇇Type ⊢Γ A of λ {
-            ⊢A →
-          case dec⇇ t ⊢A of λ where
-            (no ¬t) → no λ { (_ , []-congᵢ _ t _ _ _) → ¬t t }
-            (yes t) →
-              case dec⇇ u ⊢A of λ where
-                (no ¬u) → no λ { (_ , []-congᵢ _ _ u _ _) → ¬u u }
-                (yes u) →
-                  case dec⇇ v
-                         (Idⱼ (soundness⇇ t) (soundness⇇ u)) of λ where
-                    (no ¬v) → no λ { (_ , []-congᵢ _ _ _ v _) → ¬v v }
-                    (yes v) → yes (_ , []-congᵢ A t u v ok) }
+  dec⇉ ⊢Γ ([]-congᵢ {s} A t u v) =
+    case
+      ([]-cong-allowed? s ×-dec
+       dec⇇Type-with-cont ⊢Γ A λ ⊢A →
+       dec⇇-with-cont t ⊢A λ ⊢t →
+       dec⇇-with-cont u ⊢A λ ⊢u →
+       dec⇇ v (Idⱼ ⊢t ⊢u))
+      of λ where
+      (yes (ok , A , t , u , v)) → yes (_ , []-congᵢ A t u v ok)
+      (no not)                   →
+        no λ { (_ , []-congᵢ A t u v ok) → not (ok , A , t , u , v) }
 
   -- Decidability of bi-directional type checking
 
   dec⇇ : Checkable t → Γ ⊢ A → Dec (Γ ⊢ t ⇇ A)
-  dec⇇ (lamᶜ {p = p′} t) ⊢A = case isΠ ⊢A of λ where
-    (yes (p , _ , _ , _ , A⇒Π)) →
-      let _ , ⊢G , _ = inversion-ΠΣ (syntacticRed A⇒Π .proj₂) in
-      case dec⇇ t ⊢G of λ where
-        (yes t⇇G) → case p ≟ p′ of λ where
-          (yes PE.refl) → yes (lamᶜ (A⇒Π , ΠΣₙ) t⇇G)
-          (no p≢p′) → no λ where
-            (lamᶜ x x₁) → case whrDet* (A⇒Π , ΠΣₙ) x of λ where
-              PE.refl → p≢p′ PE.refl
-        (no ¬t⇇G) → no λ where
-          (lamᶜ x x₁) → case whrDet* (A⇒Π , ΠΣₙ) x of λ where
-            PE.refl → ¬t⇇G x₁
-    (no ¬isΠ) → no λ where
-      (lamᶜ x _) → ¬isΠ (_ , _ , _ , _ , proj₁ x)
-  dec⇇ (prodᶜ {p = p′} {m = m′} t u) ⊢A = case isΣ ⊢A of λ where
-    (yes (m , p , _ , _ , _ , A⇒Σ)) →
-      let ⊢F , ⊢G , _ = inversion-ΠΣ (syntacticRed A⇒Σ .proj₂) in
-      case dec⇇ t ⊢F of λ where
-        (yes t⇇F) → case dec⇇ u
-                           (substType ⊢G (soundness⇇ t⇇F)) of λ where
-          (yes u⇇Gₜ) → case p ≟ p′ of λ where
-            (yes PE.refl) → case decStrength m m′ of λ where
-              (yes PE.refl) → yes (prodᶜ (A⇒Σ , ΠΣₙ) t⇇F u⇇Gₜ)
-              (no m≢m′) → no λ where
-                (prodᶜ x x₁ x₂) →
-                  let Σ≡Σ′ = whrDet* (A⇒Σ , ΠΣₙ) x
-                      _ , _ , W≡W′ = B-PE-injectivity BΣ! BΣ! Σ≡Σ′
-                      _ , _ , m≡m′ = BΣ-PE-injectivity W≡W′
-                  in  m≢m′ m≡m′
-            (no p≢p′) → no λ where
-              (prodᶜ x x₁ x₂) → case whrDet* (A⇒Σ , ΠΣₙ) x of λ where
-                PE.refl → p≢p′ PE.refl
-          (no ¬u⇇Gₜ) → no λ where
-            (prodᶜ x x₁ x₂) → case whrDet* (A⇒Σ , ΠΣₙ) x of λ where
-              PE.refl → ¬u⇇Gₜ x₂
-        (no ¬t⇇F) → no λ where
-          (prodᶜ x x₁ x₂) → case whrDet* (A⇒Σ , ΠΣₙ) x of λ where
-            PE.refl → ¬t⇇F x₁
-    (no ¬isΣ) →
-      no λ { (prodᶜ x _ _) → ¬isΣ (_ , _ , _ , _ , _ , proj₁ x) }
-  dec⇇ rflᶜ ⊢A =
-    case is-Id ⊢A of λ where
-      (no is-not-Id) → no λ where
-        (rflᶜ (A⇒*Id-t-u , _) t≡u) → is-not-Id (_ , _ , _ , A⇒*Id-t-u)
+  dec⇇ (lamᶜ {p} t) ⊢A =
+    case
+      (isΠΣ-with-cont ⊢A λ {b = b} {p = p′} _ ⊢C _ _ →
+       decBinderMode b BMΠ ×-dec p ≟ p′ ×-dec dec⇇ t ⊢C)
+      of λ where
+      (yes ((_ , _ , _ , _ , _ , A) , PE.refl , PE.refl , t)) →
+        yes (lamᶜ (A , ΠΣₙ) t)
+      (no not) → no λ where
+        (lamᶜ (A , _) t) →
+          not ((_ , _ , _ , _ , _ , A) , PE.refl , PE.refl , t)
         (infᶜ () _)
-      (yes (_ , _ , _ , A⇒*Id-t-u)) →
-        let ⊢B , ⊢t , ⊢u = inversion-Id (syntacticRed A⇒*Id-t-u .proj₂)
-        in
-        case decEqTerm ⊢t ⊢u of λ where
-          (no t≢u) → no λ where
-            (rflᶜ A↘Id-t′-u′ t′≡u′) →
-              case whrDet* (A⇒*Id-t-u , Idₙ) A↘Id-t′-u′ of λ {
-                PE.refl →
-              t≢u t′≡u′ }
-            (infᶜ () _)
-          (yes t≡u) → yes (rflᶜ (A⇒*Id-t-u , Idₙ) t≡u)
-  dec⇇ (infᶜ t) ⊢A = case dec⇉ (wf ⊢A) t of λ where
-    (yes (B , t⇉B)) → case decEq (soundness⇉ (wf ⊢A) t⇉B .proj₁)
-                             ⊢A of λ where
-      (yes B≡A) → yes (infᶜ t⇉B B≡A)
-      (no B≢A) → no λ where
-        (infᶜ x x₁) → case deterministic⇉ t⇉B x of λ where
-          PE.refl → B≢A x₁
-        (rflᶜ _ _) → case t of λ ()
-    (no ¬t⇉B) → no λ where
-      (infᶜ x x₁) → ¬t⇉B (_ , x)
-      (rflᶜ _ _) → case t of λ ()
+  dec⇇ (prodᶜ {p} {m = s} t u) ⊢A =
+    case
+      (Σ-dec (isΣ ⊢A)
+         (λ (_ , _ , _ , _ , _ , A⇒*Σ₁) (_ , _ , _ , _ , _ , A⇒*Σ₂) →
+            case whrDet* (A⇒*Σ₁ , ΠΣₙ) (A⇒*Σ₂ , ΠΣₙ) of λ {
+              PE.refl →
+            idᶠ })
+         λ (s′ , p′ , _ , _ , _ , A⇒*Σ) →
+       let ⊢B , ⊢C , _ = inversion-ΠΣ (syntacticRed A⇒*Σ .proj₂) in
+       decStrength s s′ ×-dec p ≟ p′ ×-dec
+       dec⇇-with-cont t ⊢B λ ⊢t →
+       dec⇇ u (substType ⊢C ⊢t))
+      of λ where
+      (yes ((_ , _ , _ , _ , _ , A) , PE.refl , PE.refl , t , u)) →
+        yes (prodᶜ (A , ΠΣₙ) t u)
+      (no not) → no λ where
+        (prodᶜ (A , _) t u) →
+          not ((_ , _ , _ , _ , _ , A) , PE.refl , PE.refl , t , u)
+        (infᶜ () _)
+  dec⇇ rflᶜ ⊢A =
+    case
+      (Σ-dec (is-Id ⊢A)
+         (λ (_ , _ , _ , A⇒*Id₁) (_ , _ , _ , A⇒*Id₂) →
+            case whrDet* (A⇒*Id₁ , Idₙ) (A⇒*Id₂ , Idₙ) of λ {
+              PE.refl →
+            idᶠ })
+         λ (_ , _ , _ , A⇒*Id) →
+       let _ , ⊢t , ⊢u = inversion-Id (syntacticRed A⇒*Id .proj₂) in
+       decEqTerm ⊢t ⊢u)
+      of λ where
+      (yes ((_ , _ , _ , A) , t≡u)) →
+        yes (rflᶜ (A , Idₙ) t≡u)
+      (no not) → no λ where
+        (rflᶜ (A , _) t≡u) → not ((_ , _ , _ , A) , t≡u)
+        (infᶜ () _)
+  dec⇇ (infᶜ t) ⊢A =
+    case
+      (dec⇉-with-cont (wf ⊢A) t λ ⊢B →
+       decEq ⊢B ⊢A)
+      of λ where
+      (yes ((_ , t) , B≡A)) → yes (infᶜ t B≡A)
+      (no not) → no λ where
+        (infᶜ t B≡A)  → not ((_ , t) , B≡A)
+        (lamᶜ _ _)    → case t of λ ()
+        (prodᶜ _ _ _) → case t of λ ()
+        (rflᶜ _ _)    → case t of λ ()

--- a/Definition/Typechecking/Decidable.agda
+++ b/Definition/Typechecking/Decidable.agda
@@ -275,30 +275,29 @@ mutual
   dec⇉-app : ⊢ Γ → Inferable t → Checkable u → Dec (∃ λ A → Γ ⊢ t ∘⟨ p ⟩ u ⇉ A)
   dec⇉-app {p = p′} ⊢Γ t u = case dec⇉ ⊢Γ t of λ where
     (yes (A , t⇉A)) → case isΠ (proj₁ (soundness⇉ ⊢Γ t⇉A)) of λ where
-      (yes (F , G , p , q , ⊢F , ⊢G , A⇒Π)) → case dec⇇ ⊢Γ u ⊢F of λ where
-        (yes u⇇F) → case p ≟ p′ of λ where
-          (yes PE.refl) → yes (_ , appᵢ t⇉A (A⇒Π , ΠΣₙ) u⇇F)
-          (no p≢p′) → no λ where
+      (yes (p , _ , _ , _ , A⇒Π)) →
+        let ⊢F , _ = inversion-ΠΣ (syntacticRed A⇒Π .proj₂) in
+        case dec⇇ ⊢Γ u ⊢F of λ where
+          (yes u⇇F) → case p ≟ p′ of λ where
+            (yes PE.refl) → yes (_ , appᵢ t⇉A (A⇒Π , ΠΣₙ) u⇇F)
+            (no p≢p′) → no λ where
+              (_ , appᵢ x x₁ x₂) → case deterministic⇉ x t⇉A of λ where
+                PE.refl → case whrDet* (A⇒Π , ΠΣₙ) x₁ of λ where
+                  PE.refl → p≢p′ PE.refl
+          (no ¬u⇇F) → no λ where
             (_ , appᵢ x x₁ x₂) → case deterministic⇉ x t⇉A of λ where
-              PE.refl → case whrDet* (A⇒Π , ΠΣₙ) x₁ of λ where
-                PE.refl → p≢p′ PE.refl
-        (no ¬u⇇F) → no λ where
-          (_ , appᵢ x x₁ x₂) → case deterministic⇉ x t⇉A of λ where
-             PE.refl → case whrDet* (A⇒Π , ΠΣₙ) x₁ of λ where
-               PE.refl → ¬u⇇F x₂
+               PE.refl → case whrDet* (A⇒Π , ΠΣₙ) x₁ of λ where
+                 PE.refl → ¬u⇇F x₂
       (no ¬isΠ) → no λ where
         (_ , appᵢ x x₁ x₂) → case deterministic⇉ x t⇉A of λ where
-             PE.refl →
-               let _ , ⊢Π = syntacticRed (proj₁ x₁)
-                   ⊢F , ⊢G = syntacticΠ ⊢Π
-               in  ¬isΠ (_ , _ , _ , _ , ⊢F , ⊢G , proj₁ x₁)
+          PE.refl → ¬isΠ (_ , _ , _ , _ , proj₁ x₁)
     (no ¬t⇉A) → no λ where
       (_ , appᵢ x x₁ x₂) → ¬t⇉A (_ , x)
 
   dec⇉-fst : ⊢ Γ → Inferable t → Dec (∃ λ A → Γ ⊢ fst p t ⇉ A)
   dec⇉-fst {p = p′} ⊢Γ t = case dec⇉ ⊢Γ t of λ where
     (yes (A , t⇉A)) → case isΣˢ (proj₁ (soundness⇉ ⊢Γ t⇉A)) of λ where
-      (yes (F , G , p , q , ⊢F , ⊢G , A⇒Σ)) → case p ≟ p′ of λ where
+      (yes (p , _ , _ , _ , A⇒Σ)) → case p ≟ p′ of λ where
         (yes PE.refl) → yes (_ , fstᵢ t⇉A (A⇒Σ , U.ΠΣₙ))
         (no p≢p′) → no λ where
           (_ , fstᵢ x x₁) → case deterministic⇉ x t⇉A of λ where
@@ -306,17 +305,14 @@ mutual
                PE.refl → p≢p′ PE.refl
       (no ¬isΣ) → no λ where
         (_ , fstᵢ x x₁) → case deterministic⇉ x t⇉A of λ where
-          PE.refl →
-            let _ , ⊢Σ = syntacticRed (proj₁ x₁)
-                ⊢F , ⊢G = syntacticΣ ⊢Σ
-            in  ¬isΣ (_ , _ , _ , _ , ⊢F , ⊢G , proj₁ x₁)
+          PE.refl → ¬isΣ (_ , _ , _ , _ , proj₁ x₁)
     (no ¬t⇉A) → no λ where
       (_ , fstᵢ x x₁) → ¬t⇉A (_ , x)
 
   dec⇉-snd : ⊢ Γ → Inferable t → Dec (∃ λ A → Γ ⊢ snd p t ⇉ A)
   dec⇉-snd {p = p′} ⊢Γ t = case dec⇉ ⊢Γ t of λ where
     (yes (A , t⇉A)) → case isΣˢ (proj₁ (soundness⇉ ⊢Γ t⇉A)) of λ where
-      (yes (F , G , p , q , ⊢F , ⊢G , A⇒Σ)) → case p ≟ p′ of λ where
+      (yes (p , _ , _ , _ , A⇒Σ)) → case p ≟ p′ of λ where
         (yes PE.refl) → yes (_ , sndᵢ t⇉A (A⇒Σ , U.ΠΣₙ))
         (no p≢p′) → no λ where
           (_ , sndᵢ x x₁) → case deterministic⇉ x t⇉A of λ where
@@ -324,10 +320,7 @@ mutual
                PE.refl → p≢p′ PE.refl
       (no ¬isΣ) → no λ where
         (_ , sndᵢ x x₁) → case deterministic⇉ x t⇉A of λ where
-          PE.refl →
-            let _ , ⊢Σ = syntacticRed (proj₁ x₁)
-                ⊢F , ⊢G = syntacticΣ ⊢Σ
-            in  ¬isΣ (_ , _ , _ , _ , ⊢F , ⊢G , proj₁ x₁)
+          PE.refl → ¬isΣ (_ , _ , _ , _ , proj₁ x₁)
     (no ¬t⇉A) → no λ where
       (_ , sndᵢ x x₁) → ¬t⇉A (_ , x)
 
@@ -358,9 +351,9 @@ mutual
   dec⇉-prodrec {r = r} {p = p′} {q = q} ⊢Γ A t u =
     case dec⇉ ⊢Γ t of λ where
       (yes (B , t⇉B)) → case isΣʷ (proj₁ (soundness⇉ ⊢Γ t⇉B)) of λ where
-        (yes (F , G , p , _ , ⊢F , ⊢G , B⇒Σ)) →
+        (yes (p , _ , _ , _ , B⇒Σ)) →
           case inversion-ΠΣ (syntacticRed B⇒Σ .proj₂) of λ {
-            (_ , _ , ok) →
+            (⊢F , ⊢G , ok) →
           case dec⇇Type (⊢Γ ∙ ΠΣⱼ ⊢F ⊢G ok) A of λ where
             (yes A⇇Type) →
               let ⊢ΓΣ = ⊢Γ ∙ ΠΣⱼ {p = p} ⊢F ⊢G ok
@@ -388,10 +381,7 @@ mutual
         (no ¬isΣ) → no λ where
           (_ , prodrecᵢ _ x₁ x₂ _) →
             case deterministic⇉ t⇉B x₁ of λ where
-              PE.refl →
-                let _ , ⊢Σ = syntacticRed (proj₁ x₂)
-                    ⊢F , ⊢G = syntacticΣ ⊢Σ
-                in  ¬isΣ (_ , _ , _ , _ , ⊢F , ⊢G , proj₁ x₂)
+              PE.refl → ¬isΣ (_ , _ , _ , _ , proj₁ x₂)
       (no ¬t⇉B) → no λ where
         (_ , prodrecᵢ x x₁ x₂ x₃) → ¬t⇉B (_ , x₁)
 
@@ -716,55 +706,53 @@ mutual
 
   dec⇇ : ⊢ Γ → Checkable t → Γ ⊢ A → Dec (Γ ⊢ t ⇇ A)
   dec⇇ ⊢Γ (lamᶜ {p = p′} t) ⊢A = case isΠ ⊢A of λ where
-    (yes (F , G , p , q , ⊢F , ⊢G , A⇒Π)) → case dec⇇ (⊢Γ ∙ ⊢F) t ⊢G of λ where
-      (yes t⇇G) → case p ≟ p′ of λ where
-        (yes PE.refl) → yes (lamᶜ (A⇒Π , ΠΣₙ) t⇇G)
-        (no p≢p′) → no λ where
-          (lamᶜ x x₁) → case whrDet* (A⇒Π , ΠΣₙ) x of λ where
-            PE.refl → p≢p′ PE.refl
-      (no ¬t⇇G) → no λ where
-        (lamᶜ x x₁) → case whrDet* (A⇒Π , ΠΣₙ) x of λ where
-          PE.refl → ¬t⇇G x₁
-    (no ¬isΠ) → no λ where
-      (lamᶜ x x₁) →
-        let _ , ⊢Π = syntacticRed (proj₁ x)
-            ⊢F , ⊢G = syntacticΠ ⊢Π
-        in  ¬isΠ (_ , _ , _ , _ , ⊢F , ⊢G , proj₁ x)
-  dec⇇ ⊢Γ (prodᶜ {p = p′} {m = m′} t u) ⊢A = case isΣ ⊢A of λ where
-    (yes (F , G , m , p , q , ⊢F , ⊢G , A⇒Σ)) → case dec⇇ ⊢Γ t ⊢F of λ where
-      (yes t⇇F) → case dec⇇ ⊢Γ u (substType ⊢G (soundness⇇ ⊢Γ t⇇F)) of λ where
-        (yes u⇇Gₜ) → case p ≟ p′ of λ where
-          (yes PE.refl) → case decStrength m m′ of λ where
-            (yes PE.refl) → yes (prodᶜ (A⇒Σ , ΠΣₙ) t⇇F u⇇Gₜ)
-            (no m≢m′) → no λ where
-              (prodᶜ x x₁ x₂) →
-                let Σ≡Σ′ = whrDet* (A⇒Σ , ΠΣₙ) x
-                    _ , _ , W≡W′ = B-PE-injectivity BΣ! BΣ! Σ≡Σ′
-                    _ , _ , m≡m′ = BΣ-PE-injectivity W≡W′
-                in  m≢m′ m≡m′
+    (yes (p , _ , _ , _ , A⇒Π)) →
+      let ⊢F , ⊢G , _ = inversion-ΠΣ (syntacticRed A⇒Π .proj₂) in
+      case dec⇇ (⊢Γ ∙ ⊢F) t ⊢G of λ where
+        (yes t⇇G) → case p ≟ p′ of λ where
+          (yes PE.refl) → yes (lamᶜ (A⇒Π , ΠΣₙ) t⇇G)
           (no p≢p′) → no λ where
-            (prodᶜ x x₁ x₂) → case whrDet* (A⇒Σ , ΠΣₙ) x of λ where
+            (lamᶜ x x₁) → case whrDet* (A⇒Π , ΠΣₙ) x of λ where
               PE.refl → p≢p′ PE.refl
-        (no ¬u⇇Gₜ) → no λ where
+        (no ¬t⇇G) → no λ where
+          (lamᶜ x x₁) → case whrDet* (A⇒Π , ΠΣₙ) x of λ where
+            PE.refl → ¬t⇇G x₁
+    (no ¬isΠ) → no λ where
+      (lamᶜ x _) → ¬isΠ (_ , _ , _ , _ , proj₁ x)
+  dec⇇ ⊢Γ (prodᶜ {p = p′} {m = m′} t u) ⊢A = case isΣ ⊢A of λ where
+    (yes (m , p , _ , _ , _ , A⇒Σ)) →
+      let ⊢F , ⊢G , _ = inversion-ΠΣ (syntacticRed A⇒Σ .proj₂) in
+      case dec⇇ ⊢Γ t ⊢F of λ where
+        (yes t⇇F) → case dec⇇ ⊢Γ u
+                           (substType ⊢G (soundness⇇ ⊢Γ t⇇F)) of λ where
+          (yes u⇇Gₜ) → case p ≟ p′ of λ where
+            (yes PE.refl) → case decStrength m m′ of λ where
+              (yes PE.refl) → yes (prodᶜ (A⇒Σ , ΠΣₙ) t⇇F u⇇Gₜ)
+              (no m≢m′) → no λ where
+                (prodᶜ x x₁ x₂) →
+                  let Σ≡Σ′ = whrDet* (A⇒Σ , ΠΣₙ) x
+                      _ , _ , W≡W′ = B-PE-injectivity BΣ! BΣ! Σ≡Σ′
+                      _ , _ , m≡m′ = BΣ-PE-injectivity W≡W′
+                  in  m≢m′ m≡m′
+            (no p≢p′) → no λ where
+              (prodᶜ x x₁ x₂) → case whrDet* (A⇒Σ , ΠΣₙ) x of λ where
+                PE.refl → p≢p′ PE.refl
+          (no ¬u⇇Gₜ) → no λ where
+            (prodᶜ x x₁ x₂) → case whrDet* (A⇒Σ , ΠΣₙ) x of λ where
+              PE.refl → ¬u⇇Gₜ x₂
+        (no ¬t⇇F) → no λ where
           (prodᶜ x x₁ x₂) → case whrDet* (A⇒Σ , ΠΣₙ) x of λ where
-            PE.refl → ¬u⇇Gₜ x₂
-      (no ¬t⇇F) → no λ where
-        (prodᶜ x x₁ x₂) → case whrDet* (A⇒Σ , ΠΣₙ) x of λ where
-          PE.refl → ¬t⇇F x₁
-    (no ¬isΣ) → no λ where
-      (prodᶜ x x₁ x₂) →
-        let _ , ⊢Σ = syntacticRed (proj₁ x)
-            ⊢F , ⊢G = syntacticΣ ⊢Σ
-        in  ¬isΣ (_ , _ , _ , _ , _ , ⊢F , ⊢G , proj₁ x)
+            PE.refl → ¬t⇇F x₁
+    (no ¬isΣ) →
+      no λ { (prodᶜ x _ _) → ¬isΣ (_ , _ , _ , _ , _ , proj₁ x) }
   dec⇇ ⊢Γ rflᶜ ⊢A =
     case is-Id ⊢A of λ where
       (no is-not-Id) → no λ where
-        (rflᶜ (A⇒*Id-t-u , _) t≡u) →
-          case syntacticEqTerm t≡u of λ {
-            (⊢B , ⊢t , ⊢u) →
-          is-not-Id (_ , _ , _ , ⊢B , ⊢t , ⊢u , A⇒*Id-t-u) }
+        (rflᶜ (A⇒*Id-t-u , _) t≡u) → is-not-Id (_ , _ , _ , A⇒*Id-t-u)
         (infᶜ () _)
-      (yes (_ , _ , _ , ⊢B , ⊢t , ⊢u , A⇒*Id-t-u)) →
+      (yes (_ , _ , _ , A⇒*Id-t-u)) →
+        let ⊢B , ⊢t , ⊢u = inversion-Id (syntacticRed A⇒*Id-t-u .proj₂)
+        in
         case decEqTerm ⊢t ⊢u of λ where
           (no t≢u) → no λ where
             (rflᶜ A↘Id-t′-u′ t′≡u′) →

--- a/Definition/Typechecking/Deterministic.agda
+++ b/Definition/Typechecking/Deterministic.agda
@@ -15,6 +15,7 @@ open import Definition.Typechecking R
 open import Definition.Typed R
 open import Definition.Typed.Properties R
 open import Definition.Untyped M
+open import Definition.Untyped.Properties M
 
 open import Tools.Fin
 open import Tools.Nat

--- a/Definition/Typechecking/Soundness.agda
+++ b/Definition/Typechecking/Soundness.agda
@@ -55,14 +55,14 @@ mutual
   soundness⇇Type ⊢Γ (ΠΣᶜ ⊢A ⊢B ok) =
     let ⊢F = soundness⇇Type ⊢Γ ⊢A
     in  ΠΣⱼ ⊢F (soundness⇇Type (⊢Γ ∙ ⊢F) ⊢B) ok
-  soundness⇇Type ⊢Γ (Idᶜ _ ⊢t ⊢u) =
-    Idⱼ (soundness⇇ ⊢Γ ⊢t) (soundness⇇ ⊢Γ ⊢u)
-  soundness⇇Type ⊢Γ (univᶜ x) = univ (soundness⇇ ⊢Γ x)
+  soundness⇇Type _ (Idᶜ _ ⊢t ⊢u) =
+    Idⱼ (soundness⇇ ⊢t) (soundness⇇ ⊢u)
+  soundness⇇Type _ (univᶜ x) = univ (soundness⇇ x)
 
   soundness⇉ : ⊢ Γ → Γ ⊢ t ⇉ A → (Γ ⊢ A) × (Γ ⊢ t ∷ A)
   soundness⇉ ⊢Γ (ΠΣᵢ F⇇U G⇇U ok) =
-    let ⊢F = soundness⇇ ⊢Γ F⇇U
-        ⊢G = soundness⇇ (⊢Γ ∙ univ ⊢F) G⇇U
+    let ⊢F = soundness⇇ F⇇U
+        ⊢G = soundness⇇ G⇇U
     in  Uⱼ ⊢Γ , ΠΣⱼ ⊢F ⊢G ok
   soundness⇉ ⊢Γ (varᵢ x∷A∈Γ) = soundness⇉-var ⊢Γ x∷A∈Γ
   soundness⇉ ⊢Γ (appᵢ t⇉A (A⇒ΠFG , _) u⇇F) =
@@ -70,7 +70,7 @@ mutual
         A≡ΠFG = subset* A⇒ΠFG
         _ , ⊢ΠFG = syntacticEq A≡ΠFG
         ⊢F , ⊢G = syntacticΠ ⊢ΠFG
-        ⊢u = soundness⇇ ⊢Γ u⇇F
+        ⊢u = soundness⇇ u⇇F
         ⊢t′ = conv ⊢t A≡ΠFG
     in  substType ⊢G ⊢u , ⊢t′ ∘ⱼ ⊢u
   soundness⇉ ⊢Γ (fstᵢ t⇉A (A⇒ΣFG , _)) =
@@ -92,76 +92,77 @@ mutual
         _ , ⊢ΣFG = syntacticEq B≡ΣFG
         ⊢F , ⊢G , ok = inversion-ΠΣ ⊢ΣFG
         ⊢A = soundness⇇Type (⊢Γ ∙ ⊢ΣFG) A⇇Type
-        ⊢u = soundness⇇ (⊢Γ ∙ ⊢F ∙ ⊢G) u⇇A₊
+        ⊢u = soundness⇇ u⇇A₊
     in  substType ⊢A ⊢t′ , prodrecⱼ ⊢F ⊢G ⊢A ⊢t′ ⊢u ok
   soundness⇉ ⊢Γ ℕᵢ = Uⱼ ⊢Γ , ℕⱼ ⊢Γ
   soundness⇉ ⊢Γ zeroᵢ = (ℕⱼ ⊢Γ) , (zeroⱼ ⊢Γ)
-  soundness⇉ ⊢Γ (sucᵢ t⇇ℕ) = (ℕⱼ ⊢Γ) , (sucⱼ (soundness⇇ ⊢Γ t⇇ℕ))
+  soundness⇉ ⊢Γ (sucᵢ t⇇ℕ) = ℕⱼ ⊢Γ , sucⱼ (soundness⇇ t⇇ℕ)
   soundness⇉ ⊢Γ (natrecᵢ A⇇Type z⇇A₀ s⇇A₊ n⇇ℕ) =
     let ⊢ℕ = ℕⱼ ⊢Γ
         ⊢A = soundness⇇Type (⊢Γ ∙ ⊢ℕ) A⇇Type
-        ⊢z = soundness⇇ ⊢Γ z⇇A₀
-        ⊢s = soundness⇇ (⊢Γ ∙ ⊢ℕ ∙ ⊢A) s⇇A₊
-        ⊢n = soundness⇇ ⊢Γ n⇇ℕ
+        ⊢z = soundness⇇ z⇇A₀
+        ⊢s = soundness⇇ s⇇A₊
+        ⊢n = soundness⇇ n⇇ℕ
     in  substType ⊢A ⊢n , (natrecⱼ ⊢A ⊢z ⊢s ⊢n)
   soundness⇉ ⊢Γ (Unitᵢ ok) = Uⱼ ⊢Γ , Unitⱼ ⊢Γ ok
   soundness⇉ ⊢Γ (starᵢ ok) = Unitⱼ ⊢Γ ok , starⱼ ⊢Γ ok
   soundness⇉ ⊢Γ (unitrecᵢ A⇇Type t⇇Unit u⇇A₊) =
-    let ⊢t = soundness⇇ ⊢Γ t⇇Unit
+    let ⊢t = soundness⇇ t⇇Unit
         ⊢Unit = syntacticTerm ⊢t
         ok = inversion-Unit ⊢Unit
         ⊢A = soundness⇇Type (⊢Γ ∙ ⊢Unit) A⇇Type
-        ⊢u = soundness⇇ ⊢Γ u⇇A₊
+        ⊢u = soundness⇇ u⇇A₊
     in  substType ⊢A ⊢t , unitrecⱼ ⊢A ⊢t ⊢u ok
   soundness⇉ ⊢Γ Emptyᵢ = (Uⱼ ⊢Γ) , (Emptyⱼ ⊢Γ)
   soundness⇉ ⊢Γ (emptyrecᵢ A⇇Type t⇇Empty) =
     let ⊢A = soundness⇇Type ⊢Γ A⇇Type
-    in  ⊢A , (emptyrecⱼ ⊢A (soundness⇇ ⊢Γ t⇇Empty))
+    in  ⊢A , (emptyrecⱼ ⊢A (soundness⇇ t⇇Empty))
   soundness⇉ ⊢Γ (Idᵢ ⊢A ⊢t ⊢u) =
-    Uⱼ ⊢Γ , Idⱼ (soundness⇇ ⊢Γ ⊢A) (soundness⇇ ⊢Γ ⊢t) (soundness⇇ ⊢Γ ⊢u)
+    Uⱼ ⊢Γ , Idⱼ (soundness⇇ ⊢A) (soundness⇇ ⊢t) (soundness⇇ ⊢u)
   soundness⇉ ⊢Γ (Jᵢ ⊢A ⊢t ⊢B ⊢u ⊢v ⊢w) =
     case soundness⇇Type ⊢Γ ⊢A of λ {
       ⊢A →
-    case soundness⇇ ⊢Γ ⊢t of λ {
+    case soundness⇇ ⊢t of λ {
       ⊢t →
     case soundness⇇Type (⊢Γ ∙ ⊢A ∙ Idⱼ (W.wkTerm₁ ⊢A ⊢t) (var₀ ⊢A))
            ⊢B of λ {
       ⊢B →
-    case soundness⇇ ⊢Γ ⊢w of λ {
+    case soundness⇇ ⊢w of λ {
       ⊢w →
-      substType₂ ⊢B (soundness⇇ ⊢Γ ⊢v)
+      substType₂ ⊢B (soundness⇇ ⊢v)
         (PE.subst (_⊢_∷_ _ _) ≡Id-wk1-wk1-0[]₀ ⊢w)
-    , Jⱼ′ ⊢B (soundness⇇ ⊢Γ ⊢u) ⊢w }}}}
+    , Jⱼ′ ⊢B (soundness⇇ ⊢u) ⊢w }}}}
   soundness⇉ ⊢Γ (Kᵢ ⊢A ⊢t ⊢B ⊢u ⊢v ok) =
     case soundness⇇Type ⊢Γ ⊢A of λ {
       ⊢A →
-    case soundness⇇ ⊢Γ ⊢t of λ {
+    case soundness⇇ ⊢t of λ {
       ⊢t →
     case soundness⇇Type (⊢Γ ∙ Idⱼ ⊢t ⊢t) ⊢B of λ {
       ⊢B →
-    case soundness⇇ ⊢Γ ⊢v of λ {
+    case soundness⇇ ⊢v of λ {
       ⊢v →
       substType ⊢B ⊢v
-    , Kⱼ′ ⊢B (soundness⇇ ⊢Γ ⊢u) ⊢v ok }}}}
-  soundness⇉ ⊢Γ ([]-congᵢ _ ⊢t ⊢u ⊢v ok) =
-      Idⱼ ([]ⱼ ([]-cong→Erased ok) (soundness⇇ ⊢Γ ⊢t))
-        ([]ⱼ ([]-cong→Erased ok) (soundness⇇ ⊢Γ ⊢u))
-    , []-congⱼ′ ok (soundness⇇ ⊢Γ ⊢v)
+    , Kⱼ′ ⊢B (soundness⇇ ⊢u) ⊢v ok }}}}
+  soundness⇉ _ ([]-congᵢ _ ⊢t ⊢u ⊢v ok) =
+      Idⱼ ([]ⱼ ([]-cong→Erased ok) (soundness⇇ ⊢t))
+        ([]ⱼ ([]-cong→Erased ok) (soundness⇇ ⊢u))
+    , []-congⱼ′ ok (soundness⇇ ⊢v)
 
-  soundness⇇ : ⊢ Γ → Γ ⊢ t ⇇ A → Γ ⊢ t ∷ A
-  soundness⇇ ⊢Γ (lamᶜ A↘ΠFG t⇇G)=
+  soundness⇇ : Γ ⊢ t ⇇ A → Γ ⊢ t ∷ A
+  soundness⇇ (lamᶜ A↘ΠFG t⇇G)=
     let A≡ΠFG = subset* (proj₁ A↘ΠFG)
         _ , ⊢ΠFG = syntacticEq A≡ΠFG
         ⊢F , ⊢G , ok = inversion-ΠΣ ⊢ΠFG
-        ⊢t = soundness⇇ (⊢Γ ∙ ⊢F) t⇇G
+        ⊢t = soundness⇇ t⇇G
     in  conv (lamⱼ ⊢F ⊢t ok) (sym A≡ΠFG)
-  soundness⇇ ⊢Γ (prodᶜ A↘ΣFG t⇇F u⇇Gt) =
+  soundness⇇ (prodᶜ A↘ΣFG t⇇F u⇇Gt) =
     let A≡ΣFG = subset* (proj₁ A↘ΣFG)
         _ , ⊢ΣFG = syntacticEq A≡ΣFG
         ⊢F , ⊢G , ok = inversion-ΠΣ ⊢ΣFG
-        ⊢t = soundness⇇ ⊢Γ t⇇F
-        ⊢u = soundness⇇ ⊢Γ u⇇Gt
+        ⊢t = soundness⇇ t⇇F
+        ⊢u = soundness⇇ u⇇Gt
     in  conv (prodⱼ ⊢F ⊢G ⊢t ⊢u ok) (sym A≡ΣFG)
-  soundness⇇ _ (rflᶜ (A⇒*Id , _) t≡u) =
+  soundness⇇ (rflᶜ (A⇒*Id , _) t≡u) =
     conv (rflⱼ′ t≡u) (sym (subset* A⇒*Id))
-  soundness⇇ ⊢Γ (infᶜ t⇉B A≡B) = conv (proj₂ (soundness⇉ ⊢Γ t⇉B)) A≡B
+  soundness⇇ (infᶜ t⇉B A≡B) =
+    conv (soundness⇉ (wfEq A≡B) t⇉B .proj₂) A≡B

--- a/Definition/Typed/Consequences/DerivedRules/Nat.agda
+++ b/Definition/Typed/Consequences/DerivedRules/Nat.agda
@@ -35,7 +35,7 @@ opaque
   sucCong F≡G with wfEq F≡G
   sucCong F≡G | ⊢Γ ∙ ⊢ℕ =
     let ⊢F , ⊢G = syntacticEq F≡G
-    in subst↑²TypeEq ⊢ℕ ⊢F F≡G (refl (sucⱼ (var (⊢Γ ∙ ⊢ℕ ∙ ⊢F) (there here))))
+    in subst↑²TypeEq F≡G (refl (sucⱼ (var (⊢Γ ∙ ⊢ℕ ∙ ⊢F) (there here))))
 
 opaque
 
@@ -44,7 +44,7 @@ opaque
   sucCong′ F≡G with wfEq F≡G
   sucCong′ F≡G | ⊢Γ ∙ ⊢ℕ =
     let ⊢F , ⊢G = syntacticEq F≡G
-    in subst↑²TypeEq ⊢ℕ ⊢G F≡G (refl (sucⱼ (var (⊢Γ ∙ ⊢ℕ ∙ ⊢G) (there here))))
+    in subst↑²TypeEq F≡G (refl (sucⱼ (var (⊢Γ ∙ ⊢ℕ ∙ ⊢G) (there here))))
 
 opaque
 

--- a/Definition/Typed/Decidable.agda
+++ b/Definition/Typed/Decidable.agda
@@ -48,9 +48,7 @@ dec ⊢Γ A =
 -- checkable, then Γ ⊢ t ∷ A is decidable.
 
 decTermᶜ : Γ ⊢ A → Checkable t → Dec (Γ ⊢ t ∷ A)
-decTermᶜ ⊢A t = Dec.map (soundness⇇ ⊢Γ) (completeness⇇ t) (dec⇇ ⊢Γ t ⊢A)
-  where
-  ⊢Γ = wf ⊢A
+decTermᶜ ⊢A t = Dec.map soundness⇇ (completeness⇇ t) (dec⇇ t ⊢A)
 
 -- Type-checking for arbitrary checkable types: if Γ is well-formed
 -- and A and t are checkable, then Γ ⊢ t ∷ A is decidable.

--- a/Definition/Typed/Decidable/Reduction.agda
+++ b/Definition/Typed/Decidable/Reduction.agda
@@ -34,98 +34,124 @@ private
     A : Term n
     l : TypeLevel
 
--- Decidability of being (reducing to) a binding type
+private opaque
 
-isB′ : ∀ {l} → Γ ⊩⟨ l ⟩ A → Dec (∃₃ λ F G W → (Γ ⊢ F) × (Γ ∙ F ⊢ G) × Γ ⊢ A ⇒* (⟦ W ⟧ F ▹ G))
-isB′ (Uᵣ′ l′ l< ⊢Γ) = no (λ {(F , G , W , ⊢F , ⊢G , U⇒W) → U≢B W (subset* U⇒W)})
-isB′ (ℕᵣ x) = no (λ {(F , G , W , ⊢F , ⊢G , A⇒W) → ℕ≢B W (trans (sym (subset* (red x))) (subset* A⇒W))})
-isB′ (Emptyᵣ x) = no (λ {(F , G , W , ⊢F , ⊢G , A⇒W) → Empty≢Bⱼ W (trans (sym (subset* (red x))) (subset* A⇒W))})
-isB′ (Unitᵣ (Unitₜ x _)) =
-  no (λ { (_ , _ , W , _ , _ , A⇒W) →
-          Unit≢Bⱼ W (trans (sym (subset* (red x))) (subset* A⇒W)) })
-isB′ (ne′ H D neH H≡H) = no (λ {(F , G , W , ⊢F , ⊢G , A⇒W) → B≢ne W neH (trans (sym (subset* A⇒W)) (subset* (red D)))})
-isB′ (Bᵣ′ W F G D ⊢F ⊢G A≡A [F] [G] G-ext _) =
-  yes (F , G , W , ⊢F , ⊢G , red D)
-isB′ (Idᵣ ⊩A) =
-  no λ (_ , _ , _ , _ , _ , A⇒*Id) →
-    Id≢⟦⟧▷
-      (trans (sym (subset* (red (_⊩ₗId_.⇒*Id ⊩A)))) (subset* A⇒*Id ))
-isB′ (emb 0<1 [A]) = isB′ [A]
+  -- A lemma used below.
 
-isB : Γ ⊢ A → Dec (∃₃ λ F G W → (Γ ⊢ F) × (Γ ∙ F ⊢ G) × Γ ⊢ A ⇒* (⟦ W ⟧ F ▹ G))
-isB ⊢A = isB′ (reducible-⊩ ⊢A)
+  isB′ : ∀ {l} → Γ ⊩⟨ l ⟩ A → Dec (∃₃ λ W B C → Γ ⊢ A ⇒* ⟦ W ⟧ B ▹ C)
+  isB′ (Uᵣ′ _ _ _) =
+    no λ (_ , _ , _ , U⇒W) → U≢B _ (subset* U⇒W)
+  isB′ (ℕᵣ A⇒*ℕ) =
+    no λ (_ , _ , _ , A⇒*W) →
+    ℕ≢B _ (trans (sym (subset* (red A⇒*ℕ))) (subset* A⇒*W))
+  isB′ (Emptyᵣ A⇒*Empty) =
+    no λ (_ , _ , _ , A⇒*W) →
+    Empty≢Bⱼ _ (trans (sym (subset* (red A⇒*Empty))) (subset* A⇒*W))
+  isB′ (Unitᵣ (Unitₜ A⇒*Unit _)) =
+    no λ (_ , _ , _ , A⇒*W) →
+    Unit≢Bⱼ _ (trans (sym (subset* (red A⇒*Unit))) (subset* A⇒*W))
+  isB′ (ne′ _ A⇒*B B-ne _) =
+    no λ (_ , _ , _ , A⇒*W) →
+    B≢ne _ B-ne (trans (sym (subset* A⇒*W)) (subset* (red A⇒*B)))
+  isB′ (Bᵣ′ _ _ _ A⇒*ΠΣ _ _ _ _ _ _ _) =
+    yes (_ , _ , _ , red A⇒*ΠΣ)
+  isB′ (Idᵣ ⊩A) =
+    no λ (_ , _ , _ , A⇒*Id) →
+    Id≢⟦⟧▷ $
+    trans (sym (subset* (red (_⊩ₗId_.⇒*Id ⊩A)))) (subset* A⇒*Id)
+  isB′ (emb 0<1 ⊩A) = isB′ ⊩A
 
--- Decidability of being (reducing to) a Π-type
+opaque
 
-isΠ : Γ ⊢ A → Dec (∃₄ λ F G p q → (Γ ⊢ F) × (Γ ∙ F ⊢ G) × Γ ⊢ A ⇒* (Π p , q ▷ F ▹ G))
-isΠ ⊢A with isB ⊢A
-... | yes (F , G , BΠ p q , ⊢F , ⊢G , A⇒Π) = yes (F , G , p , q , ⊢F , ⊢G , A⇒Π)
-... | yes (F , G , BΣ p q x , ⊢F , ⊢G , A⇒Σ) = no (λ {(F′ , G′ , p′ , q′ , ⊢F , ⊢G , A⇒Π) → Π≢Σⱼ (trans (sym (subset* A⇒Π)) (subset* A⇒Σ))})
-... | no ¬isB = no (λ {(F′ , G′ , p′ , q′ , ⊢F , ⊢G , A⇒Π) → ¬isB (F′ , G′ , BΠ p′ q′ , ⊢F , ⊢G , A⇒Π)})
+  -- It is decidable whether a well-formed type reduces to (or does
+  -- not reduce to) either a Π-type or a Σ-type.
 
--- Decidability of being (reducing to) a Σ-type
+  isB : Γ ⊢ A → Dec (∃₃ λ W B C → Γ ⊢ A ⇒* ⟦ W ⟧ B ▹ C)
+  isB ⊢A = isB′ (reducible-⊩ ⊢A)
 
-isΣ : Γ ⊢ A → Dec (∃₄ λ F G m p → ∃ λ q → (Γ ⊢ F) × (Γ ∙ F ⊢ G) × Γ ⊢ A ⇒* (Σ⟨ m ⟩ p , q ▷ F ▹ G))
-isΣ ⊢A with isB ⊢A
-... | yes (F , G , BΣ m p q , ⊢F , ⊢G , A⇒Σ) = yes (F , G , m , p , q , ⊢F , ⊢G , A⇒Σ)
-... | yes (F , G , BΠ p q , ⊢F , ⊢G , A⇒Π) = no (λ {(F′ , G′ , m′ , p′ , q′ , ⊢F , ⊢G , A⇒Σ) → Π≢Σⱼ (trans (sym (subset* A⇒Π)) (subset* A⇒Σ))})
-... | no ¬isB = no (λ {(F′ , G′ , m , p′ , q′ , ⊢F , ⊢G , A⇒Π) → ¬isB (F′ , G′ , BΣ m p′ q′ , ⊢F , ⊢G , A⇒Π)})
+opaque
 
-isΣˢ : Γ ⊢ A → Dec (∃₄ λ F G p q → (Γ ⊢ F) × (Γ ∙ F ⊢ G) × Γ ⊢ A ⇒* (Σˢ p , q ▷ F ▹ G))
-isΣˢ ⊢A with isΣ ⊢A
-... | yes (F , G , 𝕤 , p , q , ⊢F , ⊢G , A⇒Σ) = yes (F , G , p , q , ⊢F , ⊢G , A⇒Σ)
-... | yes (F , G , 𝕨 , p , q , ⊢F , ⊢G , A⇒Σ) = no (λ {(F′ , G′ , p′ , q′ , ⊢F′ , ⊢G′ , A⇒Σ′) → Σˢ≢Σʷⱼ (trans (sym (subset* A⇒Σ′)) (subset* A⇒Σ))})
-... | no ¬isΣ = no (λ {(F′ , G′ , p′ , q′ , ⊢F′ , ⊢G′ , A⇒Σ′) → ¬isΣ (F′ , G′ , 𝕤 , p′ , q′ , ⊢F′ , ⊢G′ , A⇒Σ′)})
+  -- It is decidable whether a well-formed type reduces to a Π-type.
 
-isΣʷ : Γ ⊢ A → Dec (∃₄ λ F G p q → (Γ ⊢ F) × (Γ ∙ F ⊢ G) × Γ ⊢ A ⇒* (Σʷ p , q ▷ F ▹ G))
-isΣʷ ⊢A with isΣ ⊢A
-... | yes (F , G , 𝕤 , p , q , ⊢F , ⊢G , A⇒Σ) = no (λ {(F′ , G′ , p′ , q′ , ⊢F′ , ⊢G′ , A⇒Σ′) → Σˢ≢Σʷⱼ (trans (sym (subset* A⇒Σ)) (subset* A⇒Σ′))})
-... | yes (F , G , 𝕨 , p , q , ⊢F , ⊢G , A⇒Σ) = yes (F , G , p , q , ⊢F , ⊢G , A⇒Σ)
-... | no ¬isΣ = no (λ {(F′ , G′ , p′ , q′ , ⊢F′ , ⊢G′ , A⇒Σ′) → ¬isΣ (F′ , G′ , 𝕨 , p′ , q′ , ⊢F′ , ⊢G′ , A⇒Σ′)})
+  isΠ : Γ ⊢ A → Dec (∃₄ λ p q B C → Γ ⊢ A ⇒* Π p , q ▷ B ▹ C)
+  isΠ ⊢A with isB ⊢A
+  … | yes (BΠ _ _ , _ , _ , A⇒*Π)   = yes (_ , _ , _ , _ , A⇒*Π)
+  … | yes (BΣ _ _ _ , _ , _ , A⇒*Σ) =
+    no λ (_ , _ , _ , _ , A⇒*Π) →
+    Π≢Σⱼ (trans (sym (subset* A⇒*Π)) (subset* A⇒*Σ))
+  … | no not = no λ (_ , _ , _ , _ , A⇒*Π) → not (_ , _ , _ , A⇒*Π)
+
+opaque
+
+  -- It is decidable whether a well-formed type reduces to a Σ-type.
+
+  isΣ : Γ ⊢ A → Dec (∃₅ λ s p q B C → Γ ⊢ A ⇒* Σ⟨ s ⟩ p , q ▷ B ▹ C)
+  isΣ ⊢A with isB ⊢A
+  … | yes (BΣ _ _ _ , _ , _ , A⇒*Σ) = yes (_ , _ , _ , _ , _ , A⇒*Σ)
+  … | yes (BΠ _ _ , _ , _ , A⇒*Π)   =
+    no λ (_ , _ , _ , _ , _ , A⇒*Σ) →
+    Π≢Σⱼ (trans (sym (subset* A⇒*Π)) (subset* A⇒*Σ))
+  … | no not = no λ (_ , _ , _ , _ , _ , A⇒*Σ) → not (_ , _ , _ , A⇒*Σ)
+
+opaque
+
+  -- It is decidable whether a well-formed type reduces to a strong
+  -- Σ-type.
+
+  isΣˢ : Γ ⊢ A → Dec (∃₄ λ p q B C → Γ ⊢ A ⇒* Σˢ p , q ▷ B ▹ C)
+  isΣˢ ⊢A with isΣ ⊢A
+  … | yes (𝕤 , rest)                  = yes rest
+  … | yes (𝕨 , _ , _ , _ , _ , A⇒*Σʷ) =
+    no λ (_ , _ , _ , _ , A⇒*Σˢ) →
+    Σˢ≢Σʷⱼ (trans (sym (subset* A⇒*Σˢ)) (subset* A⇒*Σʷ))
+  … | no not = no (not ∘→ (_ ,_))
+
+opaque
+
+  -- It is decidable whether a well-formed type reduces to a weak
+  -- Σ-type.
+
+  isΣʷ : Γ ⊢ A → Dec (∃₄ λ p q B C → Γ ⊢ A ⇒* Σʷ p , q ▷ B ▹ C)
+  isΣʷ ⊢A with isΣ ⊢A
+  … | yes (𝕨 , rest)                  = yes rest
+  … | yes (𝕤 , _ , _ , _ , _ , A⇒*Σˢ) =
+    no λ (_ , _ , _ , _ , A⇒*Σʷ) →
+    Σˢ≢Σʷⱼ (trans (sym (subset* A⇒*Σˢ)) (subset* A⇒*Σʷ))
+  … | no not = no (not ∘→ (_ ,_))
 
 opaque
 
   -- It is decidable whether a well-formed type reduces to an identity
   -- type.
 
-  is-Id :
-    Γ ⊢ A →
-    Dec (∃₃ λ B t u →
-         (Γ ⊢ B) × Γ ⊢ t ∷ B × Γ ⊢ u ∷ B × Γ ⊢ A ⇒* Id B t u)
+  is-Id : Γ ⊢ A → Dec (∃₃ λ B t u → Γ ⊢ A ⇒* Id B t u)
   is-Id = helper ∘→ reducible-⊩
     where
-    helper :
-      Γ ⊩⟨ l ⟩ A →
-      Dec (∃₃ λ B t u →
-           (Γ ⊢ B) × Γ ⊢ t ∷ B × Γ ⊢ u ∷ B × Γ ⊢ A ⇒* Id B t u)
+    helper : Γ ⊩⟨ l ⟩ A → Dec (∃₃ λ B t u → Γ ⊢ A ⇒* Id B t u)
     helper (Uᵣ _) =
-      no λ (_ , _ , _ , _ , _ , _ , U⇒*Id) →
+      no λ (_ , _ , _ , U⇒*Id) →
         Id≢U (sym (subset* U⇒*Id))
     helper (ℕᵣ A⇒*ℕ) =
-      no λ (_ , _ , _ , _ , _ , _ , A⇒*Id) →
+      no λ (_ , _ , _ , A⇒*Id) →
         Id≢ℕ (trans (sym (subset* A⇒*Id)) (subset* (red A⇒*ℕ)))
     helper (Emptyᵣ A⇒*Empty) =
-      no λ (_ , _ , _ , _ , _ , _ , A⇒*Id) →
+      no λ (_ , _ , _ , A⇒*Id) →
         Id≢Empty (trans (sym (subset* A⇒*Id)) (subset* (red A⇒*Empty)))
     helper (Unitᵣ ⊩Unit) =
-      no λ (_ , _ , _ , _ , _ , _ , A⇒*Id) →
+      no λ (_ , _ , _ , A⇒*Id) →
         Id≢Unit $
         trans (sym (subset* A⇒*Id))
           (subset* (red (_⊩Unit⟨_⟩_.⇒*-Unit ⊩Unit)))
     helper (ne ⊩A) =
-      no λ (_ , _ , _ , _ , _ , _ , A⇒*Id) →
+      no λ (_ , _ , _ , A⇒*Id) →
         Id≢ne neK $ trans (sym (subset* A⇒*Id)) (subset* (red D))
       where
       open _⊩ne_ ⊩A
     helper (Bᵣ _ ⊩A) =
-      no λ (_ , _ , _ , _ , _ , _ , A⇒*Id) →
+      no λ (_ , _ , _ , A⇒*Id) →
         Id≢⟦⟧▷ $
         trans (sym (subset* A⇒*Id)) (subset* (red (_⊩ₗB⟨_⟩_.D ⊩A)))
-    helper (Idᵣ ⊩A) = yes
-        ( _ , _ , _
-        , escape ⊩Ty , escapeTerm ⊩Ty ⊩lhs , escapeTerm ⊩Ty ⊩rhs
-        , red ⇒*Id
-        )
+    helper (Idᵣ ⊩A) = yes (_ , _ , _ , red ⇒*Id)
       where
       open _⊩ₗId_ ⊩A
     helper (emb 0<1 ⊩A) =

--- a/Definition/Typed/Eta-long-normal-form.agda
+++ b/Definition/Typed/Eta-long-normal-form.agda
@@ -1338,7 +1338,7 @@ mutual
       normal-terms-unique-~↓ ⊢u ⊢v u≡v
     (Empty-ins u≡v) →
       normal-terms-unique-~↓ ⊢u ⊢v u≡v
-    (Unit-ins u≡v) →
+    (Unitʷ-ins _ u≡v) →
       normal-terms-unique-~↓ ⊢u ⊢v u≡v
     (Σʷ-ins _ _ u≡v) →
       normal-terms-unique-~↓ ⊢u ⊢v u≡v

--- a/Definition/Typed/Eta-long-normal-form.agda
+++ b/Definition/Typed/Eta-long-normal-form.agda
@@ -1121,7 +1121,7 @@ mutual
         (⊢nf∷U→⊢nf∷U ⊢A ⊢A∷U)
         (⊢nf∷U→⊢nf∷U ⊢B ⊢B∷U)
         A≡B }
-    (ΠΣ-cong _ A₁≡B₁ A₂≡B₂ _) →
+    (ΠΣ-cong A₁≡B₁ A₂≡B₂ _) →
       case inversion-nf-ΠΣ ⊢A of λ {
         (⊢A₁ , ⊢A₂ , _) →
       case inversion-nf-ΠΣ ⊢B of λ {
@@ -1356,7 +1356,7 @@ mutual
       case inversion-nf-suc ⊢v of λ {
         (⊢v , _) →
       PE.cong suc (normal-terms-unique-[conv↑]∷ ⊢u ⊢v u≡v) }}
-    (prod-cong _ _ t≡v u≡w _) →
+    (prod-cong _ t≡v u≡w _) →
       case inversion-nf-prod ⊢u of λ {
         (_ , _ , _ , _ , _ , ⊢t , ⊢u , Σ≡Σ₁ , _) →
       case inversion-nf-prod ⊢v of λ {

--- a/Definition/Typed/Properties/Well-formed.agda
+++ b/Definition/Typed/Properties/Well-formed.agda
@@ -119,6 +119,13 @@ opaque
 
 opaque
 
+  -- If ⊢ Γ ∙ A holds, then Γ ⊢ A also holds.
+
+  ⊢∙→⊢ : ⊢ Γ ∙ A → Γ ⊢ A
+  ⊢∙→⊢ (_ ∙ ⊢A) = ⊢A
+
+opaque
+
   -- A lemma which could perhaps be used to make certain proofs more
   -- readable.
 

--- a/Definition/Untyped.agda
+++ b/Definition/Untyped.agda
@@ -18,7 +18,6 @@ open import Definition.Untyped.NotParametrised public
 
 private
   variable
-    p p′ : M
     n m ℓ : Nat
     bs bs′ : List _
     ts ts′ : GenTs _ _ _
@@ -87,9 +86,8 @@ data Term (n : Nat) : Set a where
   gen : {bs : List Nat} (k : Kind bs) (ts : GenTs Term n bs) → Term n
 
 private variable
-  F H t u t′ u′ : Term n
-  E G           : Term (1+ n)
-  k k′          : Kind _
+  t    : Term n
+  k k′ : Kind _
 
 -- The Grammar of our language.
 
@@ -162,37 +160,6 @@ pattern BΣˢ = BΣ 𝕤 _ _
 
 ⟦_⟧_▹_ : BindingType → Term n → Term (1+ n) → Term n
 ⟦ BM b p q ⟧ A ▹ B = ΠΣ⟨ b ⟩ p , q ▷ A ▹ B
-
--- Injectivity of term constructors w.r.t. propositional equality.
-
--- If  W F G = W' H E  then  F = H,  G = E and W = W'.
-
-B-PE-injectivity : ∀ W W' → ⟦ W ⟧ F ▹ G PE.≡ ⟦ W' ⟧ H ▹ E
-                 → F PE.≡ H × G PE.≡ E × W PE.≡ W'
-B-PE-injectivity (BΠ p q) (BΠ .p .q) PE.refl =
-  PE.refl , PE.refl , PE.refl
-B-PE-injectivity (BΣ p q m) (BΣ .p .q .m) PE.refl =
-  PE.refl , PE.refl , PE.refl
-
-BΠ-PE-injectivity : ∀ {p p′ q q′} → BΠ p q PE.≡ BΠ p′ q′ → p PE.≡ p′ × q PE.≡ q′
-BΠ-PE-injectivity PE.refl = PE.refl , PE.refl
-
-BΣ-PE-injectivity :
-  ∀ {p p′ q q′ m m′} →
-  BΣ m p q PE.≡ BΣ m′ p′ q′ → p PE.≡ p′ × q PE.≡ q′ × m PE.≡ m′
-BΣ-PE-injectivity PE.refl = PE.refl , PE.refl , PE.refl
-
--- If  suc n = suc m  then  n = m.
-
-suc-PE-injectivity : suc t PE.≡ suc u → t PE.≡ u
-suc-PE-injectivity PE.refl = PE.refl
-
--- If prod t u = prod t′ u′ then t = t′ and u = u′
-
-prod-PE-injectivity : ∀ {m m′} → prod m p t u PE.≡ prod m′ p′ t′ u′
-                    → m PE.≡ m′ × p PE.≡ p′ × t PE.≡ t′ × u PE.≡ u′
-prod-PE-injectivity PE.refl = PE.refl , PE.refl , PE.refl , PE.refl
-
 
 -- Fully normalized natural numbers
 

--- a/Definition/Untyped/Properties/Neutral.agda
+++ b/Definition/Untyped/Properties/Neutral.agda
@@ -12,6 +12,7 @@ module Definition.Untyped.Properties.Neutral
 
 open import Tools.Fin
 open import Tools.Function
+open import Tools.Nat
 open import Tools.Product
 open import Tools.PropositionalEquality
 open import Tools.Relation
@@ -22,10 +23,54 @@ open import Definition.Untyped.Inversion M
 open import Definition.Untyped.Neutral M type-variant
 
 private variable
-  t u : Term _
+  A B t u : Term _
   ρ : Wk _ _
   σ : Subst _ _
+  b : BinderMode
+  s : Strength
+  p q : M
+  n : Nat
   x : Fin _
+
+opaque
+
+  -- Constructor applications are not neutral.
+
+  ¬-Neutral-U : ¬ Neutral {n = n} U
+  ¬-Neutral-U ()
+
+  ¬-Neutral-ΠΣ : ¬ Neutral (ΠΣ⟨ b ⟩ p , q ▷ A ▹ B)
+  ¬-Neutral-ΠΣ ()
+
+  ¬-Neutral-lam : ¬ Neutral (lam p t)
+  ¬-Neutral-lam ()
+
+  ¬-Neutral-prod : ¬ Neutral (prod s p t u)
+  ¬-Neutral-prod ()
+
+  ¬-Neutral-Empty : ¬ Neutral {n = n} Empty
+  ¬-Neutral-Empty ()
+
+  ¬-Neutral-Unit : ¬ Neutral {n = n} (Unit s)
+  ¬-Neutral-Unit ()
+
+  ¬-Neutral-star : ¬ Neutral {n = n} (star s)
+  ¬-Neutral-star ()
+
+  ¬-Neutral-ℕ : ¬ Neutral {n = n} ℕ
+  ¬-Neutral-ℕ ()
+
+  ¬-Neutral-zero : ¬ Neutral {n = n} zero
+  ¬-Neutral-zero ()
+
+  ¬-Neutral-suc : ¬ Neutral (suc t)
+  ¬-Neutral-suc ()
+
+  ¬-Neutral-Id : ¬ Neutral (Id A t u)
+  ¬-Neutral-Id ()
+
+  ¬-Neutral-rfl : ¬ Neutral {n = n} rfl
+  ¬-Neutral-rfl ()
 
 opaque
 

--- a/Everything.agda
+++ b/Everything.agda
@@ -278,6 +278,7 @@ import Definition.Conversion
 import Definition.Conversion.Whnf
 import Definition.Conversion.Reduction
 import Definition.Conversion.Soundness
+import Definition.Conversion.Inversion
 import Definition.Conversion.Stability
 import Definition.Conversion.Conversion
 import Definition.Conversion.Symmetry

--- a/Graded/Erasure/LogicalRelation/Irrelevance.agda
+++ b/Graded/Erasure/LogicalRelation/Irrelevance.agda
@@ -29,6 +29,7 @@ open import Definition.Typed.Properties R
 
 open import Definition.Untyped M
 open import Definition.Untyped.Neutral M type-variant
+open import Definition.Untyped.Properties M
 
 open import Tools.Function
 open import Tools.Nat

--- a/Graded/FullReduction.agda
+++ b/Graded/FullReduction.agda
@@ -300,7 +300,7 @@ module _ (as : Full-reduction-assumptions) where
       (Empty-refl _)        ▸⊥    → ▸⊥
       (Unit-refl  _ _)      ▸⊤    → ▸⊤
       (ne A~)               ▸A    → fullRedNe~↓ A~ ▸A
-      (ΠΣ-cong ⊢A A↑ B↑ ok) ▸ΠΣAB →
+      (ΠΣ-cong A↑ B↑ ok) ▸ΠΣAB →
         case inv-usage-ΠΣ ▸ΠΣAB of λ {
           (invUsageΠΣ ▸A ▸B γ≤) →
         sub (ΠΣₘ (fullRedConv↑ A↑ ▸A) (fullRedConv↑ B↑ ▸B)) γ≤ }
@@ -337,7 +337,7 @@ module _ (as : Full-reduction-assumptions) where
         case inv-usage-suc ▸suc-t of λ {
           (invUsageSuc ▸t γ≤) →
         sub (sucₘ (fullRedTermConv↑ t↑ ▸t)) γ≤ }
-      (prod-cong _ _ t↑ u↑ _) ▸t,u →
+      (prod-cong _ t↑ u↑ _) ▸t,u →
         case inv-usage-prodʷ ▸t,u of λ {
           (invUsageProdʷ ▸t ▸u γ≤) →
         sub (prodʷₘ (fullRedTermConv↑ t↑ ▸t) (fullRedTermConv↑ u↑ ▸u))

--- a/Graded/FullReduction.agda
+++ b/Graded/FullReduction.agda
@@ -99,8 +99,7 @@ module _ (as : Full-reduction-assumptions) where
         (inj₁ (() , _))
         (inj₂ 𝟙≤𝟘)      → ≤𝟘⇔𝟙≤𝟘 .proj₂ 𝟙≤𝟘
 
-    -- A lemma used in the Unit-ins and η-unit cases of
-    -- fullRedTermConv↓.
+    -- A lemma used in the η-unit case of fullRedTermConv↓.
     --
     -- Note that the Unit-allowed and Unit-with-η assumptions are only
     -- used when the mode is 𝟙ᵐ. Currently the typing relation does
@@ -326,10 +325,9 @@ module _ (as : Full-reduction-assumptions) where
       (⊢t : Γ ⊢ t [conv↓] t′ ∷ A) → γ ▸[ m ] t →
       γ ▸[ m ] FR.fullRedTermConv↓ ⊢t .proj₁
     fullRedTermConv↓ {Γ = Γ} {t = t} {γ = γ} {m = m} = λ where
-      (ℕ-ins t~)     ▸t → fullRedNe~↓ t~ ▸t
-      (Empty-ins t~) ▸t → fullRedNe~↓ t~ ▸t
-      (Unit-ins t~)  ▸t →
-        fullRedTermConv↓-Unit-ins t~ ▸t (Unit-with-η? _)
+      (ℕ-ins t~)          ▸t     → fullRedNe~↓ t~ ▸t
+      (Empty-ins t~)      ▸t     → fullRedNe~↓ t~ ▸t
+      (Unitʷ-ins _ t~)    ▸t     → fullRedNe~↓ t~ ▸t
       (Σʷ-ins _ _ t~)     ▸t     → fullRedNe~↓ t~ ▸t
       (ne-ins _ _ _ t~↓B) ▸t     → fullRedNe~↓ t~↓B ▸t
       (univ _ _ A↓)       ▸A     → fullRedConv↓ A↓ ▸A
@@ -368,19 +366,6 @@ module _ (as : Full-reduction-assumptions) where
         Unit-lemma (⊢∷Unit→Unit-allowed ⊢t) η ▸t
       (Id-ins _ v~) ▸v   → fullRedNe~↓ v~ ▸v
       (rfl-refl _)  ▸rfl → sub rflₘ (inv-usage-rfl ▸rfl)
-
-    private
-
-      fullRedTermConv↓-Unit-ins :
-        (⊢t : Γ ⊢ t ~ t′ ↓ Unit s) → γ ▸[ m ] t →
-        (Unit-with-η? : Unit-with-η s ⊎ s PE.≡ 𝕨 × ¬ Unitʷ-η) →
-        γ ▸[ m ] FR.fullRedTermConv↓-Unit-ins ⊢t Unit-with-η? .proj₁
-      fullRedTermConv↓-Unit-ins t~ ▸t = λ where
-        (inj₂ (PE.refl , _)) → fullRedNe~↓ t~ ▸t
-        (inj₁ η)             →
-          case syntacticEqTerm (soundness~↓ t~) of λ
-            (⊢Unit , _ , _) →
-          Unit-lemma (inversion-Unit ⊢Unit) η ▸t
 
 ------------------------------------------------------------------------
 -- The main theorems

--- a/Tools/Product.agda
+++ b/Tools/Product.agda
@@ -17,6 +17,7 @@ open import Tools.Relation
 private variable
   a b c d e f g h i : Level
   A B               : Set _
+  P                 : A → Set _
 
 -- 4-tuples.
 
@@ -111,3 +112,12 @@ no ¬A ×-dec′ _ = no (λ (a , _) → ¬A a)
 yes a ×-dec′ d with d a
 … | yes b = yes (a , b)
 … | no ¬B = no (λ (_ , b) → ¬B b)
+
+-- A variant of _×-dec_ for Σ-types.
+
+Σ-dec :
+  Dec A → (∀ x y → P x → P y) → ((x : A) → Dec (P x)) → Dec (Σ A P)
+Σ-dec (no ¬A) _   _ = no (λ (a , _) → ¬A a)
+Σ-dec (yes a) irr d with d a
+… | yes b = yes (a , b)
+… | no ¬B = no (λ (_ , b) → ¬B (irr _ _ b))

--- a/Tools/Product.agda
+++ b/Tools/Product.agda
@@ -12,8 +12,11 @@ open import Data.Product public
 open import Relation.Nullary.Decidable public
   using (_×-dec_)
 
+open import Tools.Relation
+
 private variable
   a b c d e f g h i : Level
+  A B               : Set _
 
 -- 4-tuples.
 
@@ -98,3 +101,13 @@ private variable
    (f : F a b c d e) (g : G a b c d e f) → H a b c d e f g → Set i) →
   Set (a ⊔ b ⊔ c ⊔ d ⊔ e ⊔ f ⊔ g ⊔ h ⊔ i)
 ∃₈ I = ∃ λ a → ∃₇ (I a)
+
+-- A generalisation of _×-dec_.
+
+infixr 2 _×-dec′_
+
+_×-dec′_ : Dec A → (A → Dec B) → Dec (A × B)
+no ¬A ×-dec′ _ = no (λ (a , _) → ¬A a)
+yes a ×-dec′ d with d a
+… | yes b = yes (a , b)
+… | no ¬B = no (λ (_ , b) → ¬B b)


### PR DESCRIPTION
Some observations:

* Using inversion lemmas instead of matching directly can be beneficial, especially when matching on multiple arguments at the same time.

* Fewer pattern matches can be better: I obtained speed-ups (at least on my setup) by combining several calls to decision procedures into one call. This was for code that uses case expressions and pattern-matching lambdas, I did not try using `with` instead. I also think that the resulting code is cleaner.