### PR TITLE
Redefined Term to be a more direct representation of the syntax

### DIFF
--- a/Definition/LogicalRelation/Irrelevance.agda
+++ b/Definition/LogicalRelation/Irrelevance.agda
@@ -96,7 +96,7 @@ mutual
          whrDet* (red A⇒*Unit₁ , Unitₙ) (red A⇒*Unit₂ , Unitₙ) of λ {
       (_ , PE.refl) →
     A≡B }
-  irrelevanceEqT (ne (ne K D neK _) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
+  irrelevanceEqT (ne (ne _ D neK _) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
                  rewrite whrDet* (red D , ne neK) (red D₁ , ne neK₁) =
     ne₌ M D′ neM K≡M
   irrelevanceEqT
@@ -187,9 +187,9 @@ mutual
          whrDet* (red A⇒*Unit₁ , Unitₙ) (red A⇒*Unit₂ , Unitₙ) of λ {
       (_ , PE.refl) →
     ⊩t }
-  irrelevanceTermT (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (neₜ k d nf)
+  irrelevanceTermT (ne (ne _ D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (neₜ k d nf)
                    with whrDet* (red D₁ , ne neK₁) (red D , ne neK)
-  irrelevanceTermT (ne (ne K D neK K≡K) (ne .K D₁ neK₁ K≡K₁)) (neₜ k d nf)
+  irrelevanceTermT (ne (ne _ D neK K≡K) (ne _ D₁ neK₁ K≡K₁)) (neₜ k d nf)
     | PE.refl = neₜ k d nf
   irrelevanceTermT
     {Γ = Γ} {t = t}
@@ -308,9 +308,9 @@ mutual
          whrDet* (red A⇒*Unit₁ , Unitₙ) (red A⇒*Unit₂ , Unitₙ) of λ {
       (_ , PE.refl) →
     t≡u }
-  irrelevanceEqTermT (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (neₜ₌ k m d d′ nf)
+  irrelevanceEqTermT (ne (ne _ D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (neₜ₌ k m d d′ nf)
                      with whrDet* (red D₁ , ne neK₁) (red D , ne neK)
-  irrelevanceEqTermT (ne (ne K D neK K≡K) (ne .K D₁ neK₁ K≡K₁)) (neₜ₌ k m d d′ nf)
+  irrelevanceEqTermT (ne (ne _ D neK K≡K) (ne _ D₁ neK₁ K≡K₁)) (neₜ₌ k m d d′ nf)
     | PE.refl = neₜ₌ k m d d′ nf
   irrelevanceEqTermT
     {Γ = Γ} {t = t} {u = u}

--- a/Definition/LogicalRelation/Properties/Conversion.agda
+++ b/Definition/LogicalRelation/Properties/Conversion.agda
@@ -54,7 +54,7 @@ mutual
          whrDet* (red B⇒*Unit₁ , Unitₙ) (B⇒*Unit₂ , Unitₙ) of λ {
       (_ , PE.refl) →
     ⊩t }
-  convTermT₁ (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
+  convTermT₁ (ne (ne _ D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
              (neₜ k d (neNfₜ neK₂ ⊢k k≡k)) =
     let K≡K₁ = PE.subst (λ x → _ ⊢ _ ≡ x)
                         (whrDet* (red D′ , ne neM) (red D₁ , ne neK₁))
@@ -187,7 +187,7 @@ mutual
          whrDet* (red B⇒*Unit₁ , Unitₙ) (B⇒*Unit₂ , Unitₙ) of λ {
       (_ , PE.refl) →
     ⊩t }
-  convTermT₂ (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
+  convTermT₂ (ne (ne _ D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
              (neₜ k d (neNfₜ neK₂ ⊢k k≡k)) =
     let K₁≡K = PE.subst (λ x → _ ⊢ x ≡ _)
                         (whrDet* (red D′ , ne neM) (red D₁ , ne neK₁))
@@ -349,7 +349,7 @@ mutual
          whrDet* (red B⇒*Unit₁ , Unitₙ) (B⇒*Unit₂ , Unitₙ) of λ {
       (_ , PE.refl) →
     t≡u }
-  convEqTermT₁ (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
+  convEqTermT₁ (ne (ne _ D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
                (neₜ₌ k m d d′ (neNfₜ₌ neK₂ neM₁ k≡m)) =
     let K≡K₁ = PE.subst (λ x → _ ⊢ _ ≡ x)
                         (whrDet* (red D′ , ne neM) (red D₁ , ne neK₁))
@@ -513,7 +513,7 @@ mutual
          whrDet* (red B⇒*Unit₁ , Unitₙ) (B⇒*Unit₂ , Unitₙ) of λ {
       (_ , PE.refl) →
     t≡u }
-  convEqTermT₂ (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
+  convEqTermT₂ (ne (ne _ D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
                (neₜ₌ k m d d′ (neNfₜ₌ neK₂ neM₁ k≡m)) =
     let K₁≡K = PE.subst (λ x → _ ⊢ x ≡ _)
                         (whrDet* (red D′ , ne neM) (red D₁ , ne neK₁))

--- a/Definition/LogicalRelation/Properties/Escape.agda
+++ b/Definition/LogicalRelation/Properties/Escape.agda
@@ -46,7 +46,7 @@ escape (Uᵣ′ l′ l< [ ⊢A , ⊢B , D ]) = ⊢A
 escape (ℕᵣ [ ⊢A , ⊢B , D ]) = ⊢A
 escape (Emptyᵣ [ ⊢A , ⊢B , D ]) = ⊢A
 escape (Unitᵣ (Unitₜ [ ⊢A , ⊢B , D ] _)) = ⊢A
-escape (ne′ K [ ⊢A , ⊢B , D ] neK K≡K) = ⊢A
+escape (ne′ _ [ ⊢A , ⊢B , D ] neK K≡K) = ⊢A
 escape (Bᵣ′ _ _ _ [ ⊢A , _ , _ ] _ _ _ _ _ _ _) = ⊢A
 escape (Idᵣ ⊩A) = ⊢A-red (_⊩ₗId_.⇒*Id ⊩A)
 escape (emb ≤ᵘ-refl A) = escape A
@@ -64,7 +64,7 @@ escapeTerm (Emptyᵣ D) (Emptyₜ e [ ⊢t , ⊢u , d ] t≡t prop) =
   conv ⊢t (sym (subset* (red D)))
 escapeTerm (Unitᵣ (Unitₜ D _)) (Unitₜ e [ ⊢t , ⊢u , d ] _ prop) =
   conv ⊢t (sym (subset* (red D)))
-escapeTerm (ne′ K D neK K≡K) (neₜ k [ ⊢t , ⊢u , d ] nf) =
+escapeTerm (ne′ _ D neK K≡K) (neₜ k [ ⊢t , ⊢u , d ] nf) =
   conv ⊢t (sym (subset* (red D)))
 escapeTerm (Bᵣ′ BΠ! _ _ D _ _ _ _ _ _ _) (Πₜ _ [ ⊢t , _ , _ ] _ _ _ _) =
   conv ⊢t (sym (subset* (red D)))
@@ -113,7 +113,7 @@ escapeEq (Emptyᵣ [ ⊢A , ⊢B , D ]) D′ =
   ≅-red (D , Emptyₙ) (D′ , Emptyₙ) (≅-Emptyrefl (wf ⊢A))
 escapeEq (Unitᵣ (Unitₜ [ ⊢A , ⊢B , D ] ok)) D′ =
   ≅-red (D , Unitₙ) (D′ , Unitₙ) (≅-Unitrefl (wf ⊢A) ok)
-escapeEq (ne′ K D neK K≡K) (ne₌ M D′ neM K≡M) =
+escapeEq (ne′ _ D neK K≡K) (ne₌ M D′ neM K≡M) =
   ≅-red (red D , ne neK) (red D′ , ne neM) K≡M
 escapeEq (Bᵣ′ W _ _ D _ _ _ _ _ _ _) (B₌ _ _ D′ A≡B _ _) =
   ≅-red (red D , ⟦ W ⟧ₙ) (red D′ , ⟦ W ⟧ₙ) A≡B
@@ -140,7 +140,7 @@ escapeTermEq (Unitᵣ (Unitₜ D _)) (Unitₜ₌ˢ ⊢t ⊢u ok) =
 escapeTermEq (Unitᵣ (Unitₜ D _)) (Unitₜ₌ʷ _ _ d d′ k≡k′ prop _) =
   let whK , whK′ = usplit prop
   in  ≅ₜ-red (red D , Unitₙ) (redₜ d , whK) (redₜ d′ , whK′) k≡k′
-escapeTermEq (ne′ K D neK K≡K)
+escapeTermEq (ne′ _ D neK K≡K)
                  (neₜ₌ k m d d′ (neNfₜ₌ neT neU t≡u)) =
   ≅ₜ-red (red D , ne neK) (redₜ d , ne neT) (redₜ d′ , ne neU)
          (~-to-≅ₜ t≡u)

--- a/Definition/LogicalRelation/Properties/Neutral.agda
+++ b/Definition/LogicalRelation/Properties/Neutral.agda
@@ -54,7 +54,7 @@ neuEq′ : ∀ {l A B} ([A] : Γ ⊩⟨ l ⟩ne A)
        → Γ ⊢ B
        → Γ ⊢ A ≅ B
        → Γ ⊩⟨ l ⟩ A ≡ B / ne-intr [A]
-neuEq′ (noemb (ne K [ ⊢A , ⊢B , D ] neK K≡K)) neA neB B A~B =
+neuEq′ (noemb (ne _ [ ⊢A , ⊢B , D ] neK K≡K)) neA neB B A~B =
   let A≡K = whnfRed* D (ne neA)
   in  ne₌ _ (idRed:*: B) neB (PE.subst (λ x → _ ⊢ x ≅ _) A≡K A~B)
 neuEq′ (emb ≤ᵘ-refl x) neB A:≡:B = neuEq′ x neB A:≡:B
@@ -103,7 +103,7 @@ mutual
         n≡n′ = ~-to-≅ₜ n~n′
     in  Unitₜ _ (idRedTerm:*: (conv n A≡Unit)) n≡n′
               (ne (neNfₜ neN (conv n A≡Unit) n~n′))
-  neuTerm (ne′ K [ ⊢A , ⊢B , D ] neK K≡K) neN n n~n =
+  neuTerm (ne′ _ [ ⊢A , ⊢B , D ] neK K≡K) neN n n~n =
     let A≡K = subset* D
     in  neₜ _ (idRedTerm:*: (conv n A≡K)) (neNfₜ neN (conv n A≡K)
             (~-conv n~n A≡K))
@@ -240,7 +240,7 @@ mutual
                      (idRedTerm:*: (conv n′ A≡Unit)) n≡n′
                      (ne (neNfₜ₌ neN neN′ n~n′₁)) no-η)
             ]
-  neuEqTerm (ne (ne K [ ⊢A , ⊢B , D ] neK K≡K)) neN neN′ n n′ n~n′ =
+  neuEqTerm (ne (ne _ [ ⊢A , ⊢B , D ] neK K≡K)) neN neN′ n n′ n~n′ =
     let A≡K = subset* D
     in  neₜ₌ _ _ (idRedTerm:*: (conv n A≡K)) (idRedTerm:*: (conv n′ A≡K))
              (neNfₜ₌ neN neN′ (~-conv n~n′ A≡K))

--- a/Definition/LogicalRelation/Properties/Reduction.agda
+++ b/Definition/LogicalRelation/Properties/Reduction.agda
@@ -62,9 +62,9 @@ redSubst* D (Emptyᵣ [ ⊢B , ⊢Empty , D′ ]) =
 redSubst* D (Unitᵣ (Unitₜ [ ⊢B , ⊢Unit , D′ ] ok)) =
   let ⊢A = redFirst* D
   in  Unitᵣ (Unitₜ [ ⊢A , ⊢Unit , D ⇨* D′ ] ok) , D′
-redSubst* D (ne′ K [ ⊢B , ⊢K , D′ ] neK K≡K) =
+redSubst* D (ne′ _ [ ⊢B , ⊢K , D′ ] neK K≡K) =
   let ⊢A = redFirst* D
-  in  (ne′ K [ ⊢A , ⊢K , D ⇨* D′ ] neK K≡K)
+  in  (ne′ _ [ ⊢A , ⊢K , D ⇨* D′ ] neK K≡K)
   ,   (ne₌ _ [ ⊢B , ⊢K , D′ ] neK K≡K)
 redSubst*
   D (Bᵣ′ W F G D′@([ _ , ⊢ΠFG , D″ ]) ⊢F ⊢G A≡A [F] [G] G-ext ok) =
@@ -139,7 +139,7 @@ redSubst*Term
          (inj₂ (PE.refl , no-η)) →
            Unitₜ₌ʷ n n d′ [ ⊢u , ⊢n , d ] n≡n (reflUnitʷ-prop prop)
              no-η)
-redSubst*Term t⇒u (ne′ K D neK K≡K) (neₜ k [ ⊢t , ⊢u , d ] (neNfₜ neK₁ ⊢k k≡k)) =
+redSubst*Term t⇒u (ne′ _ D neK K≡K) (neₜ k [ ⊢t , ⊢u , d ] (neNfₜ neK₁ ⊢k k≡k)) =
   let A≡K  = subset* (red D)
       [d]  = [ ⊢t , ⊢u , d ]
       [d′] = [ conv (redFirst*Term t⇒u) A≡K , ⊢u , conv* t⇒u A≡K ⇨∷* d ]

--- a/Definition/LogicalRelation/Properties/Reflexivity.agda
+++ b/Definition/LogicalRelation/Properties/Reflexivity.agda
@@ -78,7 +78,7 @@ reflEq (Uᵣ′ l′ l< ⊢Γ) = ⊢Γ
 reflEq (ℕᵣ D) = red D
 reflEq (Emptyᵣ D) = red D
 reflEq (Unitᵣ (Unitₜ D _)) = red D
-reflEq (ne′ K [ ⊢A , ⊢B , D ] neK K≡K) =
+reflEq (ne′ _ [ ⊢A , ⊢B , D ] neK K≡K) =
    ne₌ _ [ ⊢A , ⊢B , D ] neK K≡K
 reflEq (Bᵣ′ _ _ _ D _ _ A≡A [F] [G] _ _) =
    B₌ _ _ D A≡A
@@ -110,7 +110,7 @@ reflEqTerm (Unitᵣ {s} D) (Unitₜ n [ ⊢t , ⊢u , d ] t≡t prop) =
     (inj₂ (PE.refl , no-η)) →
       Unitₜ₌ʷ n n [ ⊢t , ⊢u , d ] [ ⊢t , ⊢u , d ] t≡t
         (reflUnitʷ-prop prop) no-η
-reflEqTerm (ne′ K D neK K≡K) (neₜ k d (neNfₜ neK₁ ⊢k k≡k)) =
+reflEqTerm (ne′ _ D neK K≡K) (neₜ k d (neNfₜ neK₁ ⊢k k≡k)) =
   neₜ₌ k k d d (neNfₜ₌ neK₁ neK₁ k≡k)
 reflEqTerm
   (Bᵣ′ BΠ! _ _ _ _ _ _ [F] _ _ _) [t]@(Πₜ f d funcF f≡f [f] _) =

--- a/Definition/LogicalRelation/Properties/Symmetry.agda
+++ b/Definition/LogicalRelation/Properties/Symmetry.agda
@@ -89,7 +89,7 @@ symEqT (Unitᵥ (Unitₜ A⇒*Unit _) (Unitₜ B⇒*Unit₁ _)) B⇒*Unit₂ =
        whrDet* (red B⇒*Unit₁ , Unitₙ) (B⇒*Unit₂ , Unitₙ) of λ {
     (_ , PE.refl) →
   red A⇒*Unit }
-symEqT (ne (ne K D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
+symEqT (ne (ne _ D neK K≡K) (ne K₁ D₁ neK₁ K≡K₁)) (ne₌ M D′ neM K≡M)
        rewrite whrDet* (red D′ , ne neM) (red D₁ , ne neK₁) =
   ne₌ _ D neK
       (≅-sym K≡M)
@@ -169,7 +169,7 @@ symEqTerm (Unitᵣ _) (Unitₜ₌ˢ ⊢t ⊢u ok) =
   Unitₜ₌ˢ ⊢u ⊢t ok
 symEqTerm (Unitᵣ _) (Unitₜ₌ʷ k k′ d d′ k≡k′ prop ok) =
   Unitₜ₌ʷ k′ k d′ d (≅ₜ-sym k≡k′) (symUnit-prop prop) ok
-symEqTerm (ne′ K D neK K≡K) (neₜ₌ k m d d′ nf) =
+symEqTerm (ne′ _ D neK K≡K) (neₜ₌ k m d d′ nf) =
   neₜ₌ m k d′ d (symNeutralTerm nf)
 symEqTerm (Bᵣ′ BΠ! F G D ⊢F ⊢G A≡A [F] [G] G-ext _)
           (Πₜ₌ f g d d′ funcF funcG f≡g [f] [g] [f≡g]) =

--- a/Definition/LogicalRelation/Properties/Transitivity.agda
+++ b/Definition/LogicalRelation/Properties/Transitivity.agda
@@ -193,7 +193,7 @@ transEqT (Unitᵥ _ (Unitₜ B⇒*Unit₁ _) _) B⇒*Unit₂ C⇒*Unit =
        whrDet* (red B⇒*Unit₁ , Unitₙ) (B⇒*Unit₂ , Unitₙ) of λ {
     (_ , PE.refl) →
   C⇒*Unit }
-transEqT (ne (ne K [ ⊢A , ⊢B , D ] neK K≡K) (ne K₁ D₁ neK₁ _)
+transEqT (ne (ne _ [ ⊢A , ⊢B , D ] neK K≡K) (ne K₁ D₁ neK₁ _)
              (ne K₂ D₂ neK₂ _))
          (ne₌ M D′ neM K≡M) (ne₌ M₁ D″ neM₁ K≡M₁)
          rewrite whrDet* (red D₁ , ne neK₁) (red D′ , ne neM)
@@ -282,7 +282,7 @@ transEqTerm (Uᵣ′ l′ ≤ᵘ-refl D)
 transEqTerm (ℕᵣ D) [t≡u] [u≡v] = transEqTermℕ [t≡u] [u≡v]
 transEqTerm (Emptyᵣ D) [t≡u] [u≡v] = transEqTermEmpty [t≡u] [u≡v]
 transEqTerm (Unitᵣ D) [t≡u] [u≡v] = transEqTermUnit [t≡u] [u≡v]
-transEqTerm {n} (ne′ K D neK K≡K) (neₜ₌ k m d d′ (neNfₜ₌ neK₁ neM k≡m))
+transEqTerm {n} (ne′ _ D neK K≡K) (neₜ₌ k m d d′ (neNfₜ₌ neK₁ neM k≡m))
                               (neₜ₌ k₁ m₁ d₁ d″ (neNfₜ₌ neK₂ neM₁ k≡m₁)) =
   let k₁≡m = whrDet*Term (redₜ d₁ , ne neK₂) (redₜ d′ , ne neM)
   in  neₜ₌ k m₁ d d″

--- a/Definition/LogicalRelation/ShapeView.agda
+++ b/Definition/LogicalRelation/ShapeView.agda
@@ -118,7 +118,7 @@ U-elim′ A⇒U (Emptyᵣ D) with whrDet* (A⇒U , Uₙ) (red D , Emptyₙ)
 ... | ()
 U-elim′ A⇒U (Unitᵣ (Unitₜ D _)) with whrDet* (A⇒U , Uₙ) (red D , Unitₙ)
 ... | ()
-U-elim′ A⇒U (ne′ K D neK K≡K) =
+U-elim′ A⇒U (ne′ _ D neK K≡K) =
   ⊥-elim (U≢ne neK (whrDet* (A⇒U , Uₙ) (red D , ne neK)))
 U-elim′ A⇒U (Bᵣ′ W _ _ D _ _ _ _ _ _ _) =
   ⊥-elim (U≢B W (whrDet* (A⇒U , Uₙ) (red D , ⟦ W ⟧ₙ)))
@@ -136,7 +136,7 @@ U-elim ⊩U = U-elim′ (id (escape ⊩U)) ⊩U
 ℕ-elim′ D (Uᵣ′ l′ l< D') with whrDet* (D , ℕₙ) (red  D' , Uₙ)
 ... | ()
 ℕ-elim′ D (ℕᵣ D′) = noemb D′
-ℕ-elim′ D (ne′ K D′ neK K≡K) =
+ℕ-elim′ D (ne′ _ D′ neK K≡K) =
   ⊥-elim (ℕ≢ne neK (whrDet* (D , ℕₙ) (red D′ , ne neK)))
 ℕ-elim′ D (Bᵣ′ W _ _ D′ _ _ _ _ _ _ _) =
   ⊥-elim (ℕ≢B W (whrDet* (D , ℕₙ) (red D′ , ⟦ W ⟧ₙ)))
@@ -161,7 +161,7 @@ Empty-elim′ D (Emptyᵣ D′) = noemb D′
 Empty-elim′ D (Unitᵣ (Unitₜ D′ _))
   with whrDet* (D , Emptyₙ) (red D′ , Unitₙ)
 ... | ()
-Empty-elim′ D (ne′ K D′ neK K≡K) =
+Empty-elim′ D (ne′ _ D′ neK K≡K) =
   ⊥-elim (Empty≢ne neK (whrDet* (D , Emptyₙ) (red D′ , ne neK)))
 Empty-elim′ D (Bᵣ′ W _ _ D′ _ _ _ _ _ _ _) =
   ⊥-elim (Empty≢B W (whrDet* (D , Emptyₙ) (red D′ , ⟦ W ⟧ₙ)))
@@ -185,7 +185,7 @@ Unit-elim′ D (Unitᵣ (Unitₜ D′ ok))
 ... | PE.refl = noemb (Unitₜ D′ ok)
 Unit-elim′ D (Emptyᵣ D′) with whrDet* (D , Unitₙ) (red D′ , Emptyₙ)
 ... | ()
-Unit-elim′ D (ne′ K D′ neK K≡K) =
+Unit-elim′ D (ne′ _ D′ neK K≡K) =
   ⊥-elim (Unit≢ne neK (whrDet* (D , Unitₙ) (red D′ , ne neK)))
 Unit-elim′ D (Bᵣ′ W _ _ D′ _ _ _ _ _ _ _) =
   ⊥-elim (Unit≢B W (whrDet* (D , Unitₙ) (red D′ , ⟦ W ⟧ₙ)))
@@ -208,7 +208,7 @@ ne-elim′ D neK (ℕᵣ D′) = ⊥-elim (ℕ≢ne neK (whrDet* (red D′ , ℕ
 ne-elim′ D neK (Emptyᵣ D′) = ⊥-elim (Empty≢ne neK (whrDet* (red D′ , Emptyₙ) (D , ne neK)))
 ne-elim′ D neK (Unitᵣ (Unitₜ D′ _)) =
   ⊥-elim (Unit≢ne neK (whrDet* (red D′ , Unitₙ) (D , ne neK)))
-ne-elim′ D neK (ne′ K D′ neK′ K≡K) = noemb (ne K D′ neK′ K≡K)
+ne-elim′ D neK (ne′ _ D′ neK′ K≡K) = noemb (ne _ D′ neK′ K≡K)
 ne-elim′ D neK (Bᵣ′ W _ _ D′ _ _ _ _ _ _ _) =
   ⊥-elim (B≢ne W neK (whrDet* (red D′ , ⟦ W ⟧ₙ) (D , ne neK)))
 ne-elim′ A⇒*ne n (Idᵣ ⊩A) =
@@ -229,7 +229,7 @@ B-elim′ W D (Emptyᵣ D′) =
   ⊥-elim (Empty≢B W (whrDet* (red D′ , Emptyₙ) (D , ⟦ W ⟧ₙ)))
 B-elim′ W D (Unitᵣ (Unitₜ D′ _)) =
   ⊥-elim (Unit≢B W (whrDet* (red D′ , Unitₙ) (D , ⟦ W ⟧ₙ)))
-B-elim′ W D (ne′ K D′ neK K≡K) =
+B-elim′ W D (ne′ _ D′ neK K≡K) =
   ⊥-elim (B≢ne W neK (whrDet* (D , ⟦ W ⟧ₙ) (red D′ , ne neK)))
 B-elim′ BΠ! D (Bᵣ′ BΣ! _ _ D′ _ _ _ _ _ _ _)
   with whrDet* (D , ΠΣₙ) (red D′ , ΠΣₙ)
@@ -375,7 +375,7 @@ goodCases (Uᵣ _) (Emptyᵣ D') [ _ , _ , D ] with whrDet* (D , Uₙ) (red D' ,
 ... | ()
 goodCases (Uᵣ _) (Unitᵣ (Unitₜ D' _)) [ _ , _ , D ] with whrDet* (D , Uₙ) (red D' , Unitₙ)
 ... | ()
-goodCases (Uᵣ′ _ _ ⊢Γ) (ne′ K D' neK K≡K) [ _ , _ , D ] =
+goodCases (Uᵣ′ _ _ ⊢Γ) (ne′ _ D' neK K≡K) [ _ , _ , D ] =
   ⊥-elim (U≢ne neK (whrDet* ( D , Uₙ ) ( red D' , ne neK)))
 goodCases (Uᵣ′ _ _ _) (Bᵣ′ W _ _ D' _ _ _ _ _ _ _) [ _ , _ , D ] =
   ⊥-elim (U≢B W (whrDet* ( D , Uₙ ) ( red D' , ⟦ W ⟧ₙ )))
@@ -390,7 +390,7 @@ goodCases (ℕᵣ _) (Emptyᵣ D') D with whrDet* (D , ℕₙ) (red D' , Empty�
 goodCases (ℕᵣ x) (Unitᵣ (Unitₜ D' _)) D
   with whrDet* (D , ℕₙ) (red D' , Unitₙ)
 ... | ()
-goodCases (ℕᵣ D) (ne′ K D₁ neK K≡K) A≡B =
+goodCases (ℕᵣ D) (ne′ _ D₁ neK K≡K) A≡B =
   ⊥-elim (ℕ≢ne neK (whrDet* (A≡B , ℕₙ) (red D₁ , ne neK)))
 goodCases (ℕᵣ _) (Bᵣ′ W _ _ D _ _ _ _ _ _ _) A≡B =
   ⊥-elim (ℕ≢B W (whrDet* (A≡B , ℕₙ) (red D , ⟦ W ⟧ₙ)))
@@ -405,7 +405,7 @@ goodCases (Emptyᵣ _) (Unitᵣ (Unitₜ D' _)) D
 ... | ()
 goodCases (Emptyᵣ _) (ℕᵣ D') D with whrDet* (red D' , ℕₙ) (D , Emptyₙ)
 ... | ()
-goodCases (Emptyᵣ D) (ne′ K D₁ neK K≡K) A≡B =
+goodCases (Emptyᵣ D) (ne′ _ D₁ neK K≡K) A≡B =
   ⊥-elim (Empty≢ne neK (whrDet* (A≡B , Emptyₙ) (red D₁ , ne neK)))
 goodCases (Emptyᵣ _) (Bᵣ′ W _ _ D _ _ _ _ _ _ _) A≡B =
   ⊥-elim (Empty≢B W (whrDet* (A≡B , Emptyₙ) (red D , ⟦ W ⟧ₙ)))
@@ -419,7 +419,7 @@ goodCases (Unitᵣ _) (Emptyᵣ D') D with whrDet* (red D' , Emptyₙ) (D , Unit
 ... | ()
 goodCases (Unitᵣ _) (ℕᵣ D') D with whrDet* (red D' , ℕₙ) (D , Unitₙ)
 ... | ()
-goodCases (Unitᵣ D) (ne′ K D₁ neK K≡K) A≡B =
+goodCases (Unitᵣ D) (ne′ _ D₁ neK K≡K) A≡B =
   ⊥-elim (Unit≢ne neK (whrDet* (A≡B , Unitₙ) (red D₁ , ne neK)))
 goodCases (Unitᵣ _) (Bᵣ′ W _ _ D _ _ _ _ _ _ _) A≡B =
   ⊥-elim (Unit≢B W (whrDet* (A≡B , Unitₙ) (red D , ⟦ W ⟧ₙ)))
@@ -427,13 +427,13 @@ goodCases (Unitᵣ _) (Idᵣ ⊩B) ⇒*Unit =
   case whrDet* (⇒*Unit , Unitₙ) (red (_⊩ₗId_.⇒*Id ⊩B) , Idₙ) of λ ()
 
 -- ne ≡ _
-goodCases (ne′ K D neK K≡K) (Uᵣ (Uᵣ _ _ D')) (ne₌ M D′ neM K≡M) =
+goodCases (ne′ _ D neK K≡K) (Uᵣ (Uᵣ _ _ D')) (ne₌ M D′ neM K≡M) =
   ⊥-elim (U≢ne neM (whrDet* (red D' , Uₙ) (red D′ , ne neM)))
-goodCases (ne′ K D neK K≡K) (ℕᵣ D₁) (ne₌ M D′ neM K≡M) =
+goodCases (ne′ _ D neK K≡K) (ℕᵣ D₁) (ne₌ M D′ neM K≡M) =
   ⊥-elim (ℕ≢ne neM (whrDet* (red D₁ , ℕₙ) (red D′ , ne neM)))
-goodCases (ne′ K D neK K≡K) (Emptyᵣ D₁) (ne₌ M D′ neM K≡M) =
+goodCases (ne′ _ D neK K≡K) (Emptyᵣ D₁) (ne₌ M D′ neM K≡M) =
   ⊥-elim (Empty≢ne neM (whrDet* (red D₁ , Emptyₙ) (red D′ , ne neM)))
-goodCases (ne′ K D neK K≡K) (Unitᵣ (Unitₜ D₁ _)) (ne₌ M D′ neM K≡M) =
+goodCases (ne′ _ D neK K≡K) (Unitᵣ (Unitₜ D₁ _)) (ne₌ M D′ neM K≡M) =
   ⊥-elim (Unit≢ne neM (whrDet* (red D₁ , Unitₙ) (red D′ , ne neM)))
 goodCases (ne′ _ _ _ _) (Bᵣ′ W _ _ D₁ _ _ _ _ _ _ _) (ne₌ _ D₂ neM _) =
   ⊥-elim (B≢ne W neM (whrDet* (red D₁ , ⟦ W ⟧ₙ) (red D₂ , ne neM)))
@@ -453,7 +453,7 @@ goodCases (Bᵣ W x) (Emptyᵣ D₁) (B₌ F′ G′ D′ A≡B [F≡F′] [G≡
 goodCases
   (Bᵣ W x) (Unitᵣ (Unitₜ D₁ _)) (B₌ F′ G′ D′ A≡B [F≡F′] [G≡G′]) =
   ⊥-elim (Unit≢B W (whrDet* (red D₁ , Unitₙ) (red D′ , ⟦ W ⟧ₙ)))
-goodCases (Bᵣ W x) (ne′ K D neK K≡K) (B₌ F′ G′ D′ A≡B [F≡F′] [G≡G′]) =
+goodCases (Bᵣ W x) (ne′ _ D neK K≡K) (B₌ F′ G′ D′ A≡B [F≡F′] [G≡G′]) =
   ⊥-elim (B≢ne W neK (whrDet* (red D′ , ⟦ W ⟧ₙ) (red D , ne neK)))
 goodCases (Bᵣ′ BΠ! _ _ _ _ _ _ _ _ _ _)
           (Bᵣ′ BΣ! _ _ D₁ _ _ _ _ _ _ _)
@@ -568,7 +568,7 @@ combine (Uᵥ UA (Uᵣ _ _ ⇒*U)) (Emptyᵥ EA EB) with whrDet* (red ⇒*U , U�
 ... | ()
 combine (Uᵥ UA (Uᵣ _ _ ⇒*U)) (Unitᵥ (Unitₜ UnA _) UnB) with whrDet* (red ⇒*U , Uₙ) (red UnA , Unitₙ)
 ... | ()
-combine (Uᵥ UA (Uᵣ _ _ ⇒*U)) (ne (ne K D neK K≡K) neB) =
+combine (Uᵥ UA (Uᵣ _ _ ⇒*U)) (ne (ne _ D neK K≡K) neB) =
   ⊥-elim (U≢ne neK (whrDet* (red ⇒*U , Uₙ) (red D , ne neK)))
 combine (Uᵥ UA (Uᵣ _ _ ⇒*U)) (Bᵥ W (Bᵣ _ _ D _ _ _ _ _ _ _) _) =
   ⊥-elim (U≢B W (whrDet* (red ⇒*U , Uₙ) (red D , ⟦ W ⟧ₙ)))
@@ -583,7 +583,7 @@ combine (ℕᵥ ℕA ℕB) (Emptyᵥ EmptyA EmptyB) with whrDet* (red ℕB , ℕ
 combine (ℕᵥ ℕA ℕB) (Unitᵥ (Unitₜ UnA _) UnB)
   with whrDet* (red ℕB , ℕₙ) (red UnA , Unitₙ)
 ... | ()
-combine (ℕᵥ ℕA ℕB) (ne (ne K D neK K≡K) neB) =
+combine (ℕᵥ ℕA ℕB) (ne (ne _ D neK K≡K) neB) =
   ⊥-elim (ℕ≢ne neK (whrDet* (red ℕB , ℕₙ) (red D , ne neK)))
 combine (ℕᵥ _ ℕB) (Bᵥ W (Bᵣ _ _ D _ _ _ _ _ _ _) _) =
   ⊥-elim (ℕ≢B W (whrDet* (red ℕB , ℕₙ) (red D , ⟦ W ⟧ₙ)))
@@ -598,7 +598,7 @@ combine (Emptyᵥ EmptyA EmptyB) (ℕᵥ ℕA ℕB) with whrDet* (red EmptyB , E
 combine (Emptyᵥ EmptyA EmptyB) (Unitᵥ (Unitₜ UnA _) UnB)
   with whrDet* (red EmptyB , Emptyₙ) (red UnA , Unitₙ)
 ... | ()
-combine (Emptyᵥ EmptyA EmptyB) (ne (ne K D neK K≡K) neB) =
+combine (Emptyᵥ EmptyA EmptyB) (ne (ne _ D neK K≡K) neB) =
   ⊥-elim (Empty≢ne neK (whrDet* (red EmptyB , Emptyₙ) (red D , ne neK)))
 combine
   (Emptyᵥ _ EmptyB) (Bᵥ W (Bᵣ _ _ D _ _ _ _ _ _ _) _) =
@@ -615,7 +615,7 @@ combine (Unitᵥ UnitA (Unitₜ UnitB _)) (ℕᵥ ℕA ℕB)
 combine (Unitᵥ UnitA (Unitₜ UnitB _)) (Emptyᵥ EmptyA EmptyB)
   with whrDet* (red UnitB , Unitₙ) (red EmptyA , Emptyₙ)
 ... | ()
-combine (Unitᵥ UnitA (Unitₜ UnitB _)) (ne (ne K D neK K≡K) neB) =
+combine (Unitᵥ UnitA (Unitₜ UnitB _)) (ne (ne _ D neK K≡K) neB) =
   ⊥-elim (Unit≢ne neK (whrDet* (red UnitB , Unitₙ) (red D , ne neK)))
 combine (Unitᵥ _ (Unitₜ UnitB _)) (Bᵥ W (Bᵣ _ _ D _ _ _ _ _ _ _) _) =
   ⊥-elim (Unit≢B W (whrDet* (red UnitB , Unitₙ) (red D , ⟦ W ⟧ₙ)))
@@ -627,13 +627,13 @@ combine (Unitᵥ _ ⊩B) (Idᵥ ⊩B′ _) =
   of λ ()
 
 -- ne ≡ _
-combine (ne neA (ne K D neK K≡K)) (Uᵥ (Uᵣ _ _ ⇒*U) UB) =
+combine (ne neA (ne _ D neK K≡K)) (Uᵥ (Uᵣ _ _ ⇒*U) UB) =
   ⊥-elim (U≢ne neK (whrDet* (red ⇒*U , Uₙ) (red D , ne neK)))
-combine (ne neA (ne K D neK K≡K)) (ℕᵥ ℕA ℕB) =
+combine (ne neA (ne _ D neK K≡K)) (ℕᵥ ℕA ℕB) =
   ⊥-elim (ℕ≢ne neK (whrDet* (red ℕA , ℕₙ) (red D , ne neK)))
-combine (ne neA (ne K D neK K≡K)) (Emptyᵥ EmptyA EmptyB) =
+combine (ne neA (ne _ D neK K≡K)) (Emptyᵥ EmptyA EmptyB) =
   ⊥-elim (Empty≢ne neK (whrDet* (red EmptyA , Emptyₙ) (red D , ne neK)))
-combine (ne neA (ne K D neK K≡K)) (Unitᵥ (Unitₜ UnA _) UnB) =
+combine (ne neA (ne _ D neK K≡K)) (Unitᵥ (Unitₜ UnA _) UnB) =
   ⊥-elim (Unit≢ne neK (whrDet* (red UnA , Unitₙ) (red D , ne neK)))
 combine (ne _ (ne _ D neK _)) (Bᵥ W (Bᵣ _ _ D′ _ _ _ _ _ _ _) _) =
   ⊥-elim (B≢ne W neK (whrDet* (red D′ , ⟦ W ⟧ₙ) (red D , ne neK)))

--- a/Definition/LogicalRelation/Weakening.agda
+++ b/Definition/LogicalRelation/Weakening.agda
@@ -161,8 +161,8 @@ wk ρ ⊢Δ (ℕᵣ D) = ℕᵣ (wkRed:*: ρ ⊢Δ D)
 wk ρ ⊢Δ (Emptyᵣ D) = Emptyᵣ (wkRed:*: ρ ⊢Δ D)
 wk ρ ⊢Δ (Unitᵣ (Unitₜ D ok)) =
   Unitᵣ (Unitₜ (wkRed:*: ρ ⊢Δ D) ok)
-wk {ρ = ρ} [ρ] ⊢Δ (ne′ K D neK K≡K) =
-  ne′ (U.wk ρ K) (wkRed:*: [ρ] ⊢Δ D) (wkNeutral ρ neK) (≅-wk [ρ] ⊢Δ K≡K)
+wk {ρ = ρ} [ρ] ⊢Δ (ne′ _ D neK K≡K) =
+  ne′ (U.wk ρ _) (wkRed:*: [ρ] ⊢Δ D) (wkNeutral ρ neK) (≅-wk [ρ] ⊢Δ K≡K)
 wk
   {m = m} {Δ = Δ} {Γ = Γ} {l = l} {A = A} {ρ = ρ} [ρ] ⊢Δ
   (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext ok) =
@@ -329,7 +329,7 @@ wkTerm {ρ = ρ} [ρ] ⊢Δ (Uᵣ′ l ≤ᵘ-refl D) (Uₜ A d typeA A≡A [t])
 wkTerm ρ ⊢Δ (ℕᵣ D) [t] = wkTermℕ ρ ⊢Δ [t]
 wkTerm ρ ⊢Δ (Emptyᵣ D) [t] = wkTermEmpty ρ ⊢Δ [t]
 wkTerm ρ ⊢Δ (Unitᵣ (Unitₜ D _)) [t] = wkTermUnit ρ ⊢Δ [t]
-wkTerm {ρ = ρ} [ρ] ⊢Δ (ne′ K D neK K≡K) (neₜ k d nf) =
+wkTerm {ρ = ρ} [ρ] ⊢Δ (ne′ _ D neK K≡K) (neₜ k d nf) =
   neₜ (U.wk ρ k) (wkRed:*:Term [ρ] ⊢Δ d) (wkTermNe [ρ] ⊢Δ nf)
 wkTerm
   {ρ = ρ} [ρ] ⊢Δ (Πᵣ′ F G D ⊢F ⊢G A≡A [F] [G] G-ext _)
@@ -464,7 +464,7 @@ wkEqTerm
 wkEqTerm ρ ⊢Δ (ℕᵣ D) [t≡u] = wkEqTermℕ ρ ⊢Δ [t≡u]
 wkEqTerm ρ ⊢Δ (Emptyᵣ D) [t≡u] = wkEqTermEmpty ρ ⊢Δ [t≡u]
 wkEqTerm ρ ⊢Δ (Unitᵣ (Unitₜ D _)) [t≡u] = wkEqTermUnit ρ ⊢Δ [t≡u]
-wkEqTerm {ρ  = ρ} [ρ] ⊢Δ (ne′ K D neK K≡K) (neₜ₌ k m d d′ nf) =
+wkEqTerm {ρ  = ρ} [ρ] ⊢Δ (ne′ _ D neK K≡K) (neₜ₌ k m d d′ nf) =
   neₜ₌ (U.wk ρ k) (U.wk ρ m)
        (wkRed:*:Term [ρ] ⊢Δ d) (wkRed:*:Term [ρ] ⊢Δ d′)
        (wkEqTermNe [ρ] ⊢Δ nf)

--- a/Definition/Untyped.agda
+++ b/Definition/Untyped.agda
@@ -38,6 +38,101 @@ infix 25 _[_]↑
 infix 25 _[_,_]₁₀
 infix 25 _[_]↑²
 
+------------------------------------------------------------------------
+-- The syntax
+
+-- The type of terms is parametrised by the number of free variables.
+-- Variables are de Bruijn indices.
+
+data Term (n : Nat) : Set a where
+  var : (x : Fin n) → Term n
+  U : Universe-level → Term n
+  ΠΣ⟨_⟩_,_▷_▹_ : (b : BinderMode) (p q : M) (A : Term n)
+               (B : Term (1+ n)) → Term n
+  lam : (p : M) (t : Term (1+ n)) → Term n
+  _∘⟨_⟩_ : (t : Term n) (p : M) (u : Term n) → Term n
+  prod : Strength → (p : M) (t u : Term n) → Term n
+  fst : (p : M) (t : Term n) → Term n
+  snd : (p : M) (t : Term n) → Term n
+  prodrec : (r p q : M) (A : Term (1+ n)) (t : Term n)
+            (u : Term (2+ n)) → Term n
+  ℕ : Term n
+  zero : Term n
+  suc : (t : Term n) → Term n
+  natrec : (p q r : M) (A : Term (1+ n)) (z : Term n)
+           (s : Term (2+ n)) (t : Term n) → Term n
+  Unit : Strength → Universe-level → Term n
+  star : Strength → Universe-level → Term n
+  unitrec : Universe-level → (p q : M) (A : Term (1+ n))
+            (t u : Term n) → Term n
+  Empty : Term n
+  emptyrec : (p : M) (A t : Term n) → Term n
+  Id : (A t u : Term n) → Term n
+  rfl : Term n
+  J : (p q : M) (A t : Term n) (B : Term (2+ n)) (u v w : Term n) →
+      Term n
+  K : (p : M) (A t : Term n) (B : Term (1+ n)) (u v : Term n) →
+      Term n
+  []-cong : Strength → (A t u v : Term n) → Term n
+
+pattern Unit! = Unit _ _
+pattern Unitʷ l = Unit 𝕨 l
+pattern Unitˢ l = Unit 𝕤 l
+
+pattern Π_,_▷_▹_ p q F G = ΠΣ⟨ BMΠ ⟩ p , q ▷ F ▹ G
+pattern Σˢ_,_▷_▹_ p q F G = ΠΣ⟨ BMΣ 𝕤 ⟩ p , q ▷ F ▹ G
+pattern Σʷ_,_▷_▹_ p q F G = ΠΣ⟨ BMΣ 𝕨 ⟩ p , q ▷ F ▹ G
+pattern Σ_,_▷_▹_ p q F G = ΠΣ⟨ BMΣ _ ⟩ p , q ▷ F ▹ G
+pattern Σ⟨_⟩_,_▷_▹_ s p q F G = ΠΣ⟨ BMΣ s ⟩ p , q ▷ F ▹ G
+
+pattern _∘_ t u = t ∘⟨ _ ⟩ u
+
+pattern prodˢ p t u = prod 𝕤 p t u
+pattern prodʷ p t u = prod 𝕨 p t u
+pattern prod! t u = prod _ _ t u
+
+pattern star! = star _ _
+pattern starʷ l = star 𝕨 l
+pattern starˢ l = star 𝕤 l
+
+pattern []-cong! A t u v = []-cong _ A t u v
+pattern []-congʷ A t u v = []-cong 𝕨 A t u v
+pattern []-congˢ A t u v = []-cong 𝕤 A t u v
+
+private variable
+  t : Term _
+
+-- Type constructors.
+
+data BindingType : Set a where
+  BM : BinderMode → (p q : M) → BindingType
+
+pattern BΠ p q = BM BMΠ p q
+pattern BΠ! = BΠ _ _
+pattern BΣ s p q = BM (BMΣ s) p q
+pattern BΣ! = BΣ _ _ _
+pattern BΣʷ = BΣ 𝕨 _ _
+pattern BΣˢ = BΣ 𝕤 _ _
+
+⟦_⟧_▹_ : BindingType → Term n → Term (1+ n) → Term n
+⟦ BM b p q ⟧ A ▹ B = ΠΣ⟨ b ⟩ p , q ▷ A ▹ B
+
+-- Fully normalized natural numbers
+
+data Numeral {n : Nat} : Term n → Set a where
+  zeroₙ : Numeral zero
+  sucₙ : Numeral t → Numeral (suc t)
+
+-- The canonical term corresponding to the given natural number.
+
+sucᵏ : (k : Nat) → Term n
+sucᵏ 0      = zero
+sucᵏ (1+ n) = suc (sucᵏ n)
+
+------------------------------------------------------------------------
+-- An alternative syntax representation
+
+
 -- Kinds are indexed by a list of natural numbers specifying
 -- the number of sub-terms (the length of the list) and the
 -- number of new variables bound by each sub-term (each element
@@ -74,121 +169,182 @@ data Kind : (ns : List Nat) → Set a where
   Kkind       : M → Kind (0 ∷ 0 ∷ 1 ∷ 0 ∷ 0 ∷ [])
   Boxcongkind : Strength → Kind (0 ∷ 0 ∷ 0 ∷ 0 ∷ [])
 
--- The type of terms is parametrised by the number of free variables.
--- A term is either a variable (a de Bruijn index) or a generic term,
--- consisting of a kind and a list of sub-terms.
+-- In the alternative term representations, a term is either a
+-- variable (de Bruijn index) or a "generic"
+
+-- The alternative term representation is parametrised by the number of
+-- free variables. A term is either a variable (a de Bruijn index) or a
+-- generic term, consisting of a kind and a list of sub-terms.
 --
 -- A term (gen k (n₁ ∷ … ∷ nₘ)) consists of m sub-terms (possibly zero)
--- each binding nᵢ variables.
+-- with sub-term i binding nᵢ variables.
 
-data Term (n : Nat) : Set a where
-  var : (x : Fin n) → Term n
-  gen : {bs : List Nat} (k : Kind bs) (ts : GenTs Term n bs) → Term n
+data Term′ (n : Nat) : Set a where
+  var : (x : Fin n) → Term′ n
+  gen : {bs : List Nat} (k : Kind bs) (ts : GenTs Term′ n bs) → Term′ n
 
 private variable
-  t    : Term n
   k k′ : Kind _
 
--- The Grammar of our language.
+-- Converting from the alternative syntax.
 
--- We represent the expressions of our language as de Bruijn terms.
--- Variables are natural numbers interpreted as de Bruijn indices.
--- Π, lam, and natrec are binders.
+toTerm : Term′ n → Term n
+toTerm (var x) =
+  var x
+toTerm (gen (Ukind l) []) =
+  U l
+toTerm (gen (Binderkind b p q) (A ∷ₜ B ∷ₜ [])) =
+  ΠΣ⟨ b ⟩ p , q ▷ (toTerm A) ▹ (toTerm B)
+toTerm (gen (Lamkind p) (t ∷ₜ [])) =
+  lam p (toTerm t)
+toTerm (gen (Appkind p) (t ∷ₜ u ∷ₜ [])) =
+  toTerm t ∘⟨ p ⟩ toTerm u
+toTerm (gen (Prodkind s p) (t ∷ₜ u ∷ₜ [])) =
+  prod s p (toTerm t) (toTerm u)
+toTerm (gen (Fstkind p) (t ∷ₜ [])) =
+  fst p (toTerm t)
+toTerm (gen (Sndkind p) (t ∷ₜ [])) =
+  snd p (toTerm t)
+toTerm (gen (Prodreckind r p q) (A ∷ₜ t ∷ₜ u ∷ₜ [])) =
+  prodrec r p q (toTerm A) (toTerm t) (toTerm u)
+toTerm (gen Natkind []) =
+  ℕ
+toTerm (gen Zerokind []) =
+  zero
+toTerm (gen Suckind (t ∷ₜ [])) =
+  suc (toTerm t)
+toTerm (gen (Natreckind p q r) (A ∷ₜ z ∷ₜ s ∷ₜ n ∷ₜ [])) =
+  natrec p q r (toTerm A) (toTerm z) (toTerm s) (toTerm n)
+toTerm (gen (Unitkind s l) []) =
+  Unit s l
+toTerm (gen (Starkind s l) []) =
+  star s l
+toTerm (gen (Unitreckind l p q) (A ∷ₜ t ∷ₜ u ∷ₜ [])) =
+  unitrec l p q (toTerm A) (toTerm t) (toTerm u)
+toTerm (gen Emptykind []) =
+  Empty
+toTerm (gen (Emptyreckind p) (A ∷ₜ t ∷ₜ [])) =
+  emptyrec p (toTerm A) (toTerm t)
+toTerm (gen Idkind (A ∷ₜ t ∷ₜ u ∷ₜ [])) =
+  Id (toTerm A) (toTerm t) (toTerm u)
+toTerm (gen Reflkind []) =
+  rfl
+toTerm (gen (Jkind p q) (A ∷ₜ t ∷ₜ B ∷ₜ u ∷ₜ v ∷ₜ w ∷ₜ [])) =
+  J p q (toTerm A) (toTerm t) (toTerm B) (toTerm u) (toTerm v) (toTerm w)
+toTerm (gen (Kkind p) (A ∷ₜ t ∷ₜ B ∷ₜ u ∷ₜ v ∷ₜ [])) =
+  K p (toTerm A) (toTerm t) (toTerm B) (toTerm u) (toTerm v)
+toTerm (gen (Boxcongkind s) (A ∷ₜ t ∷ₜ u ∷ₜ v ∷ₜ [])) =
+  []-cong s (toTerm A) (toTerm t) (toTerm u) (toTerm v)
 
--- Type constructors.
-pattern U n = gen (Ukind n) []
-pattern ℕ = gen Natkind []
-pattern Empty = gen Emptykind []
-pattern Unit! = gen (Unitkind _ _) []
-pattern Unit s l = gen (Unitkind s l) []
-pattern Unitʷ l = gen (Unitkind 𝕨 l) []
-pattern Unitˢ l = gen (Unitkind 𝕤 l) []
+-- Converting to the alternative syntax.
 
-pattern ΠΣ⟨_⟩_,_▷_▹_ b p q F G = gen (Binderkind b p q) (F ∷ₜ G ∷ₜ [])
-pattern Π_,_▷_▹_ p q F G = gen (Binderkind BMΠ p q) (F ∷ₜ G ∷ₜ [])
-pattern Σˢ_,_▷_▹_ p q F G = gen (Binderkind (BMΣ 𝕤) p q) (F ∷ₜ G ∷ₜ [])
-pattern Σʷ_,_▷_▹_ p q F G = gen (Binderkind (BMΣ 𝕨) p q) (F ∷ₜ G ∷ₜ [])
-pattern Σ_,_▷_▹_ p q F G = gen (Binderkind (BMΣ _) p q) (F ∷ₜ G ∷ₜ [])
-pattern Σ⟨_⟩_,_▷_▹_ s p q F G =
-  gen (Binderkind (BMΣ s) p q) (F ∷ₜ G ∷ₜ [])
-
-pattern lam p t = gen (Lamkind p) (t ∷ₜ [])
-pattern _∘⟨_⟩_ t p u = gen (Appkind p) (t ∷ₜ u ∷ₜ [])
-pattern _∘_ t u = gen (Appkind _) (t ∷ₜ u ∷ₜ [])
-
-pattern prodˢ p t u = gen (Prodkind 𝕤 p) (t ∷ₜ u ∷ₜ [])
-pattern prodʷ p t u = gen (Prodkind 𝕨 p) (t ∷ₜ u ∷ₜ [])
-pattern prod m p t u = gen (Prodkind m p) (t ∷ₜ u ∷ₜ [])
-pattern prod! t u = gen (Prodkind _ _) (t ∷ₜ u ∷ₜ [])
-pattern fst p t = gen (Fstkind p) (t ∷ₜ [])
-pattern snd p t = gen (Sndkind p) (t ∷ₜ [])
-pattern prodrec r p q A t u =
-  gen (Prodreckind r p q) (A ∷ₜ t ∷ₜ u ∷ₜ [])
-
-pattern zero = gen Zerokind []
-pattern suc t = gen Suckind (t ∷ₜ [])
-pattern natrec p q r A z s n =
-  gen (Natreckind p q r) (A ∷ₜ z ∷ₜ s ∷ₜ n ∷ₜ [])
-
-pattern star! = gen (Starkind _ _) []
-pattern star s l = gen (Starkind s l) []
-pattern starʷ l = gen (Starkind 𝕨 l) []
-pattern starˢ l = gen (Starkind 𝕤 l) []
-pattern unitrec l p q A t u =
-  gen (Unitreckind l p q) (A ∷ₜ t ∷ₜ u ∷ₜ [])
-pattern emptyrec p A t = gen (Emptyreckind p) (A ∷ₜ t ∷ₜ [])
-
-pattern Id A t u = gen Idkind (A ∷ₜ t ∷ₜ u ∷ₜ [])
-pattern rfl = gen Reflkind []
-pattern J p q A t B u v w =
-  gen (Jkind p q) (A ∷ₜ t ∷ₜ B ∷ₜ u ∷ₜ v ∷ₜ w ∷ₜ [])
-pattern K p A t B u v = gen (Kkind p) (A ∷ₜ t ∷ₜ B ∷ₜ u ∷ₜ v ∷ₜ [])
-pattern []-cong! A t u v = gen (Boxcongkind _) (A ∷ₜ t ∷ₜ u ∷ₜ v ∷ₜ [])
-pattern []-cong m A t u v = gen (Boxcongkind m) (A ∷ₜ t ∷ₜ u ∷ₜ v ∷ₜ [])
-pattern []-congʷ A t u v = gen (Boxcongkind 𝕨) (A ∷ₜ t ∷ₜ u ∷ₜ v ∷ₜ [])
-pattern []-congˢ A t u v = gen (Boxcongkind 𝕤) (A ∷ₜ t ∷ₜ u ∷ₜ v ∷ₜ [])
-
-
-data BindingType : Set a where
-  BM : BinderMode → (p q : M) → BindingType
-
-pattern BΠ p q = BM BMΠ p q
-pattern BΠ! = BΠ _ _
-pattern BΣ s p q = BM (BMΣ s) p q
-pattern BΣ! = BΣ _ _ _
-pattern BΣʷ = BΣ 𝕨 _ _
-pattern BΣˢ = BΣ 𝕤 _ _
-
-⟦_⟧_▹_ : BindingType → Term n → Term (1+ n) → Term n
-⟦ BM b p q ⟧ A ▹ B = ΠΣ⟨ b ⟩ p , q ▷ A ▹ B
-
--- Fully normalized natural numbers
-
-data Numeral {n : Nat} : Term n → Set a where
-  zeroₙ : Numeral zero
-  sucₙ : Numeral t → Numeral (suc t)
-
--- The canonical term corresponding to the given natural number.
-
-sucᵏ : (k : Nat) → Term n
-sucᵏ 0      = zero
-sucᵏ (1+ n) = suc (sucᵏ n)
+fromTerm : Term n → Term′ n
+fromTerm (var x) =
+  var x
+fromTerm (U l) =
+  gen (Ukind l) []
+fromTerm (ΠΣ⟨ b ⟩ p , q ▷ A ▹ B) =
+  gen (Binderkind b p q) (fromTerm A ∷ₜ fromTerm B ∷ₜ [])
+fromTerm (lam p t) =
+  gen (Lamkind p) (fromTerm t ∷ₜ [])
+fromTerm (t ∘⟨ p ⟩ u) =
+  gen (Appkind p) (fromTerm t ∷ₜ fromTerm u ∷ₜ [])
+fromTerm (prod s p t u) =
+  gen (Prodkind s p) (fromTerm t ∷ₜ fromTerm u ∷ₜ [])
+fromTerm (fst p t) =
+  gen (Fstkind p) (fromTerm t ∷ₜ [])
+fromTerm (snd p t) =
+  gen (Sndkind p) (fromTerm t ∷ₜ [])
+fromTerm (prodrec r p q A t u) =
+  gen (Prodreckind r p q)
+    (fromTerm A ∷ₜ fromTerm t ∷ₜ fromTerm u ∷ₜ [])
+fromTerm ℕ =
+  gen Natkind []
+fromTerm zero =
+  gen Zerokind []
+fromTerm (suc t) =
+  gen Suckind (fromTerm t ∷ₜ [])
+fromTerm (natrec p q r A z s n) =
+  gen (Natreckind p q r)
+    (fromTerm A ∷ₜ fromTerm z ∷ₜ fromTerm s ∷ₜ fromTerm n ∷ₜ [])
+fromTerm (Unit s l) =
+  gen (Unitkind s l) []
+fromTerm (star s l) =
+  gen (Starkind s l) []
+fromTerm (unitrec l p q A t u) =
+  gen (Unitreckind l p q)
+    (fromTerm A ∷ₜ fromTerm t ∷ₜ fromTerm u ∷ₜ [])
+fromTerm Empty =
+  gen Emptykind []
+fromTerm (emptyrec p A t) =
+  gen (Emptyreckind p) (fromTerm A ∷ₜ fromTerm t ∷ₜ [])
+fromTerm (Id A t u) =
+  gen Idkind (fromTerm A ∷ₜ fromTerm t ∷ₜ fromTerm u ∷ₜ [])
+fromTerm rfl =
+  gen Reflkind []
+fromTerm (J p q A t B u v w) =
+  gen (Jkind p q)
+    (fromTerm A ∷ₜ fromTerm t ∷ₜ fromTerm B ∷ₜ fromTerm u
+                ∷ₜ fromTerm v ∷ₜ fromTerm w ∷ₜ [])
+fromTerm (K p A t B u v) =
+  gen (Kkind p)
+    (fromTerm A ∷ₜ fromTerm t ∷ₜ fromTerm B
+                ∷ₜ fromTerm u ∷ₜ fromTerm v ∷ₜ [])
+fromTerm ([]-cong s A t u v) =
+  gen (Boxcongkind s)
+    (fromTerm A ∷ₜ fromTerm t ∷ₜ fromTerm u
+                ∷ₜ fromTerm v ∷ₜ [])
 
 ------------------------------------------------------------------------
 -- Weakening
 
-  -- Weakening of terms.
-  -- If η : Γ ≤ Δ and Δ ⊢ t : A then Γ ⊢ wk η t : wk η A.
+-- Weakening of terms.
+-- If η : Γ ≤ Δ and Δ ⊢ t : A then Γ ⊢ wk η t : wk η A.
+
+wk : (ρ : Wk m n) (t : Term n) → Term m
+wk ρ (var x) = var (wkVar ρ x)
+wk ρ (U l) = U l
+wk ρ (ΠΣ⟨ b ⟩ p , q ▷ A ▹ B) =
+  ΠΣ⟨ b ⟩ p , q ▷ wk ρ A ▹ wk (lift ρ) B
+wk ρ (lam p t) = lam p (wk (lift ρ) t)
+wk ρ (t ∘⟨ p ⟩ u) = wk ρ t ∘⟨ p ⟩ wk ρ u
+wk ρ (prod s p t u) = prod s p (wk ρ t) (wk ρ u)
+wk ρ (fst p t) = fst p (wk ρ t)
+wk ρ (snd p t) = snd p (wk ρ t)
+wk ρ (prodrec r p q A t u) =
+  prodrec r p q (wk (lift ρ) A) (wk ρ t) (wk (liftn ρ 2) u)
+wk ρ ℕ = ℕ
+wk ρ zero = zero
+wk ρ (suc t) = suc (wk ρ t)
+wk ρ (natrec p q r A z s n) =
+  natrec p q r (wk (lift ρ) A) (wk ρ z) (wk (liftn ρ 2) s) (wk ρ n)
+wk ρ (Unit s l) = Unit s l
+wk ρ (star s l) = star s l
+wk ρ (unitrec l p q A t u) =
+  unitrec l p q (wk (lift ρ) A) (wk ρ t) (wk ρ u)
+wk ρ Empty = Empty
+wk ρ (emptyrec p A t) = emptyrec p (wk ρ A) (wk ρ t)
+wk ρ (Id A t u) = Id (wk ρ A) (wk ρ t) (wk ρ u)
+wk ρ rfl = rfl
+wk ρ (J p q A t B u v w) =
+  J p q (wk ρ A) (wk ρ t) (wk (liftn ρ 2) B) (wk ρ u) (wk ρ v) (wk ρ w)
+wk ρ (K p A t B u v) =
+  K p (wk ρ A) (wk ρ t) (wk (lift ρ) B) (wk ρ u) (wk ρ v)
+wk ρ ([]-cong s A t u v) =
+  []-cong s (wk ρ A) (wk ρ t) (wk ρ u) (wk ρ v)
+
+-- Weakening for the alternative term representation.
 
 mutual
-  wkGen : {m n : Nat} {bs : List Nat} (ρ : Wk m n) (c : GenTs (Term) n bs) → GenTs (Term) m bs
+
+  wkGen : {m n : Nat} {bs : List Nat} (ρ : Wk m n)
+          (c : GenTs Term′ n bs) → GenTs Term′ m bs
   wkGen ρ []                 = []
-  wkGen ρ (_∷ₜ_ {b = b} t c) = wk (liftn ρ b) t ∷ₜ wkGen ρ c
+  wkGen ρ (_∷ₜ_ {b = b} t c) = wk′ (liftn ρ b) t ∷ₜ wkGen ρ c
 
-  wk : {m n : Nat} (ρ : Wk m n) (t : Term n) → Term m
-  wk ρ (var x)   = var (wkVar ρ x)
-  wk ρ (gen k c) = gen k (wkGen ρ c)
-
+  wk′ : (ρ : Wk m n) (t : Term′ n) → Term′ m
+  wk′ ρ (var x) = var (wkVar ρ x)
+  wk′ ρ (gen k ts) = gen k (wkGen ρ ts)
 
 -- Adding one variable to the context requires wk1.
 -- If Γ ⊢ t : B then Γ∙A ⊢ wk1 t : wk1 B.
@@ -216,14 +372,11 @@ wk3 = wk1 ∘→ wk2
 wk₃ : Term n → Term (3+ n)
 wk₃ = wk (step (step (step id)))
 
-
-
-
 ------------------------------------------------------------------------
 -- Substitution
 
--- The substitution operation t [ σ ] replaces the free de Bruijn indices
--- of term t by chosen terms as specified by σ.
+-- The substitution operation t [ σ ] replaces the free de Bruijn
+-- indices of term t by chosen terms as specified by σ.
 
 -- The substitution σ itself is a map from Fin n to terms.
 
@@ -302,6 +455,10 @@ liftSubstn σ (1+ n)   = liftSubst (liftSubstn σ n)
 _⇑ : Subst m n → Subst (1+ m) (1+ n)
 _⇑ = liftSubst
 
+-- A synonym of liftSubst ∘ liftSubst
+_⇑² : Subst m n → Subst (2+ m) (2+ n)
+_⇑² = flip liftSubstn 2
+
 -- Transform a weakening into a substitution.
 --
 -- If ρ : Γ ≤ Δ then Γ ⊢ toSubst ρ : Δ.
@@ -313,14 +470,49 @@ toSubst pr x = var (wkVar pr x)
 --
 -- If Γ ⊢ σ : Δ and Δ ⊢ t : A then Γ ⊢ t [ σ ] : A [ σ ].
 
-mutual
-  substGen : {bs : List Nat} (σ : Subst m n) (g : GenTs (Term) n bs) → GenTs (Term) m bs
-  substGen σ []              = []
-  substGen σ (_∷ₜ_ {b} t ts) = t [ liftSubstn σ b ] ∷ₜ substGen σ ts
+_[_] : (t : Term n) (σ : Subst m n) → Term m
+var x [ σ ] = σ x
+U l [ σ ] = U l
+ΠΣ⟨ b ⟩ p , q ▷ A ▹ B [ σ ] =
+  ΠΣ⟨ b ⟩ p , q ▷ A [ σ ] ▹ (B [ σ ⇑ ])
+lam p t [ σ ] = lam p (t [ σ ⇑ ])
+t ∘⟨ p ⟩ u [ σ ] = (t [ σ ]) ∘⟨ p ⟩ (u [ σ ])
+prod s p t u [ σ ] = prod s p (t [ σ ]) (u [ σ ])
+fst p t [ σ ] = fst p (t [ σ ])
+snd p t [ σ ] = snd p (t [ σ ])
+prodrec r p q A t u [ σ ] =
+  prodrec r p q (A [ σ ⇑ ]) (t [ σ ]) (u [ σ ⇑² ])
+ℕ [ σ ] = ℕ
+zero [ σ ] = zero
+suc t [ σ ] = suc (t [ σ ])
+natrec p q r A z s n [ σ ] =
+  natrec p q r (A [ σ ⇑ ]) (z [ σ ]) (s [ σ ⇑² ]) (n [ σ ])
+Unit s l [ σ ] = Unit s l
+star s l [ σ ] = star s l
+unitrec l p q A t u [ σ ] =
+  unitrec l p q (A [ σ ⇑ ]) (t [ σ ]) (u [ σ ])
+Empty [ σ ] = Empty
+emptyrec p A t [ σ ] = emptyrec p (A [ σ ]) (t [ σ ])
+Id A t u [ σ ] = Id (A [ σ ]) (t [ σ ]) (u [ σ ])
+rfl [ σ ] = rfl
+J p q A t B u v w [ σ ] =
+  J p q (A [ σ ]) (t [ σ ]) (B [ σ ⇑² ]) (u [ σ ]) (v [ σ ]) (w [ σ ])
+K p A t B u v [ σ ] =
+  K p (A [ σ ]) (t [ σ ]) (B [ σ ⇑ ]) (u [ σ ]) (v [ σ ])
+[]-cong s A t u v [ σ ] =
+  []-cong s (A [ σ ]) (t [ σ ]) (u [ σ ]) (v [ σ ])
 
-  _[_] : (t : Term n) (σ : Subst m n) → Term m
-  var x [ σ ] = substVar σ x
-  gen x c [ σ ] = gen x (substGen σ c)
+-- Substitution for the alternative term representation.
+
+mutual
+  substGen : {bs : List Nat} (σ : Subst m n)
+             (ts : GenTs Term′ n bs) → GenTs Term′ m bs
+  substGen σ []              = []
+  substGen σ (_∷ₜ_ {b} t ts) = t [ liftSubstn σ b ]′ ∷ₜ substGen σ ts
+
+  _[_]′ : (t : Term′ n) (σ : Subst m n) → Term′ m
+  var x [ σ ]′ = fromTerm (σ x)
+  gen k ts [ σ ]′ = gen k (substGen σ ts)
 
 -- Extend a substitution by adding a term as
 -- the first variable substitution and shift the rest.
@@ -375,19 +567,21 @@ t [ s ]↑ = t [ consSubst (wk1Subst idSubst) s ]
 
 -- Substitute the first two variables of a term with other terms.
 --
--- If Γ∙A∙B ⊢ t : C, Γ ⊢ s : A and Γ ⊢ s′ : B and  then Γ ⊢ t[s,s′] : C[s,s′]
+-- If Γ∙A∙B ⊢ t : C, Γ ⊢ s : A and Γ ⊢ s′ : B then Γ ⊢ t[s,s′] : C[s,s′]
 
 _[_,_]₁₀ : (t : Term (2+ n)) (s s′ : Term n) → Term n
 t [ s , s′ ]₁₀ = t [ consSubst (sgSubst s) s′ ]
 
--- Substitute the first variable with a term and shift remaining variables up by one
+-- Substitute the first variable with a term and shift remaining
+-- variables up by one
 -- If Γ ∙ A ⊢ t : A′ and Γ ∙ B ∙ C ⊢ s : A then Γ ∙ B ∙ C ⊢ t[s]↑² : A′
 
 _[_]↑² : (t : Term (1+ n)) (s : Term (2+ n)) → Term (2+ n)
 t [ s ]↑² = t [ consSubst (wk1Subst (wk1Subst idSubst)) s ]
 
 
-B-subst : (σ : Subst m n) (W : BindingType) (F : Term n) (G : Term (1+ n))
+B-subst : (σ : Subst m n) (W : BindingType)
+          (F : Term n) (G : Term (1+ n))
         → (⟦ W ⟧ F ▹ G) [ σ ] PE.≡ ⟦ W ⟧ F [ σ ] ▹ (G [ liftSubst σ ])
 B-subst σ (BΠ p q) F G = PE.refl
 B-subst σ (BΣ m p q) F G = PE.refl
@@ -401,13 +595,13 @@ gen-cong⁻¹ :
   gen {bs = bs} k ts ≡ gen {bs = bs′} k′ ts′ →
   ∃ λ (eq : bs ≡ bs′) →
     PE.subst Kind eq k ≡ k′ ×
-    PE.subst (GenTs Term _) eq ts ≡ ts′
+    PE.subst (GenTs Term′ _) eq ts ≡ ts′
 gen-cong⁻¹ refl = refl , refl , refl
 
--- Inversion of equality for _∷_.
+-- Inversion of equality for _∷ₜ_.
 
 ∷-cong⁻¹ :
-  ∀ {b} {t t′ : Term (b + n)} →
-  _∷ₜ_ {A = Term} {b = b} t ts ≡ t′ ∷ₜ ts′ →
+  ∀ {b} {t t′ : Term′ (b + n)} →
+  _∷ₜ_ {A = Term′} {b = b} t ts ≡ t′ ∷ₜ ts′ →
   t ≡ t′ × ts ≡ ts′
 ∷-cong⁻¹ refl = refl , refl

--- a/Definition/Untyped/QuantityTranslation/Identity.agda
+++ b/Definition/Untyped/QuantityTranslation/Identity.agda
@@ -13,6 +13,7 @@ open import Tools.Function
 open import Tools.PropositionalEquality
 
 open import Definition.Untyped M
+open import Definition.Untyped.Properties M
 open import Definition.Untyped.QuantityTranslation {M₁ = M} idᶠ idᶠ
 
 private variable
@@ -64,17 +65,24 @@ opaque
 
 opaque mutual
 
-  -- The function tr-Term is pointwise equal to an identity function.
+  -- The function tr-Term′ is pointwise equal to an identity function.
 
-  tr-Term-id : tr-Term t ≡ t
-  tr-Term-id {t = var _}   = refl
-  tr-Term-id {t = gen _ _} = cong₂ gen tr-Kind-id tr-GenTs-id
+  tr-Term′-id : ∀ {n} {t : Term′ n} → tr-Term′ t ≡ t
+  tr-Term′-id {t = var _}   = refl
+  tr-Term′-id {t = gen _ _} = cong₂ gen tr-Kind-id tr-GenTs-id
 
   -- The function tr-GenTs is pointwise equal to an identity function.
 
   tr-GenTs-id : tr-GenTs ts ≡ ts
   tr-GenTs-id {ts = []}     = refl
-  tr-GenTs-id {ts = _ ∷ₜ _} = cong₂ _∷ₜ_ tr-Term-id tr-GenTs-id
+  tr-GenTs-id {ts = _ ∷ₜ _} = cong₂ _∷ₜ_ tr-Term′-id tr-GenTs-id
+
+opaque
+
+  -- The function tr-Term is pointwise equal to an identity function.
+
+  tr-Term-id : tr-Term t ≡ t
+  tr-Term-id {t} rewrite tr-Term′-id {t = fromTerm t} = toTerm∘fromTerm t
 
 opaque
 

--- a/Graded/Erasure/LogicalRelation.agda
+++ b/Graded/Erasure/LogicalRelation.agda
@@ -102,7 +102,7 @@ mutual
   t ®⟨ l ⟩ v ∷ A / ℕᵣ x            = t ® v ∷ℕ
   t ®⟨ l ⟩ v ∷ A / Emptyᵣ x        = t ® v ∷Empty
   t ®⟨ l ⟩ v ∷ A / Unitᵣ {s = s} x = t ® v ∷Unit⟨ s , l ⟩
-  t ®⟨ l ⟩ v ∷ A / ne′ K D neK K≡K = Lift a ⊥
+  t ®⟨ l ⟩ v ∷ A / ne′ _ D neK K≡K = Lift a ⊥
 
   -- Π:
   t ®⟨ l ⟩ v ∷ A / Bᵣ′ (BΠ p q) F G D ⊢F ⊢G A≡A [F] [G] G-ext _ =


### PR DESCRIPTION
Closes #8.

Replaces the definition of `Term` with a more direct representation of the syntax. The old definition has been renamed to `Term′` and is still used to prove some properties (mainly weakening and substitution properties) by translating between the new and old term representations.

This change also seems to have made type-checking faster (~5 minutes on my machine).
