### PR TITLE
Don't require modalities to have grade ω

### DIFF
--- a/Application/NegativeOrErasedAxioms/Canonicity.agda
+++ b/Application/NegativeOrErasedAxioms/Canonicity.agda
@@ -37,6 +37,7 @@ open Usage-restrictions UR
 
 open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
+open import Graded.Modality.Omega-instances
 open import Graded.Reduction.Zero-one variant TR UR
 open import Graded.Usage UR
 open import Graded.Usage.Inversion UR
@@ -208,7 +209,7 @@ neNeg
   NegativeType Γ (A [ t ]₀)               □ }
 neNeg {γ} (Jⱼ {t} {A} {B} {v} {w} ⊢t _ _ ⊢v ⊢w) (Jₙ w-ne) ▸J =
   case inv-usage-J ▸J of λ where
-    (invUsageJ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} _ _ _ _ _ _ _ ▸w γ≤) →
+    (invUsageJ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} _ _ _ _ _ _ ▸w γ≤) →
       NegativeErasedContext Γ γ                                    →⟨ NegativeErasedContext-upwards-closed γ≤ ⟩
       NegativeErasedContext Γ (ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆))  →⟨ NegativeErasedContext-upwards-closed $
                                                                       ≤ᶜ-trans ω·ᶜ+ᶜ≤ω·ᶜʳ $
@@ -220,19 +221,19 @@ neNeg {γ} (Jⱼ {t} {A} {B} {v} {w} ⊢t _ _ ⊢v ⊢w) (Jₙ w-ne) ▸J =
       NegativeType Γ (Id A t v)                                    →⟨ flip ¬negId (refl (Idⱼ′ ⊢t ⊢v)) ⟩
       ⊥                                                            →⟨ ⊥-elim ⟩
       NegativeType Γ (B [ v , w ]₁₀)                               □
-    (invUsageJ₀₁ em _ _ _ _ _ _ _ _ _) →
+    (invUsageJ₀₁ ⦃ (em) ⦄ _ _ _ _ _ _ _ _ _) →
       case
         PE.trans (PE.sym em)
           (no-erased-matches non-trivial .proj₂ .proj₂ .proj₂ .proj₁)
       of λ ()
-    (invUsageJ₀₂ em _ _ _ _ _ _ _) →
+    (invUsageJ₀₂ ⦃ (em) ⦄ _ _ _ _ _ _ _) →
       case
         PE.trans (PE.sym em)
           (no-erased-matches non-trivial .proj₂ .proj₂ .proj₂ .proj₁)
         of λ ()
 neNeg {γ} (Kⱼ {A} {t} {B} {v} _ _ ⊢v ok) (Kₙ v-ne) ▸K =
   case inv-usage-K ▸K of λ where
-    (invUsageK {γ₂} {γ₃} {γ₄} {γ₅} _ _ _ _ _ _ ▸v γ≤) →
+    (invUsageK {γ₂} {γ₃} {γ₄} {γ₅} _ _ _ _ _ ▸v γ≤) →
       NegativeErasedContext Γ γ                              →⟨ NegativeErasedContext-upwards-closed γ≤ ⟩
       NegativeErasedContext Γ (ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅))  →⟨ NegativeErasedContext-upwards-closed $
                                                                 ≤ᶜ-trans ω·ᶜ+ᶜ≤ω·ᶜʳ $
@@ -243,12 +244,12 @@ neNeg {γ} (Kⱼ {A} {t} {B} {v} _ _ ⊢v ok) (Kₙ v-ne) ▸K =
       NegativeType Γ (Id A t t)                              →⟨ flip ¬negId (refl (wf-⊢ ⊢v)) ⟩
       ⊥                                                      →⟨ ⊥-elim ⟩
       NegativeType Γ (B [ v ]₀)                              □
-    (invUsageK₀₁ em _ _ _ _ _ _ _) →
+    (invUsageK₀₁ ⦃ (em) ⦄ _ _ _ _ _ _ _) →
       case
         PE.trans (PE.sym em)
           (no-erased-matches non-trivial .proj₂ .proj₂ .proj₂ .proj₂)
       of λ ()
-    (invUsageK₀₂ em _ _ _ _ _ _) →
+    (invUsageK₀₂ ⦃ (em) ⦄ _ _ _ _ _ _) →
       case
         PE.trans (PE.sym em)
           (no-erased-matches non-trivial .proj₂ .proj₂ .proj₂ .proj₂)

--- a/Definition/Typed/Consequences/Admissible/Bool/Erased.agda
+++ b/Definition/Typed/Consequences/Admissible/Bool/Erased.agda
@@ -19,6 +19,8 @@ module Definition.Typed.Consequences.Admissible.Bool.Erased
   (open Type-restrictions R)
   -- It is assumed that the modality has an nr function.
   ⦃ has-nr : Has-nr M 𝕄 ⦄
+  -- It is assumed that the modality has grade ω.
+  ⦃ has-ω : Has-omega M 𝕄 ⦄
   -- It is assumed that certain Σ-types are allowed.
   (Σ-ok : Σʷ-allowed 𝟙 Boolᵍ)
   -- It is assumed that Erased is allowed for the strength 𝕨.

--- a/Definition/Typed/Consequences/Admissible/Bool/Nr.agda
+++ b/Definition/Typed/Consequences/Admissible/Bool/Nr.agda
@@ -6,6 +6,7 @@
 open import Definition.Typed.Restrictions
 import Definition.Untyped.Bool.Nr
 open import Graded.Modality
+open import Graded.Modality.Omega-instances
 open import Graded.Mode
 
 module Definition.Typed.Consequences.Admissible.Bool.Nr
@@ -18,6 +19,8 @@ module Definition.Typed.Consequences.Admissible.Bool.Nr
   (open Definition.Untyped.Bool.Nr 𝕄 𝐌)
   -- It is assumed that the modality has an nr function.
   ⦃ has-nr : Has-nr _ 𝕄 ⦄
+  -- It is assumed that the modality has grade ω.
+  ⦃ has-ω : Has-omega M 𝕄 ⦄
   -- It is assumed that certain Σ-types are allowed.
   (Σ-ok : Σʷ-allowed ω Boolᵍ)
   -- It is assumed that weak unit types are allowed.

--- a/Definition/Typed/Consequences/Admissible/Identity.agda
+++ b/Definition/Typed/Consequences/Admissible/Identity.agda
@@ -16,6 +16,8 @@ module Definition.Typed.Consequences.Admissible.Identity
 open Modality 𝕄
 open Type-restrictions R
 
+open import Graded.Modality.Omega-instances
+
 open import Definition.Typed R
 open import Definition.Typed.Decidable.Internal 𝐌 R
 import Definition.Typed.Decidable.Internal.Context 𝐌 R as IC
@@ -101,7 +103,9 @@ opaque
   -- A definition that is used to state
   -- Is-function-extensionality-lower-ext below.
 
-  lower-ext : M → M → M → Lvl n → Lvl n → Term n → Term n
+  lower-ext :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
+    M → M → M → Lvl n → Lvl n → Term n → Term n
   lower-ext p q p′ l₁′ l₂′ ext =
     lam p $ lam p′ $ lam p′ $ lam p′ $ lam p′ $
     cong ω
@@ -131,6 +135,7 @@ opaque
   -- are well-formed).
 
   Is-function-extensionality-lower-ext :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     {Γ : Cons m n} →
     Γ ⊢ l₁ ∷Level →
     Γ ⊢ l₁′ ∷Level →
@@ -151,7 +156,7 @@ opaque
       (I.base nothing I.» I.base)
       (I.lam xp nothing $ I.lam xp′ nothing $ I.lam xp′ nothing $
        I.lam xp′ nothing $ I.lam xp′ nothing $
-       congᵢ I.ω
+       congᵢ xω
          (I.Π xp , xq ▷ I.Lift (IW.wk[ 5 ] xl₁′) (I.var x4) ▹
           I.Lift (IW.wk[ 6 ] xl₂′)
             (I.var x4 I.∘⟨ xp ⟩ I.lower (I.var x0)))
@@ -175,7 +180,7 @@ opaque
             (I.lift nothing (I.var x2 I.∘⟨ xp ⟩ I.lower (I.var x0)))
             I.∘⟨ xp′ ⟩
           I.lam xp nothing
-            (congᵢ I.ω (I.var x4 I.∘⟨ xp ⟩ I.lower (I.var x0))
+            (congᵢ xω (I.var x4 I.∘⟨ xp ⟩ I.lower (I.var x0))
                (I.var x3 I.∘⟨ xp ⟩ I.lower (I.var x0))
                (I.var x2 I.∘⟨ xp ⟩ I.lower (I.var x0))
                (I.Lift (IW.wk[ 6 ] xl₂′)
@@ -198,7 +203,7 @@ opaque
       (wf ⊢ext)
       where
       c′ : I.Constants
-      c′ .I.gs                 = 4
+      c′ .I.gs                 = 5
       c′ .I.ss                 = 0
       c′ .I.bms                = 0
       c′ .I.ms                 = 5
@@ -209,11 +214,12 @@ opaque
       c′ .I.meta-con-term-kind =
         lvl V.∷ lvl V.∷ lvl V.∷ lvl V.∷ tm V.∷ V.ε
 
-      xp xp′ xq xq′ : I.Termᵍ 4
+      xp xp′ xq xq′ xω : I.Termᵍ 5
       xp  = I.var x0
       xp′ = I.var x1
       xq  = I.var x2
       xq′ = I.var x3
+      xω  = I.var x4
 
       xl₁ xl₁′ xl₂ xl₂′ : I.Lvl c′ n
       xl₁  = I.varᵐ x0
@@ -225,7 +231,7 @@ opaque
       xext = I.varᵐ x4
 
       γ′ : I.Contexts c′
-      γ′ .I.grades       = p V.∷ p′ V.∷ q V.∷ q′ V.∷ V.ε
+      γ′ .I.grades       = p V.∷ p′ V.∷ q V.∷ q′ V.∷ ω V.∷ V.ε
       γ′ .I.strengths    = V.ε
       γ′ .I.binder-modes = V.ε
       γ′ .I.⌜base⌝       = Γ
@@ -255,6 +261,7 @@ opaque
   -- are well-formed).
 
   Has-function-extensionality-supᵘₗ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ l₁ ∷Level →
     Γ ⊢ l₁′ ∷Level →
     Γ ⊢ l₂ ∷Level →
@@ -273,6 +280,7 @@ opaque
   -- holds for smaller levels l₁ and l₂.
 
   Has-function-extensionality-downwards-closed :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ l₁ ≤ₗ l₁′ ∷Level →
     Γ ⊢ l₂ ≤ₗ l₂′ ∷Level →
     Has-function-extensionality p q p′ q′ l₁′ l₂′ Γ →
@@ -339,6 +347,7 @@ opaque
   -- A term used to state ⊢ΠΣ-cong-Idˡ.
 
   ΠΣ-cong-Idˡ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     BinderMode → M → M → M → M → M → M → Lvl n → Term n → Term n →
     Term (1+ n) → Term n → Term (1+ n) → Term n → Term (1+ n) → Term n
   ΠΣ-cong-Idˡ b p q p′ q′ p″ q″ l ext A₁ B₁ A₂ B₂ t u =
@@ -372,6 +381,7 @@ opaque
   -- allowed).
 
   ⊢ΠΣ-cong-Idˡ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     {Γ : Cons m n} →
     ΠΣ-allowed b p q →
     Π-allowed p′ q′ →
@@ -395,7 +405,7 @@ opaque
     check-type-and-term-sound
       γ′
       (I.base nothing I.» I.base)
-      (I.J I.ω I.ω (I.U xl) xA₁
+      (I.J xω xω (I.U xl) xA₁
          (I.Π xp″ , xq″ ▷
             I.Π xp′ , xq′ ▷ I.var x1 ▹ I.U (IW.wk[ 3 ] xl) ▹
           I.Π xp″ , xq″ ▷
@@ -410,7 +420,7 @@ opaque
             (I.ΠΣ⟨ xb ⟩ xp , xq ▷ I.var x3 ▹
              (I.var x2 I.∘⟨ xp′ ⟩ I.var x0)))
          (I.lam xp″ nothing $ I.lam xp″ nothing $
-          congᵢ I.ω
+          congᵢ xω
             (IW.wk[ 2 ] (I.Π xp′ , xq′ ▷ xA₁ ▹ I.U (IW.wk[ 1 ] xl)))
             (IW.wk[ 2 ] (I.lam xp′ (just (xq′ , xA₁)) xB₁)) (I.var x1)
             (I.U (IW.wk[ 2 ] xl))
@@ -445,7 +455,7 @@ opaque
       (wf ⊢A₁)
       where
       c′ : I.Constants
-      c′ .I.gs                 = 6
+      c′ .I.gs                 = 7
       c′ .I.ss                 = 0
       c′ .I.bms                = 1
       c′ .I.ms                 = 8
@@ -459,13 +469,14 @@ opaque
       xb : I.Termᵇᵐ 0 1
       xb = I.var x0
 
-      xp xp′ xp″ xq xq′ xq″ : I.Termᵍ 6
+      xp xp′ xp″ xq xq′ xq″ xω : I.Termᵍ 7
       xp  = I.var x0
       xp′ = I.var x1
       xp″ = I.var x2
       xq  = I.var x3
       xq′ = I.var x4
       xq″ = I.var x5
+      xω  = I.var x6
 
       xl : I.Lvl c′ n
       xl = I.varᵐ x0
@@ -482,7 +493,7 @@ opaque
       xu  = I.varᵐ x6
 
       γ′ : I.Contexts c′
-      γ′ .I.grades       = p V.∷ p′ V.∷ p″ V.∷ q V.∷ q′ V.∷ q″ V.∷ V.ε
+      γ′ .I.grades       = p V.∷ p′ V.∷ p″ V.∷ q V.∷ q′ V.∷ q″ V.∷ ω V.∷ V.ε
       γ′ .I.strengths    = V.ε
       γ′ .I.binder-modes = b V.∷ V.ε
       γ′ .I.⌜base⌝       = Γ
@@ -519,6 +530,7 @@ opaque
   -- A term used to state ⊢ΠΣ-cong-Idʳ.
 
   ΠΣ-cong-Idʳ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     BinderMode → M → M → M → M → M → M → Lvl n → Term n → Term n →
     Term (1+ n) → Term n → Term (1+ n) → Term n → Term (1+ n) → Term n
   ΠΣ-cong-Idʳ b p q p′ q′ p″ q″ l ext A₁ B₁ A₂ B₂ t u =
@@ -534,6 +546,7 @@ opaque
   -- A variant of ⊢ΠΣ-cong-Idˡ.
 
   ⊢ΠΣ-cong-Idʳ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     ΠΣ-allowed b p q →
     Π-allowed p′ q′ →
     Π-allowed p″ q″ →
@@ -576,6 +589,7 @@ opaque
   -- that some Π-type is allowed).
 
   Id-cong-Idˡ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     {Γ : Cons m n} →
     Π-allowed p q →
     Γ ⊢ t ∷ Id (U l) A₁ A₂ →
@@ -596,7 +610,7 @@ opaque
     check-type-and-term-sound
       γ′
       (I.base nothing I.» I.base)
-      (I.J I.ω I.ω (I.U xl) xA₁
+      (I.J xω xω (I.U xl) xA₁
          (I.Π xp , xq ▷ I.var x1 ▹
           I.Π xp , xq ▷ I.var x2 ▹
           I.Π xp , xq ▷
@@ -613,7 +627,7 @@ opaque
             (I.Id (I.var x5) (I.var x3) (I.var x2)))
          (I.lam xp nothing $ I.lam xp nothing $ I.lam xp nothing $
           I.lam xp nothing $
-          cong₂ᵢ I.ω (IW.wk[ 4 ] xA₁) (IW.wk[ 4 ] xt₁) (I.var x3)
+          cong₂ᵢ xω xω (IW.wk[ 4 ] xA₁) (IW.wk[ 4 ] xt₁) (I.var x3)
             (IW.wk[ 4 ] xA₁) (IW.wk[ 4 ] xu₁) (I.var x2)
             (I.U (IW.wk[ 4 ] xl))
             (I.Id (IW.wk[ 6 ] xA₁) (I.var x1) (I.var x0)) (I.var x1)
@@ -641,7 +655,7 @@ opaque
       (wf ⊢A₁)
       where
       c′ : I.Constants
-      c′ .I.gs                 = 2
+      c′ .I.gs                 = 3
       c′ .I.ss                 = 0
       c′ .I.bms                = 0
       c′ .I.ms                 = 10
@@ -651,9 +665,10 @@ opaque
       c′ .I.meta-con-size      = V.replicate 10 n
       c′ .I.meta-con-term-kind = lvl V.∷ V.replicate 9 tm
 
-      xp xq : I.Termᵍ 2
+      xp xq xω : I.Termᵍ 3
       xp = I.var x0
       xq = I.var x1
+      xω = I.var x2
 
       xl : I.Lvl c′ n
       xl = I.varᵐ x0
@@ -670,7 +685,7 @@ opaque
       xv  = I.varᵐ x9
 
       γ′ : I.Contexts c′
-      γ′ .I.grades              = p V.∷ q V.∷ V.ε
+      γ′ .I.grades              = p V.∷ q V.∷ ω V.∷ V.ε
       γ′ .I.strengths           = V.ε
       γ′ .I.binder-modes        = V.ε
       γ′ .I.⌜base⌝              = Γ
@@ -697,6 +712,7 @@ opaque
   -- A variant of Id-cong-Idˡ.
 
   Id-cong-Idʳ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Π-allowed p q →
     Γ ⊢ t ∷ Id (U l) A₁ A₂ →
     Γ ⊢ u ∷ Id A₁ t₁ (cast⁻¹ l A₁ A₂ t t₂) →

--- a/Definition/Typed/Decidable/Internal.agda
+++ b/Definition/Typed/Decidable/Internal.agda
@@ -111,6 +111,7 @@ private variable
   ℓ ℓ₁ ℓ₂                              : Universe-level⁻
   k                                    : Term-kind
   σ σ′ σ₁ σ₂                           : Subst _ _ _
+  p p₁ p₂ p₃ p₄ p₅ p₆                  : Termᵍ _
 
 ------------------------------------------------------------------------
 -- A lemma
@@ -2073,7 +2074,7 @@ opaque
     Equality-reflection →
     let n = 3 N.+ n
         Γ = record { defs = ε; vars = ε ∙ Empty }
-        t = emptyrec ω ℕ zero
+        t = emptyrec p ℕ zero
         u = t
         A = ℕ
     in
@@ -2109,8 +2110,8 @@ opaque
     Unitʷ-η →
     let n = 4 N.+ n
         Γ = emptyᶜ »∙ Unit 𝕨
-        t = unitrec ω ω ℕ (unitrec ω ω (Unit 𝕨) (star 𝕨) (var x0)) zero
-        u = unitrec ω ω ℕ (var x0) zero
+        t = unitrec p₁ p₂ ℕ (unitrec p₃ p₄ (Unit 𝕨) (star 𝕨) (var x0)) zero
+        u = unitrec p₁ p₂ ℕ (var x0) zero
         A = ℕ
     in
     ⌜ Γ ⌝ᶜ γ ⊢ ⌜ t ⌝ γ ∷ ⌜ A ⌝ γ ×

--- a/Definition/Typed/Decidable/Internal/Equality.agda
+++ b/Definition/Typed/Decidable/Internal/Equality.agda
@@ -38,8 +38,6 @@ var x ≟ᵍ var y =
   just refl
 𝟙 ≟ᵍ 𝟙 =
   just refl
-ω ≟ᵍ ω =
-  just refl
 t₁₁ + t₁₂ ≟ᵍ t₂₁ + t₂₂ =
   cong₂ _+_ <$> t₁₁ ≟ᵍ t₂₁ ⊛ t₁₂ ≟ᵍ t₂₂
 t₁₁ · t₁₂ ≟ᵍ t₂₁ · t₂₂ =

--- a/Definition/Typed/Decidable/Internal/Examples.agda
+++ b/Definition/Typed/Decidable/Internal/Examples.agda
@@ -55,7 +55,7 @@ private variable
   c                                               : I.Constants
   Δ                                               : Con _ _
   A A₁ A₂ B B₁ B₂ t t₁ t₂ u u₁ u₂ v v₁ v₂ w w₁ w₂ : Term _
-  p                                               : M
+  p q                                             : M
 
 opaque
 
@@ -65,30 +65,32 @@ opaque
   -- used.
 
   let-α≡zero-in-λλ0∘zero≡λα :
-    Π-allowed ω ω →
+    Π-allowed 𝟘 𝟘 →
+    Π-allowed 𝟙 𝟘 →
     Unit-allowed 𝕤 →
     ε ∙⟨ tra ⟩[ zero ∷ ℕ ] » ε ⊢
-      lam ω (lam ω (var x0) ∘⟨ ω ⟩ zero) ≡
-      lam ω (defn 0) ∷
-      Π ω , ω ▷ Unit 𝕤 ▹ ℕ
-  let-α≡zero-in-λλ0∘zero≡λα ok₁ ok₂ =
+      lam 𝟘 (lam 𝟙 (var x0) ∘⟨ 𝟙 ⟩ zero) ≡
+      lam 𝟘 (defn 0) ∷
+      Π 𝟘 , 𝟘 ▷ Unit 𝕤 ▹ ℕ
+  let-α≡zero-in-λλ0∘zero≡λα ok₁ ok₂ ok₃ =
     check-and-equal-cons-type-and-terms-sound
       (record (I.empty-Contexts false)
          { constraints⁺ =
-             I.π-allowed I.ω I.ω L.∷
+             I.π-allowed I.𝟘 I.𝟘 L.∷
+             I.π-allowed I.𝟙 I.𝟘 L.∷
              I.unit-allowed I.𝕤  L.∷
              L.[]
          })
       (I.ε I.∙⟨ tra ⟩[ I.zero ∷ I.ℕ ] I.» I.ε)
-      (I.lam I.ω nothing $
-       I.lam I.ω (just (I.ω , I.ℕ)) (I.var x0) I.∘⟨ I.ω ⟩ I.zero)
-      (I.lam I.ω nothing (I.defn 0))
-      (I.Π I.ω , I.ω ▷ I.Unit I.𝕤 ▹ I.ℕ)
+      (I.lam I.𝟘 nothing $
+       I.lam I.𝟙 (just (I.𝟘 , I.ℕ)) (I.var x0) I.∘⟨ I.𝟙 ⟩ I.zero)
+      (I.lam I.𝟘 nothing (I.defn 0))
+      (I.Π I.𝟘 , I.𝟘 ▷ I.Unit I.𝕤 ▹ I.ℕ)
       10
       PE.refl
       (record
          { metas-wf       = C.Meta-con-wf-empty PE.refl
-         ; constraints-wf = ok₁ L.∷ ok₂ L.∷ L.[]
+         ; constraints-wf = ok₁ L.∷ ok₂ L.∷ ok₃ L.∷ L.[]
          })
       ε
       (λ ())
@@ -107,15 +109,16 @@ opaque
 
   let-α≡zero-in-let-β≡λ0-in-λβ∙zero≡λα :
     ε »⊢ Δ →
-    Π-allowed ω ω →
+    Π-allowed 𝟘 𝟘 →
+    Π-allowed 𝟙 𝟘 →
     Unit-allowed 𝕤 →
     ε ∙⟨ tra ⟩[ zero ∷ ℕ ]
-      ∙⟨ tra ⟩[ lam ω (var x0) ∷ Π ω , ω ▷ ℕ ▹ ℕ ]
+      ∙⟨ tra ⟩[ lam 𝟙 (var x0) ∷ Π 𝟙 , 𝟘 ▷ ℕ ▹ ℕ ]
       » Δ ⊢
-      lam ω (defn 1 ∘⟨ ω ⟩ zero) ≡
-      lam ω (defn 0) ∷
-      Π ω , ω ▷ Unit 𝕤 ▹ ℕ
-  let-α≡zero-in-let-β≡λ0-in-λβ∙zero≡λα {Δ} ⊢Δ ok₁ ok₂ =
+      lam 𝟘 (defn 1 ∘⟨ 𝟙 ⟩ zero) ≡
+      lam 𝟘 (defn 0) ∷
+      Π 𝟘 , 𝟘 ▷ Unit 𝕤 ▹ ℕ
+  let-α≡zero-in-let-β≡λ0-in-λβ∙zero≡λα {Δ} ⊢Δ ok₁ ok₂ ok₃ =
     check-and-equal-type-and-terms-sound
       {c = record { base-con-allowed = true }}
       (record
@@ -126,36 +129,36 @@ opaque
          ; ⌜base⌝       = ε » Δ
          ; constraints⁰ = I.emptyᶜ⁰
          ; constraints⁺ =
-             I.π-allowed I.ω I.ω L.∷
+             I.π-allowed I.𝟘 I.𝟘 L.∷
              I.unit-allowed I.𝕤  L.∷
              L.[]
          })
       (I.ε I.∙⟨ tra ⟩[ I.zero ∷ I.ℕ ]
-           I.∙⟨ tra ⟩[ I.lam I.ω nothing (I.var x0) ∷
-                       I.Π I.ω , I.ω ▷ I.ℕ ▹ I.ℕ ] I.»
+           I.∙⟨ tra ⟩[ I.lam I.𝟙 nothing (I.var x0) ∷
+                       I.Π I.𝟙 , I.𝟘 ▷ I.ℕ ▹ I.ℕ ] I.»
            I.base)
-      (I.lam I.ω nothing (I.defn 1 I.∘⟨ I.ω ⟩ I.zero))
-      (I.lam I.ω nothing (I.defn 0))
-      (I.Π I.ω , I.ω ▷ I.Unit I.𝕤 ▹ I.ℕ)
+      (I.lam I.𝟘 nothing (I.defn 1 I.∘⟨ I.𝟙 ⟩ I.zero))
+      (I.lam I.𝟘 nothing (I.defn 0))
+      (I.Π I.𝟘 , I.𝟘 ▷ I.Unit I.𝕤 ▹ I.ℕ)
       10
       PE.refl
       (record
          { metas-wf       = C.Meta-con-wf-empty PE.refl
-         ; constraints-wf = ok₁ L.∷ ok₂ L.∷ L.[]
+         ; constraints-wf = ok₁ L.∷ ok₃ L.∷ L.[]
          })
       (flip defn-wk ⊢Δ $ »⊇ε $
        check-dcon-sound
          (record (I.empty-Contexts false)
             { constraints⁺ =
-                I.π-allowed I.ω I.ω L.∷
+                I.π-allowed I.𝟙 I.𝟘 L.∷
                 L.[]
             })
          (I.ε I.∙⟨ tra ⟩[ I.zero ∷ I.ℕ ]
-              I.∙⟨ tra ⟩[ I.lam I.ω nothing (I.var x0) ∷
-                          I.Π I.ω , I.ω ▷ I.ℕ ▹ I.ℕ ])
+              I.∙⟨ tra ⟩[ I.lam I.𝟙 nothing (I.var x0) ∷
+                          I.Π I.𝟙 , I.𝟘 ▷ I.ℕ ▹ I.ℕ ])
          6
          PE.refl
-         (ok₁ L.∷ L.[])
+         (ok₂ L.∷ L.[])
          ε)
 
 opaque

--- a/Definition/Typed/Decidable/Internal/Term.agda
+++ b/Definition/Typed/Decidable/Internal/Term.agda
@@ -56,7 +56,7 @@ infixr 45 _·_
 
 data Termᵍ (n : Nat) : Set a where
   var         : (x : Fin n) → Termᵍ n
-  𝟘 𝟙 ω       : Termᵍ n
+  𝟘 𝟙         : Termᵍ n
   _+_ _·_ _∧_ : (p q : Termᵍ n) → Termᵍ n
   ⌜⌞_⌟⌝       : (p : Termᵍ n) → Termᵍ n
 
@@ -473,14 +473,13 @@ is-id? _  = nothing
 -- Translates grade terms to grades.
 
 ⟦_⟧ᵍ : Termᵍ (c .gs) → Contexts c → M
-⟦ var x   ⟧ᵍ γ = Vec.lookup (γ .grades) x
-⟦ 𝟘       ⟧ᵍ γ = M.𝟘
-⟦ 𝟙       ⟧ᵍ γ = M.𝟙
-⟦ ω       ⟧ᵍ γ = M.ω
-⟦ t₁ + t₂ ⟧ᵍ γ = ⟦ t₁ ⟧ᵍ γ M.+ ⟦ t₂ ⟧ᵍ γ
-⟦ t₁ · t₂ ⟧ᵍ γ = ⟦ t₁ ⟧ᵍ γ M.· ⟦ t₂ ⟧ᵍ γ
-⟦ t₁ ∧ t₂ ⟧ᵍ γ = ⟦ t₁ ⟧ᵍ γ M.∧ ⟦ t₂ ⟧ᵍ γ
-⟦ ⌜⌞ t ⌟⌝ ⟧ᵍ γ = Mode.⌜ Mode.⌞ ⟦ t ⟧ᵍ γ ⌟ ⌝
+⟦ var x    ⟧ᵍ γ = Vec.lookup (γ .grades) x
+⟦ 𝟘        ⟧ᵍ γ = M.𝟘
+⟦ 𝟙        ⟧ᵍ γ = M.𝟙
+⟦ t₁ + t₂  ⟧ᵍ γ = ⟦ t₁ ⟧ᵍ γ M.+ ⟦ t₂ ⟧ᵍ γ
+⟦ t₁ · t₂  ⟧ᵍ γ = ⟦ t₁ ⟧ᵍ γ M.· ⟦ t₂ ⟧ᵍ γ
+⟦ t₁ ∧ t₂  ⟧ᵍ γ = ⟦ t₁ ⟧ᵍ γ M.∧ ⟦ t₂ ⟧ᵍ γ
+⟦ ⌜⌞ t ⌟⌝  ⟧ᵍ γ = Mode.⌜ Mode.⌞ ⟦ t ⟧ᵍ γ ⌟ ⌝
 
 -- Translates strength terms to strengths.
 

--- a/Definition/Typed/Properties/Admissible/Identity.agda
+++ b/Definition/Typed/Properties/Admissible/Identity.agda
@@ -36,6 +36,8 @@ import Definition.Untyped.Erased 𝕄 as Erased
 open import Definition.Untyped.Identity 𝕄
 open import Definition.Untyped.Properties M
 
+open import Graded.Modality.Omega-instances
+
 open import Tools.Fin
 open import Tools.Function
 open import Tools.Nat as N using (Nat; 1+)
@@ -559,6 +561,7 @@ opaque
   -- An equality rule for transitivity.
 
   transitivity-cong :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ A₁ ≡ A₂ →
     Γ ⊢ t₁ ≡ t₂ ∷ A₁ →
     Γ ⊢ u₁ ≡ u₂ ∷ A₁ →
@@ -578,6 +581,7 @@ opaque
   -- A typing rule for transitivity.
 
   ⊢transitivity :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ eq₁ ∷ Id A t u →
     Γ ⊢ eq₂ ∷ Id A u v →
     Γ ⊢ transitivity A t u v eq₁ eq₂ ∷ Id A t v
@@ -596,6 +600,7 @@ opaque
   -- A reduction rule for transitivity.
 
   transitivity-⇒ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ eq ∷ Id A t u →
     Γ ⊢ transitivity A t u u eq rfl ⇒ eq ∷ Id A t u
   transitivity-⇒ ⊢eq =
@@ -614,6 +619,7 @@ opaque
   -- An equality rule for transitivity.
 
   transitivity-≡ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ eq ∷ Id A t u →
     Γ ⊢ transitivity A t u u eq rfl ≡ eq ∷ Id A t u
   transitivity-≡ ⊢eq =
@@ -761,6 +767,7 @@ opaque
   -- An equality rule for cong₂.
 
   cong₂-cong :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ A₁₁ ≡ A₁₂ →
     Γ ⊢ t₁₁ ≡ t₁₂ ∷ A₁₁ →
     Γ ⊢ u₁₁ ≡ u₁₂ ∷ A₁₁ →
@@ -812,6 +819,7 @@ opaque
   -- A typing rule for cong₂.
 
   ⊢cong₂ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ »∙ A₁ »∙ wk1 A₂ ⊢ v ∷ wk[ 2 ]′ B →
     Γ ⊢ w₁ ∷ Id A₁ t₁ u₁ →
     Γ ⊢ w₂ ∷ Id A₂ t₂ u₂ →
@@ -837,6 +845,7 @@ opaque
   -- A β-rule for cong₂.
 
   cong₂-β :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ t₁ ∷ A₁ →
     Γ ⊢ t₂ ∷ A₂ →
     Γ »∙ A₁ »∙ wk1 A₂ ⊢ u ∷ wk[ 2 ]′ B →
@@ -881,6 +890,7 @@ opaque
   -- A typing rule for pointwise-equality.
 
   ⊢pointwise-equality :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ v ∷ Id (Π p , q ▷ A ▹ B) t u →
     Γ ⊢ w ∷ A →
     Γ ⊢ pointwise-equality p q A B t u v w ∷
@@ -903,6 +913,7 @@ opaque
   -- A reduction rule for pointwise-equality.
 
   pointwise-equality-⇒ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ t ∷ Π p , q ▷ A ▹ B →
     Γ ⊢ u ∷ A →
     Γ ⊢ pointwise-equality p q A B t t rfl u ⇒ rfl ∷
@@ -924,6 +935,7 @@ opaque
   -- An equality rule for pointwise-equality.
 
   pointwise-equality-≡ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ t ∷ Π p , q ▷ A ▹ B →
     Γ ⊢ u ∷ A →
     Γ ⊢ pointwise-equality p q A B t t rfl u ≡ rfl ∷
@@ -940,6 +952,7 @@ opaque
   -- An equality rule for symmetry.
 
   symmetry-cong :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ A₁ ≡ A₂ →
     Γ ⊢ t₁ ≡ t₂ ∷ A₁ →
     Γ ⊢ u₁ ≡ u₂ ∷ A₁ →
@@ -963,6 +976,7 @@ opaque
   -- A typing rule for symmetry.
 
   ⊢symmetry :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ eq ∷ Id A t u →
     Γ ⊢ symmetry A t u eq ∷ Id A u t
   ⊢symmetry ⊢eq =
@@ -976,6 +990,7 @@ opaque
   -- A reduction rule for symmetry.
 
   symmetry-⇒′ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ t ≡ t′ ∷ A →
     Γ ⊢ symmetry A t t′ rfl ⇒ rfl ∷ Id A t t
   symmetry-⇒′ t≡t′ =
@@ -995,6 +1010,7 @@ opaque
   -- A reduction rule for symmetry.
 
   symmetry-⇒ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ t ∷ A →
     Γ ⊢ symmetry A t t rfl ⇒ rfl ∷ Id A t t
   symmetry-⇒ ⊢t =
@@ -1005,6 +1021,7 @@ opaque
   -- An equality rule for symmetry.
 
   symmetry-≡ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ t ∷ A →
     Γ ⊢ symmetry A t t rfl ≡ rfl ∷ Id A t t
   symmetry-≡ ⊢t =
@@ -1016,6 +1033,7 @@ opaque
   -- A reduction rule for symmetry.
 
   symmetry-subst :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ v₁ ⇒ v₂ ∷ Id A t u →
     Γ ⊢ symmetry A t u v₁ ⇒ symmetry A t u v₂ ∷ Id A u t
   symmetry-subst v₁⇒v₂ =
@@ -1036,6 +1054,7 @@ opaque
   -- A reduction rule for symmetry.
 
   symmetry-subst* :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ v₁ ⇒* v₂ ∷ Id A t u →
     Γ ⊢ symmetry A t u v₁ ⇒* symmetry A t u v₂ ∷ Id A u t
   symmetry-subst* (id ⊢v)          = id (⊢symmetry ⊢v)
@@ -1048,6 +1067,7 @@ opaque
   -- An inversion lemma for symmetry.
 
   inversion-symmetry :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ symmetry A t u v ∷ B →
     Γ ⊢ v ∷ Id A t u ×
     Γ ⊢ B ≡ Id A u t
@@ -1062,6 +1082,7 @@ opaque
   -- A preservation lemma for symmetry.
 
   symmetry-cong-Id :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ w ∷ Id (Id A t u) v₁ v₂ →
     ∃ λ eq →
       Γ ⊢ eq ∷ Id (Id A u t) (symmetry A t u v₁) (symmetry A t u v₂)
@@ -1087,6 +1108,7 @@ opaque
   -- A simplification lemma for symmetry.
 
   Id-symmetry-symmetry :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ v ∷ Id A t u →
     ∃ λ w → Γ ⊢ w ∷ Id (Id A t u) (symmetry A u t (symmetry A t u v)) v
   Id-symmetry-symmetry {v} {A} {t} {u} ⊢v =
@@ -1138,6 +1160,7 @@ opaque
   -- A typing rule for transitivity-symmetryˡ.
 
   ⊢transitivity-symmetryˡ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ eq ∷ Id A t u →
     Γ ⊢ transitivity-symmetryˡ A t u eq ∷
       Id (Id A u u) (transitivity A u t u (symmetry A t u eq) eq) rfl
@@ -1312,6 +1335,7 @@ opaque
   -- A preservation lemma for cast.
 
   cast-cong-Id :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ v ∷ Id (Id (U l) A B) t₁ t₂ →
     Γ ⊢ w ∷ Id A u₁ u₂ →
     ∃ λ eq → Γ ⊢ eq ∷ Id B (cast l A B t₁ u₁) (cast l A B t₂ u₂)
@@ -1347,6 +1371,7 @@ opaque
   -- An equality rule for cast⁻¹.
 
   cast⁻¹-cong :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ l₁ ≡ l₂ ∷Level →
     Γ ⊢ A₁ ≡ A₂ ∷ U l₁ →
     Γ ⊢ B₁ ≡ B₂ ∷ U l₁ →
@@ -1362,6 +1387,7 @@ opaque
   -- A typing rule for cast⁻¹.
 
   ⊢cast⁻¹ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ t ∷ Id (U l) A B →
     Γ ⊢ u ∷ B →
     Γ ⊢ cast⁻¹ l A B t u ∷ A
@@ -1380,6 +1406,7 @@ opaque
   -- A reduction rule for cast⁻¹.
 
   cast⁻¹-⇒′ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ A ≡ A′ ∷ U l →
     Γ ⊢ t ∷ A′ →
     Γ ⊢ cast⁻¹ l A A′ rfl t ⇒* t ∷ A
@@ -1394,6 +1421,7 @@ opaque
   -- Another reduction rule for cast⁻¹.
 
   cast⁻¹-⇒ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ A ∷ U l →
     Γ ⊢ t ∷ A →
     Γ ⊢ cast⁻¹ l A A rfl t ⇒* t ∷ A
@@ -1405,6 +1433,7 @@ opaque
   -- An equality rule for cast⁻¹.
 
   cast⁻¹-≡ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ A ∷ U l →
     Γ ⊢ t ∷ A →
     Γ ⊢ cast⁻¹ l A A rfl t ≡ t ∷ A
@@ -1417,6 +1446,7 @@ opaque
   -- A reduction rule for cast⁻¹.
 
   cast⁻¹-subst :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ t₁ ⇒ t₂ ∷ Id (U l) A B →
     Γ ⊢ u ∷ B →
     Γ ⊢ cast⁻¹ l A B t₁ u ⇒ cast⁻¹ l A B t₂ u ∷ A
@@ -1428,6 +1458,7 @@ opaque
   -- A reduction rule for cast⁻¹.
 
   cast⁻¹-subst* :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ t₁ ⇒* t₂ ∷ Id (U l) A B →
     Γ ⊢ u ∷ B →
     Γ ⊢ cast⁻¹ l A B t₁ u ⇒* cast⁻¹ l A B t₂ u ∷ A
@@ -1442,6 +1473,7 @@ opaque
   -- An inversion lemma for cast⁻¹.
 
   inversion-cast⁻¹ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ cast⁻¹ l A B t u ∷ C →
     Γ ⊢ t ∷ Id (U l) A B ×
     Γ ⊢ u ∷ B ×
@@ -1456,6 +1488,7 @@ opaque
   -- A preservation lemma for cast⁻¹.
 
   cast⁻¹-cong-Id :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ v ∷ Id (Id (U l) A B) t₁ t₂ →
     Γ ⊢ w ∷ Id B u₁ u₂ →
     ∃ λ eq → Γ ⊢ eq ∷ Id A (cast⁻¹ l A B t₁ u₁) (cast⁻¹ l A B t₂ u₂)
@@ -1470,6 +1503,7 @@ opaque
   -- A simplification lemma involving cast⁻¹ and cast.
 
   Id-cast⁻¹-cast :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ t ∷ Id (U l) A B →
     Γ ⊢ u ∷ A →
     ∃ λ v → Γ ⊢ v ∷ Id A (cast⁻¹ l A B t (cast l A B t u)) u
@@ -1531,6 +1565,7 @@ opaque
   -- A simplification lemma involving cast and cast⁻¹.
 
   Id-cast-cast⁻¹ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ t ∷ Id (U l) A B →
     Γ ⊢ u ∷ B →
     ∃ λ v → Γ ⊢ v ∷ Id B (cast l A B t (cast⁻¹ l A B t u)) u
@@ -1548,6 +1583,7 @@ opaque
   -- A simplification lemma involving cast⁻¹, symmetry and cast.
 
   Id-cast⁻¹-symmetry :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ t ∷ Id (U l) A B →
     Γ ⊢ u ∷ A →
     ∃ λ v →
@@ -1563,6 +1599,7 @@ opaque
   -- t₂".
 
   cast-right-left :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ u ∷ Id (U l) A₁ A₂ →
     Γ ⊢ v ∷ Id A₂ t₁ (cast l A₁ A₂ u t₂) →
     ∃ λ v → Γ ⊢ v ∷ Id A₁ (cast⁻¹ l A₁ A₂ u t₁) t₂
@@ -1599,6 +1636,7 @@ opaque
   -- A variant of cast-right-left.
 
   cast-right-left′ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ u ∷ Id (U l) A₁ A₂ →
     Γ ⊢ v ∷ Id A₁ t₁ (cast⁻¹ l A₁ A₂ u t₂) →
     ∃ λ v → Γ ⊢ v ∷ Id A₂ (cast l A₁ A₂ u t₁) t₂
@@ -1615,6 +1653,7 @@ opaque
   -- t₂".
 
   cast-left-right :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ u ∷ Id (U l) A₁ A₂ →
     Γ ⊢ v ∷ Id A₂ (cast l A₁ A₂ u t₁) t₂ →
     ∃ λ v → Γ ⊢ v ∷ Id A₁ t₁ (cast⁻¹ l A₁ A₂ u t₂)
@@ -1627,6 +1666,7 @@ opaque
   -- A variant of cast-left-right.
 
   cast-left-right′ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Γ ⊢ u ∷ Id (U l) A₁ A₂ →
     Γ ⊢ v ∷ Id A₁ (cast⁻¹ l A₁ A₂ u t₁) t₂ →
     ∃ λ v → Γ ⊢ v ∷ Id A₂ t₁ (cast l A₁ A₂ u t₂)
@@ -1646,6 +1686,7 @@ opaque
   -- is allowed.
 
   ⊢uip :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     K-allowed →
     Γ ⊢ eq₁ ∷ Id A t u →
     Γ ⊢ eq₂ ∷ Id A t u →
@@ -1907,7 +1948,7 @@ opaque
     Γ ⊢ v ∷ A →
     Γ ⊢ u ≡ v ∷ A
   ⊢∷Empty→⊢≡∷ ok ⊢t ⊢u ⊢v =
-    equality-reflection′ ok (emptyrecⱼ {p = ω} (Idⱼ′ ⊢u ⊢v) ⊢t)
+    equality-reflection′ ok (emptyrecⱼ {p = 𝟘} (Idⱼ′ ⊢u ⊢v) ⊢t)
 
 opaque
 
@@ -2019,6 +2060,7 @@ opaque
   -- definitional variant of UIP.
 
   uip-with-equality-reflection-≡ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Equality-reflection →
     Γ ⊢ eq₁ ∷ Id A t u →
     Γ ⊢ eq₂ ∷ Id A t u →
@@ -2049,6 +2091,7 @@ opaque
   -- UIP.
 
   uip-with-equality-reflection-Id :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Equality-reflection →
     Γ ⊢ eq₁ ∷ Id A t u →
     Γ ⊢ eq₂ ∷ Id A t u →

--- a/Definition/Typed/Properties/Definition.agda
+++ b/Definition/Typed/Properties/Definition.agda
@@ -1697,7 +1697,7 @@ opaque
               (possibly-nonempty ⦃ ok = p , q , ok ⦄) →
                 p , q , possibly-nonempty ⦃ ok = ok ⦄
               ε →
-                Modality.ω 𝕄 , Modality.ω 𝕄 , ε
+                Modality.𝟘 𝕄 , Modality.𝟘 𝕄 , ε
 
             ok = p,q,ok .proj₂ .proj₂
 

--- a/Definition/Untyped/Bool/Erased.agda
+++ b/Definition/Untyped/Bool/Erased.agda
@@ -19,6 +19,8 @@ module Definition.Untyped.Bool.Erased
   (𝐌 : IsMode)
   -- It is assumed that the modality has an nr function.
   ⦃ has-nr : Has-nr 𝕄 ⦄
+  -- It is assumed that the modality has the grade ω
+  ⦃ has-omega : Has-omega 𝕄 ⦄
   where
 
 open Modality 𝕄

--- a/Definition/Untyped/Bool/Greatest-lower-bound.agda
+++ b/Definition/Untyped/Bool/Greatest-lower-bound.agda
@@ -17,7 +17,7 @@ module Definition.Untyped.Bool.Greatest-lower-bound
   where
 
 private
-  open module M = Modality 𝕄 using (𝟘; 𝟙; ω; _+_; _·_; _∧_)
+  open module M = Modality 𝕄 using (𝟘; 𝟙; _+_; _·_; _∧_)
 
 open import Definition.Untyped M
 open import Definition.Untyped.Empty 𝕄

--- a/Definition/Untyped/Bool/Nr.agda
+++ b/Definition/Untyped/Bool/Nr.agda
@@ -18,12 +18,15 @@ module Definition.Untyped.Bool.Nr
   (𝐌 : IsMode)
   -- It is assumed that the modality has an nr function.
   ⦃ has-nr : Has-nr 𝕄 ⦄
+  -- It is assumed that the modality has the grade ω
+  ⦃ has-omega : Has-omega 𝕄 ⦄
   where
 
 private
-  open module M = Modality 𝕄 using (𝟘; 𝟙; ω; _+_; _·_; _∧_)
+  open module M = Modality 𝕄 using (𝟘; 𝟙; _+_; _·_; _∧_)
 
 open IsMode 𝐌
+open Has-omega has-omega
 
 open import Definition.Untyped M
 open import Definition.Untyped.Empty 𝕄

--- a/Definition/Untyped/Identity.agda
+++ b/Definition/Untyped/Identity.agda
@@ -23,6 +23,7 @@ open import Definition.Untyped M
 open import Definition.Untyped.Properties M
 
 open import Graded.Mode
+open import Graded.Modality.Omega-instances
 
 open import Tools.Fin
 open import Tools.Function
@@ -67,6 +68,7 @@ opaque
   -- Symmetry.
 
   symmetry :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Term n → Term n → Term n → Term n → Term n
   symmetry A t u eq =
     subst ω A (Id (wk1 A) (var x0) (wk1 t)) t u eq rfl
@@ -77,6 +79,7 @@ opaque
   -- A substitution lemma for symmetry.
 
   symmetry-[] :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     symmetry A t u eq [ σ ] ≡
     symmetry (A [ σ ]) (t [ σ ]) (u [ σ ]) (eq [ σ ])
   symmetry-[] {A} {t} {u} {eq} {σ} =
@@ -96,6 +99,7 @@ opaque
   -- Transitivity.
 
   transitivity :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Term n → Term n → Term n → Term n → Term n → Term n → Term n
   transitivity A t u v eq₁ eq₂ =
     subst ω A (Id (wk1 A) (wk1 t) (var x0)) u v eq₂ eq₁
@@ -106,6 +110,7 @@ opaque
   -- A substitution lemma for transitivity.
 
   transitivity-[] :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     transitivity A t u v eq₁ eq₂ [ σ ] ≡
     transitivity (A [ σ ]) (t [ σ ]) (u [ σ ]) (v [ σ ]) (eq₁ [ σ ])
       (eq₂ [ σ ])
@@ -125,6 +130,7 @@ opaque
   -- A simplification lemma for transitivity and symmetry.
 
   transitivity-symmetryˡ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Term n → Term n → Term n → Term n → Term n
   transitivity-symmetryˡ A t u eq =
     J ω ω A t
@@ -176,7 +182,9 @@ opaque
 
   -- An inverse of cast.
 
-  cast⁻¹ : Lvl n → Term n → Term n → Term n → Term n → Term n
+  cast⁻¹ :
+   ⦃ ok : Has-omega _ 𝕄 ⦄ →
+   Lvl n → Term n → Term n → Term n → Term n → Term n
   cast⁻¹ l A B t u =
     cast l B A (symmetry (U l) A B t) u
 
@@ -186,6 +194,7 @@ opaque
   -- A substitution lemma for cast⁻¹.
 
   cast⁻¹-[] :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     cast⁻¹ l A B t u [ σ ] ≡
     cast⁻¹ (l [ σ ]) (A [ σ ]) (B [ σ ]) (t [ σ ]) (u [ σ ])
   cast⁻¹-[] {l} {A} {B} {t} {u} {σ} =
@@ -202,6 +211,7 @@ opaque
   -- A weakening lemma for cast⁻¹.
 
   wk-cast⁻¹ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     wk ρ (cast⁻¹ l A B t u) ≡
     cast⁻¹ (wk ρ l) (wk ρ A) (wk ρ B) (wk ρ t) (wk ρ u)
   wk-cast⁻¹ {ρ} {l} {A} {B} {t} {u} =
@@ -275,6 +285,7 @@ opaque
   -- Binary congruence.
 
   cong₂ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     M → Term n → Term n → Term n → Term n → Term n → Term n → Term n →
     Term (2+ n) → Term n → Term n → Term n
   cong₂ p A₁ t₁ u₁ A₂ t₂ u₂ B v w₁ w₂ =
@@ -288,6 +299,7 @@ opaque
   -- A substitution lemma for cong₂.
 
   cong₂-[] :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     cong₂ p A₁ t₁ u₁ A₂ t₂ u₂ B v w₁ w₂ [ σ ] ≡
     cong₂ p (A₁ [ σ ]) (t₁ [ σ ]) (u₁ [ σ ]) (A₂ [ σ ]) (t₂ [ σ ])
       (u₂ [ σ ]) (B [ σ ]) (v [ σ ⇑[ 2 ] ]) (w₁ [ σ ]) (w₂ [ σ ])
@@ -340,6 +352,7 @@ opaque
   -- If two functions are equal, then they are pointwise equal.
 
   pointwise-equality :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     M → M → Term n → Term (1+ n) → Term n → Term n → Term n → Term n →
     Term n
   pointwise-equality p q A B t u v w =
@@ -351,6 +364,7 @@ opaque
   -- A substitution lemma for pointwise-equality.
 
   pointwise-equality-[] :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     pointwise-equality p q A B t u v w [ σ ] ≡
     pointwise-equality p q (A [ σ ]) (B [ liftSubst σ ]) (t [ σ ])
       (u [ σ ]) (v [ σ ]) (w [ σ ])
@@ -371,7 +385,9 @@ opaque
 
   -- Uniqueness of identity proofs (UIP)
 
-  uip : M → M → Term n → Term n → Term n → Term n → Term n → Term n
+  uip :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
+    M → M → Term n → Term n → Term n → Term n → Term n → Term n
   uip p q A t u eq₁ eq₂ =
     transitivity
       (Id A t u)
@@ -531,7 +547,7 @@ module Internal
 
   private variable
     c                                     : I.Constants
-    pᵢ p′ᵢ qᵢ q′ᵢ                         : I.Termᵍ _
+    pᵢ p′ᵢ qᵢ q′ᵢ ωᵢ                      : I.Termᵍ _
     Aᵢ A₁ᵢ A₂ᵢ Bᵢ eq₁ᵢ eq₂ᵢ
       tᵢ t₁ᵢ t₂ᵢ uᵢ u₁ᵢ u₂ᵢ vᵢ wᵢ w₁ᵢ w₂ᵢ : I.Term _ _
     lᵢ l₁ᵢ l₂ᵢ                            : I.Lvl _ _
@@ -579,10 +595,11 @@ module Internal
   -- type-checker.
 
   transitivityᵢ :
+    I.Termᵍ (c .I.gs) →
     I.Term c n → I.Term c n → I.Term c n → I.Term c n → I.Term c n →
     I.Term c n → I.Term c n
-  transitivityᵢ A t u v eq₁ eq₂ =
-    substᵢ I.ω A (I.Id (IW.wk[ 1 ] A) (IW.wk[ 1 ] t) (I.var x0)) u v eq₂
+  transitivityᵢ ω A t u v eq₁ eq₂ =
+    substᵢ ω A (I.Id (IW.wk[ 1 ] A) (IW.wk[ 1 ] t) (I.var x0)) u v eq₂
       eq₁
 
   opaque
@@ -591,10 +608,12 @@ module Internal
     -- A translation lemma for transitivityᵢ.
 
     ⌜transitivityᵢ⌝ :
-      I.⌜ transitivityᵢ Aᵢ tᵢ uᵢ vᵢ eq₁ᵢ eq₂ᵢ ⌝ γ ≡
+      ⦃ ok : Has-omega _ 𝕄 ⦄ →
+      I.⟦ ωᵢ ⟧ᵍ γ ≡ ω →
+      I.⌜ transitivityᵢ ωᵢ Aᵢ tᵢ uᵢ vᵢ eq₁ᵢ eq₂ᵢ ⌝ γ ≡
       transitivity (I.⌜ Aᵢ ⌝ γ) (I.⌜ tᵢ ⌝ γ) (I.⌜ uᵢ ⌝ γ) (I.⌜ vᵢ ⌝ γ)
         (I.⌜ eq₁ᵢ ⌝ γ) (I.⌜ eq₂ᵢ ⌝ γ)
-    ⌜transitivityᵢ⌝ = refl
+    ⌜transitivityᵢ⌝ eq rewrite eq = refl
 
   -- A variant of cong, intended to be used with the internal
   -- type-checker.
@@ -613,8 +632,8 @@ module Internal
     -- A translation lemma for congᵢ.
 
     ⌜congᵢ⌝ :
-      I.⌜ congᵢ pᵢ Aᵢ tᵢ uᵢ Bᵢ vᵢ wᵢ ⌝ γ ≡
-      cong (I.⟦ pᵢ ⟧ᵍ γ) (I.⌜ Aᵢ ⌝ γ) (I.⌜ tᵢ ⌝ γ) (I.⌜ uᵢ ⌝ γ)
+      I.⌜ congᵢ ωᵢ Aᵢ tᵢ uᵢ Bᵢ vᵢ wᵢ ⌝ γ ≡
+      cong (I.⟦ ωᵢ ⟧ᵍ γ) (I.⌜ Aᵢ ⌝ γ) (I.⌜ tᵢ ⌝ γ) (I.⌜ uᵢ ⌝ γ)
         (I.⌜ Bᵢ ⌝ γ) (I.⌜ vᵢ ⌝ γ) (I.⌜ wᵢ ⌝ γ)
     ⌜congᵢ⌝ = refl
 
@@ -622,11 +641,12 @@ module Internal
   -- type-checker.
 
   cong₂ᵢ :
+    I.Termᵍ (c .I.gs) →
     I.Termᵍ (c .I.gs) → I.Term c n → I.Term c n → I.Term c n →
     I.Term c n → I.Term c n → I.Term c n → I.Term c n →
     I.Term c (2+ n) → I.Term c n → I.Term c n → I.Term c n
-  cong₂ᵢ p A₁ t₁ u₁ A₂ t₂ u₂ B v w₁ w₂ =
-    transitivityᵢ B (I.subst v (I.cons (IS.sgSubst t₁) t₂))
+  cong₂ᵢ ω p A₁ t₁ u₁ A₂ t₂ u₂ B v w₁ w₂ =
+    transitivityᵢ ω B (I.subst v (I.cons (IS.sgSubst t₁) t₂))
       (I.subst v (I.cons (IS.sgSubst u₁) t₂))
       (I.subst v (I.cons (IS.sgSubst u₁) u₂))
       (congᵢ p A₁ t₁ u₁ B (I.subst v (IS.sgSubst (IW.wk[ 1 ] t₂))) w₁)
@@ -638,11 +658,13 @@ module Internal
     -- A translation lemma for cong₂ᵢ.
 
     ⌜cong₂ᵢ⌝ :
-      I.⌜ cong₂ᵢ pᵢ A₁ᵢ t₁ᵢ u₁ᵢ A₂ᵢ t₂ᵢ u₂ᵢ Bᵢ vᵢ w₁ᵢ w₂ᵢ ⌝ γ ≡
+      ⦃ ok : Has-omega _ 𝕄 ⦄ →
+      I.⟦ ωᵢ ⟧ᵍ γ ≡ ω →
+      I.⌜ cong₂ᵢ ωᵢ pᵢ A₁ᵢ t₁ᵢ u₁ᵢ A₂ᵢ t₂ᵢ u₂ᵢ Bᵢ vᵢ w₁ᵢ w₂ᵢ ⌝ γ ≡
       cong₂ (I.⟦ pᵢ ⟧ᵍ γ) (I.⌜ A₁ᵢ ⌝ γ) (I.⌜ t₁ᵢ ⌝ γ) (I.⌜ u₁ᵢ ⌝ γ)
         (I.⌜ A₂ᵢ ⌝ γ) (I.⌜ t₂ᵢ ⌝ γ) (I.⌜ u₂ᵢ ⌝ γ) (I.⌜ Bᵢ ⌝ γ)
         (I.⌜ vᵢ ⌝ γ) (I.⌜ w₁ᵢ ⌝ γ) (I.⌜ w₂ᵢ ⌝ γ)
-    ⌜cong₂ᵢ⌝ = refl
+    ⌜cong₂ᵢ⌝ eq rewrite eq = refl
 
   -- A variant of Funext, intended to be used with the internal
   -- type-checker.

--- a/Everything.agda
+++ b/Everything.agda
@@ -37,6 +37,7 @@ import Tools.Algebra
 
 import Graded.Modality
 import Graded.Modality.Nr-instances
+import Graded.Modality.Omega-instances
 
 ------------------------------------------------------------------------
 -- Properties of the modality semiring
@@ -191,6 +192,7 @@ import Definition.Typed.EqRelInstance
 import Graded.Usage.Erased-matches
 import Graded.Usage.Restrictions.Natrec
 import Graded.Usage.Restrictions.Natrec.Instance
+import Graded.Usage.Restrictions.JK
 import Graded.Usage.Restrictions
 import Graded.Usage.Restrictions.Instance
 import Graded.Usage

--- a/Graded/Box-cong.agda
+++ b/Graded/Box-cong.agda
@@ -61,6 +61,7 @@ import Graded.Derived.Erased.Usage.Zero-one UR as ErasedU₀₁
 open import Graded.Derived.Identity UR
 open import Graded.Erasure.Extraction 𝕄
 import Graded.Erasure.Target as T
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 open import Graded.Neutral TR UR
 open import Graded.Reduction.Zero-one variant TR UR
@@ -70,6 +71,7 @@ open import Graded.Usage.Erased-matches
 open import Graded.Usage.Inversion UR
 open import Graded.Usage.Properties UR
 open import Graded.Usage.Properties.Zero-one variant UR
+open import Graded.Usage.Restrictions.Instance UR
 open import Graded.Usage.Weakening UR
 
 open import Tools.Bool using (Bool; T; true)
@@ -186,6 +188,7 @@ opaque
   -- A usage rule for []-cong-J.
 
   ▸[]-cong-J :
+    ⦃ has-ω : JK-with-omega ⦄ →
     erased-matches-for-J m PE.≡ not-none sem →
     γ₁ ▸[ 𝟘ᵐ[ ok ] ] l →
     γ₂ ▸[ 𝟘ᵐ[ ok ] ] A →
@@ -225,6 +228,7 @@ opaque
   -- Another usage rule for []-cong-J.
 
   ▸[]-cong-J-𝟘ᵐ :
+    ⦃ has-ω : JK-with-omega ⦄ →
     γ₁ ▸[ 𝟘ᵐ[ ok ] ] l →
     γ₂ ▸[ 𝟘ᵐ[ ok ] ] A →
     γ₃ ▸[ 𝟘ᵐ[ ok ] ] t →
@@ -260,6 +264,7 @@ opaque
   -- trivial.
 
   ▸[]-cong-J-trivial :
+    ⦃ has-ω : JK-with-omega ⦄ →
     Trivial →
     γ₁ ▸[ 𝟘ᵐ? ] l →
     γ₂ ▸[ 𝟘ᵐ? ] A →
@@ -1140,6 +1145,7 @@ opaque
   -- modality with 𝟘ᵐ.
 
   Has-[]-cong-for-level-stronger :
+    ⦃ has-ω : JK-with-omega ⦄ →
     {Γ : Con Term n} →
     (s PE.≡ 𝕨 → ¬ T 𝟘ᵐ-allowed → Trivial) →
     (s PE.≡ 𝕨 → Prodrec-allowed 𝟘ᵐ? (𝟘 ∧ 𝟙) 𝟘 𝟘) →
@@ -1260,6 +1266,7 @@ opaque
   -- with 𝟘ᵐ.
 
   Has-computing-[]-cong-for-level-stronger :
+    ⦃ has-ω : JK-with-omega ⦄ →
     {Γ : Con Term n} →
     (s PE.≡ 𝕨 → ¬ T 𝟘ᵐ-allowed → Trivial) →
     (s PE.≡ 𝕨 → Prodrec-allowed 𝟘ᵐ? (𝟘 ∧ 𝟙) 𝟘 𝟘) →
@@ -1867,6 +1874,7 @@ opaque
   -- erasure modality with 𝟘ᵐ.
 
   Has-[]-cong-stronger :
+    ⦃ has-ω : JK-with-omega ⦄ →
     {Γ : Con Term n} →
     (s PE.≡ 𝕨 → ¬ T 𝟘ᵐ-allowed → Trivial) →
     (s PE.≡ 𝕨 → Prodrec-allowed 𝟘ᵐ? (𝟘 ∧ 𝟙) 𝟘 𝟘) →
@@ -2055,6 +2063,7 @@ opaque
   -- erasure modality with 𝟘ᵐ.
 
   Has-computing-[]-cong-stronger :
+    ⦃ has-ω : JK-with-omega ⦄ →
     {Γ : Con Term n} →
     (s PE.≡ 𝕨 → ¬ T 𝟘ᵐ-allowed → Trivial) →
     (s PE.≡ 𝕨 → Prodrec-allowed 𝟘ᵐ? (𝟘 ∧ 𝟙) 𝟘 𝟘) →
@@ -2376,6 +2385,7 @@ opaque
 
 private
   module []-cong⊎J⊎𝟘ᵐ⊎Trivial⊎Equality-reflection→[]-cong
+    ⦃ has-ω : JK-with-omega ⦄
     (ok : ([]-cong-allowed s × []-cong-allowed-mode s m) ⊎
           Erased-allowed s ×
           (erased-matches-for-J m ≢ none × T 𝟘ᵐ-allowed ⊎
@@ -2597,6 +2607,7 @@ opaque
   --   * equality reflection is allowed.
 
   []-cong⊎J⊎𝟘ᵐ⊎Trivial⊎Equality-reflection→[]-cong-for-level :
+    ⦃ has-ω : JK-with-omega ⦄ →
     {Γ : Con Term n} →
     ([]-cong-allowed s × []-cong-allowed-mode s m) ⊎
     Erased-allowed s ×
@@ -2658,6 +2669,7 @@ opaque
   --   * equality reflection is allowed.
 
   []-cong⊎J⊎𝟘ᵐ⊎Trivial⊎Equality-reflection→[]-cong :
+    ⦃ has-ω : JK-with-omega ⦄ →
     {Γ : Con Term n} →
     Level-allowed →
     ([]-cong-allowed s × []-cong-allowed-mode s m) ⊎
@@ -2874,6 +2886,7 @@ opaque
   -- Consistent (ε » Δ) also holds.
 
   ¬-[]-cong-for-level′ :
+    ⦃ has-ω : JK-with-omega ⦄ →
     ⦃ not-ok : No-equality-reflection ⦄
     ⦃ 𝟘-well-behaved : Has-well-behaved-zero 𝕄 ⦄ →
     No-erased-matches TR UR →
@@ -2949,6 +2962,7 @@ opaque
   -- holds.
 
   ¬-[]-cong′ :
+    ⦃ has-ω : JK-with-omega ⦄ →
     ⦃ not-ok : No-equality-reflection ⦄
     ⦃ 𝟘-well-behaved : Has-well-behaved-zero 𝕄 ⦄ →
     No-erased-matches TR UR →

--- a/Graded/Context/Properties.agda
+++ b/Graded/Context/Properties.agda
@@ -31,6 +31,7 @@ open import Graded.Context.Properties.Natrec 𝕄 public
 open import Graded.Context.Properties.PartialOrder 𝕄 public
 open import Graded.Context.Properties.Star 𝕄 public
 open import Graded.Context.Properties.Update 𝕄 public
+open import Graded.Modality.Omega-instances
 
 private
   variable
@@ -207,7 +208,9 @@ opaque
 
   -- A lemma related to some of the usage rules for J and K.
 
-  ω·ᶜ+ᶜ²𝟘ᶜ : ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ) ≈ᶜ 𝟘ᶜ {n = n}
+  ω·ᶜ+ᶜ²𝟘ᶜ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
+    ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ) ≈ᶜ 𝟘ᶜ {n = n}
   ω·ᶜ+ᶜ²𝟘ᶜ = begin
     ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ)  ≈⟨ ·ᶜ-congˡ $ +ᶜ-identityˡ _ ⟩
     ω ·ᶜ 𝟘ᶜ          ≈⟨ ·ᶜ-zeroʳ _ ⟩
@@ -219,7 +222,9 @@ opaque
 
   -- A lemma related to one of the usage rules for K.
 
-  ω·ᶜ+ᶜ⁴𝟘ᶜ : ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ) ≈ᶜ 𝟘ᶜ {n = n}
+  ω·ᶜ+ᶜ⁴𝟘ᶜ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
+    ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ) ≈ᶜ 𝟘ᶜ {n = n}
   ω·ᶜ+ᶜ⁴𝟘ᶜ = begin
     ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ)  ≈⟨ ·ᶜ-congˡ +ᶜ⁴𝟘ᶜ ⟩
     ω ·ᶜ 𝟘ᶜ                      ≈⟨ ·ᶜ-zeroʳ _ ⟩
@@ -231,7 +236,9 @@ opaque
 
   -- A lemma related to one of the usage rules for J.
 
-  ω·ᶜ+ᶜ⁵𝟘ᶜ : ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ) ≈ᶜ 𝟘ᶜ {n = n}
+  ω·ᶜ+ᶜ⁵𝟘ᶜ :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
+    ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ) ≈ᶜ 𝟘ᶜ {n = n}
   ω·ᶜ+ᶜ⁵𝟘ᶜ = begin
     ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ)  ≈⟨ ·ᶜ-congˡ +ᶜ⁵𝟘ᶜ ⟩
     ω ·ᶜ 𝟘ᶜ                            ≈⟨ ·ᶜ-zeroʳ _ ⟩

--- a/Graded/Context/Properties/Addition.agda
+++ b/Graded/Context/Properties/Addition.agda
@@ -10,6 +10,7 @@ module Graded.Context.Properties.Addition
 open import Graded.Context 𝕄
 open import Graded.Context.Properties.Equivalence 𝕄
 open import Graded.Context.Properties.PartialOrder 𝕄
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 
 open import Tools.Algebra
@@ -157,7 +158,7 @@ opaque
 
   -- The context ω ·ᶜ (γ +ᶜ δ) is bounded by ω ·ᶜ δ.
 
-  ω·ᶜ+ᶜ≤ω·ᶜʳ : ω ·ᶜ (γ +ᶜ δ) ≤ᶜ ω ·ᶜ δ
+  ω·ᶜ+ᶜ≤ω·ᶜʳ : ⦃ ok : Has-omega _ 𝕄 ⦄ → ω ·ᶜ (γ +ᶜ δ) ≤ᶜ ω ·ᶜ δ
   ω·ᶜ+ᶜ≤ω·ᶜʳ {γ = ε}     {δ = ε}     = ε
   ω·ᶜ+ᶜ≤ω·ᶜʳ {γ = _ ∙ _} {δ = _ ∙ _} = ω·ᶜ+ᶜ≤ω·ᶜʳ ∙ ω·+≤ω·ʳ
 
@@ -165,6 +166,6 @@ opaque
 
   -- The context ω ·ᶜ (γ +ᶜ δ) is bounded by ω ·ᶜ γ.
 
-  ω·ᶜ+ᶜ≤ω·ᶜˡ : ω ·ᶜ (γ +ᶜ δ) ≤ᶜ ω ·ᶜ γ
+  ω·ᶜ+ᶜ≤ω·ᶜˡ : ⦃ ok : Has-omega _ 𝕄 ⦄ → ω ·ᶜ (γ +ᶜ δ) ≤ᶜ ω ·ᶜ γ
   ω·ᶜ+ᶜ≤ω·ᶜˡ {γ = ε}     {δ = ε}     = ε
   ω·ᶜ+ᶜ≤ω·ᶜˡ {γ = _ ∙ _} {δ = _ ∙ _} = ω·ᶜ+ᶜ≤ω·ᶜˡ ∙ ω·+≤ω·ˡ

--- a/Graded/Context/Properties/Multiplication.agda
+++ b/Graded/Context/Properties/Multiplication.agda
@@ -10,6 +10,7 @@ module Graded.Context.Properties.Multiplication
 open import Graded.Context 𝕄
 open import Graded.Context.Properties.Equivalence 𝕄
 open import Graded.Context.Properties.PartialOrder 𝕄
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 
 open import Tools.Nat using (Nat; 1+)
@@ -128,6 +129,6 @@ private
 
 -- Multiplication by ω is decreasing.
 
-ω·ᶜ-decreasing : ω ·ᶜ γ ≤ᶜ γ
+ω·ᶜ-decreasing : ⦃ ok : Has-omega _ 𝕄 ⦄ → ω ·ᶜ γ ≤ᶜ γ
 ω·ᶜ-decreasing {γ = ε}     = ε
 ω·ᶜ-decreasing {γ = _ ∙ _} = ω·ᶜ-decreasing ∙ ω·-decreasing

--- a/Graded/Context/Properties/Natrec.agda
+++ b/Graded/Context/Properties/Natrec.agda
@@ -14,6 +14,7 @@ module Graded.Context.Properties.Natrec
 open import Graded.Context 𝕄
 open import Graded.Context.Properties.Equivalence 𝕄
 open import Graded.Modality.Nr-instances
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties.Natrec 𝕄
 
 open import Tools.Fin
@@ -151,6 +152,7 @@ module _  ⦃ has-nr : Has-nr 𝕄 ⦄ where
     -- corresponding property holds for nrᶜ.
 
     nrᶜ-linearity-like-for-𝟙 :
+      ⦃ ok : Has-omega 𝕄 ⦄ →
       Linearity-like-nr-for-𝟙 →
       nrᶜ p 𝟙 γ δ η ≈ᶜ (𝟙 + p) ·ᶜ η +ᶜ ω ·ᶜ δ +ᶜ γ
     nrᶜ-linearity-like-for-𝟙 {γ = ε}     {δ = ε}     {η = ε}     _   = ε

--- a/Graded/Context/QuantityTranslation.agda
+++ b/Graded/Context/QuantityTranslation.agda
@@ -28,6 +28,7 @@ open import Graded.Modality.Morphism as M
   using (Is-morphism; Is-order-embedding; Is-Σ-order-embedding)
   hiding (module Is-morphism; module Is-order-embedding;
           module Is-Σ-order-embedding)
+open import Graded.Modality.Omega-instances
 import Graded.Modality.Properties
 
 private
@@ -313,74 +314,6 @@ module Is-order-embedding (m : Is-order-embedding 𝕄₁ 𝕄₂ tr) where
     case tr-≤-+ hyp₂ of λ (_ , _ , ≤q , ≤r , p≤) →
     _ , _ , ≤δ ∙ ≤q , ≤η ∙ ≤r , γ≤ ∙ p≤
 
-  opaque
-
-    -- A variant of tr-≤-ω·+ for usage contexts.
-
-    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ :
-      tr-Conₘ γ C₂.≤ᶜ M₂.ω C₂.·ᶜ (δ C₂.+ᶜ η) →
-      ∃₂ λ δ′ η′ →
-        tr-Conₘ δ′ C₂.≤ᶜ δ × tr-Conₘ η′ C₂.≤ᶜ η ×
-        γ C₁.≤ᶜ M₁.ω C₁.·ᶜ (δ′ C₁.+ᶜ η′)
-    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ {γ = ε} {δ = ε} {η = ε} _ =
-      ε , ε , ε , ε , ε
-    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ
-      {γ = _ ∙ _} {δ = _ ∙ _} {η = _ ∙ _} (hyp₁ ∙ hyp₂) =
-      case tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ hyp₁ of λ (_ , _ , ≤δ , ≤η , γ≤) →
-      case tr-≤-ω·+ hyp₂ of λ (_ , _ , ≤q , ≤r , p≤) →
-      _ , _ , ≤δ ∙ ≤q , ≤η ∙ ≤r , γ≤ ∙ p≤
-
-  opaque
-
-    -- A variant of tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ.
-
-    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ³ :
-      tr-Conₘ γ C₂.≤ᶜ M₂.ω C₂.·ᶜ (δ₁ C₂.+ᶜ δ₂ C₂.+ᶜ δ₃ C₂.+ᶜ δ₄) →
-      ∃₄ λ δ₁′ δ₂′ δ₃′ δ₄′ →
-        tr-Conₘ δ₁′ C₂.≤ᶜ δ₁ × tr-Conₘ δ₂′ C₂.≤ᶜ δ₂ ×
-        tr-Conₘ δ₃′ C₂.≤ᶜ δ₃ × tr-Conₘ δ₄′ C₂.≤ᶜ δ₄ ×
-        γ C₁.≤ᶜ M₁.ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ₂′ C₁.+ᶜ δ₃′ C₁.+ᶜ δ₄′)
-    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ³ {γ} γ≤ =
-      case tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ γ≤ of λ
-        (δ₁′ , δ′ , δ₁′≤ , δ′≤ , γ≤) →
-      case tr-Conₘ-≤ᶜ-+ᶜ δ′≤ of λ
-        (δ₂′ , δ″ , δ₂′≤ , δ″≤ , δ′≤′) →
-      case tr-Conₘ-≤ᶜ-+ᶜ δ″≤ of λ
-        (δ₃′ , δ₄′ , δ₃′≤ , δ₄′≤ , δ″≤′) →
-      δ₁′ , δ₂′ , δ₃′ , δ₄′ , δ₁′≤ , δ₂′≤ , δ₃′≤ , δ₄′≤ , (begin
-        γ                                               ≤⟨ γ≤ ⟩
-        M₁.ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ′)                       ≤⟨ CP₁.·ᶜ-monotoneʳ $ CP₁.+ᶜ-monotoneʳ δ′≤′ ⟩
-        M₁.ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ₂′ C₁.+ᶜ δ″)             ≤⟨ CP₁.·ᶜ-monotoneʳ $ CP₁.+ᶜ-monotoneʳ $ CP₁.+ᶜ-monotoneʳ δ″≤′ ⟩
-        M₁.ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ₂′ C₁.+ᶜ δ₃′ C₁.+ᶜ δ₄′)  ∎)
-      where
-      open CP₁.≤ᶜ-reasoning
-
-  opaque
-
-    -- Another variant of tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ.
-
-    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ⁴ :
-      tr-Conₘ γ C₂.≤ᶜ
-      M₂.ω C₂.·ᶜ (δ₁ C₂.+ᶜ δ₂ C₂.+ᶜ δ₃ C₂.+ᶜ δ₄ C₂.+ᶜ δ₅) →
-      ∃₅ λ δ₁′ δ₂′ δ₃′ δ₄′ δ₅′ →
-        tr-Conₘ δ₁′ C₂.≤ᶜ δ₁ × tr-Conₘ δ₂′ C₂.≤ᶜ δ₂ ×
-        tr-Conₘ δ₃′ C₂.≤ᶜ δ₃ × tr-Conₘ δ₄′ C₂.≤ᶜ δ₄ ×
-        tr-Conₘ δ₅′ C₂.≤ᶜ δ₅ ×
-        γ C₁.≤ᶜ M₁.ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ₂′ C₁.+ᶜ δ₃′ C₁.+ᶜ δ₄′ C₁.+ᶜ δ₅′)
-    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ⁴ {γ} γ≤ =
-      case tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ³ γ≤ of λ
-        (δ₁′ , δ₂′ , δ₃′ , δ′ , δ₁′≤ , δ₂′≤ , δ₃′≤ , δ′≤ , γ≤) →
-      case tr-Conₘ-≤ᶜ-+ᶜ δ′≤ of λ
-        (δ₄′ , δ₅′ , δ₄′≤ , δ₅′≤ , δ′≤′) →
-        δ₁′ , δ₂′ , δ₃′ , δ₄′ , δ₅′ , δ₁′≤ , δ₂′≤ , δ₃′≤ , δ₄′≤ , δ₅′≤
-      , (begin
-           γ                                                         ≤⟨ γ≤ ⟩
-           M₁.ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ₂′ C₁.+ᶜ δ₃′ C₁.+ᶜ δ′)             ≤⟨ CP₁.·ᶜ-monotoneʳ $ CP₁.+ᶜ-monotoneʳ $ CP₁.+ᶜ-monotoneʳ $ CP₁.+ᶜ-monotoneʳ
-                                                                        δ′≤′ ⟩
-           M₁.ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ₂′ C₁.+ᶜ δ₃′ C₁.+ᶜ δ₄′ C₁.+ᶜ δ₅′)  ∎)
-      where
-      open CP₁.≤ᶜ-reasoning
-
   -- A variant of tr-≤-∧ for usage contexts.
 
   tr-Conₘ-≤ᶜ-∧ᶜ :
@@ -393,3 +326,85 @@ module Is-order-embedding (m : Is-order-embedding 𝕄₁ 𝕄₂ tr) where
     case tr-Conₘ-≤ᶜ-∧ᶜ hyp₁ of λ (_ , _ , ≤δ , ≤η , γ≤) →
     case tr-≤-∧ hyp₂ of λ (_ , _ , ≤q , ≤r , p≤) →
     _ , _ , ≤δ ∙ ≤q , ≤η ∙ ≤r , γ≤ ∙ p≤
+
+------------------------------------------------------------------------
+-- Lemmas that hold if the translation is an omega reflecting
+-- order-embedding.
+
+module Is-omega-reflecting
+  ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+  ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄
+  (m : Is-order-embedding 𝕄₁ 𝕄₂ tr)
+  (m′ : M.Is-omega-reflecting-morphism 𝕄₁ 𝕄₂ tr)
+  where
+
+  open Is-order-embedding m
+  open M.Is-omega-reflecting-morphism m′
+
+  opaque
+
+    -- A variant of tr-≤-ω·+ for usage contexts.
+
+    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ :
+      tr-Conₘ γ C₂.≤ᶜ ω C₂.·ᶜ (δ C₂.+ᶜ η) →
+      ∃₂ λ δ′ η′ →
+        tr-Conₘ δ′ C₂.≤ᶜ δ × tr-Conₘ η′ C₂.≤ᶜ η ×
+        γ C₁.≤ᶜ ω C₁.·ᶜ (δ′ C₁.+ᶜ η′)
+    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ {γ = ε} {δ = ε} {η = ε} _ =
+      ε , ε , ε , ε , ε
+    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ
+      {γ = _ ∙ _} {δ = _ ∙ _} {η = _ ∙ _} (hyp₁ ∙ hyp₂) =
+      case tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ hyp₁ of λ (_ , _ , ≤δ , ≤η , γ≤) →
+      case tr-≤-ω·+ m hyp₂ of λ (_ , _ , ≤q , ≤r , p≤) →
+      _ , _ , ≤δ ∙ ≤q , ≤η ∙ ≤r , γ≤ ∙ p≤
+
+  opaque
+
+    -- A variant of tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ.
+
+    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ³ :
+      tr-Conₘ γ C₂.≤ᶜ ω C₂.·ᶜ (δ₁ C₂.+ᶜ δ₂ C₂.+ᶜ δ₃ C₂.+ᶜ δ₄) →
+      ∃₄ λ δ₁′ δ₂′ δ₃′ δ₄′ →
+        tr-Conₘ δ₁′ C₂.≤ᶜ δ₁ × tr-Conₘ δ₂′ C₂.≤ᶜ δ₂ ×
+        tr-Conₘ δ₃′ C₂.≤ᶜ δ₃ × tr-Conₘ δ₄′ C₂.≤ᶜ δ₄ ×
+        γ C₁.≤ᶜ ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ₂′ C₁.+ᶜ δ₃′ C₁.+ᶜ δ₄′)
+    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ³ {γ} γ≤ =
+      case tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ γ≤ of λ
+        (δ₁′ , δ′ , δ₁′≤ , δ′≤ , γ≤) →
+      case tr-Conₘ-≤ᶜ-+ᶜ δ′≤ of λ
+        (δ₂′ , δ″ , δ₂′≤ , δ″≤ , δ′≤′) →
+      case tr-Conₘ-≤ᶜ-+ᶜ δ″≤ of λ
+        (δ₃′ , δ₄′ , δ₃′≤ , δ₄′≤ , δ″≤′) →
+      δ₁′ , δ₂′ , δ₃′ , δ₄′ , δ₁′≤ , δ₂′≤ , δ₃′≤ , δ₄′≤ , (begin
+        γ                                            ≤⟨ γ≤ ⟩
+        ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ′)                       ≤⟨ CP₁.·ᶜ-monotoneʳ $ CP₁.+ᶜ-monotoneʳ δ′≤′ ⟩
+        ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ₂′ C₁.+ᶜ δ″)             ≤⟨ CP₁.·ᶜ-monotoneʳ $ CP₁.+ᶜ-monotoneʳ $ CP₁.+ᶜ-monotoneʳ δ″≤′ ⟩
+        ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ₂′ C₁.+ᶜ δ₃′ C₁.+ᶜ δ₄′)  ∎)
+      where
+      open CP₁.≤ᶜ-reasoning
+
+  opaque
+
+    -- Another variant of tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ.
+
+    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ⁴ :
+      tr-Conₘ γ C₂.≤ᶜ
+      ω C₂.·ᶜ (δ₁ C₂.+ᶜ δ₂ C₂.+ᶜ δ₃ C₂.+ᶜ δ₄ C₂.+ᶜ δ₅) →
+      ∃₅ λ δ₁′ δ₂′ δ₃′ δ₄′ δ₅′ →
+        tr-Conₘ δ₁′ C₂.≤ᶜ δ₁ × tr-Conₘ δ₂′ C₂.≤ᶜ δ₂ ×
+        tr-Conₘ δ₃′ C₂.≤ᶜ δ₃ × tr-Conₘ δ₄′ C₂.≤ᶜ δ₄ ×
+        tr-Conₘ δ₅′ C₂.≤ᶜ δ₅ ×
+        γ C₁.≤ᶜ ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ₂′ C₁.+ᶜ δ₃′ C₁.+ᶜ δ₄′ C₁.+ᶜ δ₅′)
+    tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ⁴ {γ} γ≤ =
+      case tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ³ γ≤ of λ
+        (δ₁′ , δ₂′ , δ₃′ , δ′ , δ₁′≤ , δ₂′≤ , δ₃′≤ , δ′≤ , γ≤) →
+      case tr-Conₘ-≤ᶜ-+ᶜ δ′≤ of λ
+        (δ₄′ , δ₅′ , δ₄′≤ , δ₅′≤ , δ′≤′) →
+        δ₁′ , δ₂′ , δ₃′ , δ₄′ , δ₅′ , δ₁′≤ , δ₂′≤ , δ₃′≤ , δ₄′≤ , δ₅′≤
+      , (begin
+           γ                                                      ≤⟨ γ≤ ⟩
+           ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ₂′ C₁.+ᶜ δ₃′ C₁.+ᶜ δ′)             ≤⟨ CP₁.·ᶜ-monotoneʳ $ CP₁.+ᶜ-monotoneʳ $ CP₁.+ᶜ-monotoneʳ $ CP₁.+ᶜ-monotoneʳ
+                                                                     δ′≤′ ⟩
+           ω C₁.·ᶜ (δ₁′ C₁.+ᶜ δ₂′ C₁.+ᶜ δ₃′ C₁.+ᶜ δ₄′ C₁.+ᶜ δ₅′)  ∎)
+      where
+      open CP₁.≤ᶜ-reasoning

--- a/Graded/Derived/Bool/Erased.agda
+++ b/Graded/Derived/Bool/Erased.agda
@@ -16,6 +16,8 @@ module Graded.Derived.Bool.Erased
   (open Usage-restrictions R)
   -- It is assumed that the modality has an nr function.
   ⦃ has-nr : Nr-available ⦄
+  -- It is assumed that the modality has a grade ω.
+  ⦃ has-ω : Has-omega 𝕄 ⦄
   where
 
 open Modality 𝕄
@@ -35,6 +37,7 @@ open import Graded.Derived.Empty R
 open import Graded.Derived.Erased.Usage R 𝕨
 open import Graded.Derived.Nat R
 open import Graded.Usage.Restrictions.Instance R
+  hiding (JK-with-omega-has-omega)
 open import Graded.Modality.Nr-instances
 open import Graded.Modality.Properties 𝕄
 open import Graded.Substitution.Properties R

--- a/Graded/Derived/Bool/Nr.agda
+++ b/Graded/Derived/Bool/Nr.agda
@@ -17,10 +17,13 @@ module Graded.Derived.Bool.Nr
   (open Usage-restrictions R)
   -- It is assumed that the modality has an nr function.
   ⦃ has-nr : Nr-available ⦄
+  -- It is assumed that the modality has a grade ω.
+  ⦃ has-ω : Has-omega 𝕄 ⦄
   where
 
 open Modality 𝕄
 open IsMode 𝐌
+open Has-omega has-ω
 
 open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
@@ -33,6 +36,7 @@ open import Graded.Substitution.Properties R
 open import Graded.Usage R
 open import Graded.Usage.Properties R
 open import Graded.Usage.Restrictions.Instance R
+  hiding (JK-with-omega-has-omega)
 open import Graded.Usage.Weakening R
 
 open import Definition.Untyped M

--- a/Graded/Derived/Erased/Usage.agda
+++ b/Graded/Derived/Erased/Usage.agda
@@ -21,12 +21,14 @@ open Usage-restrictions R
 
 open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 open import Graded.Substitution R
 open import Graded.Substitution.Properties R
 open import Graded.Usage R
 open import Graded.Usage.Inversion R
 open import Graded.Usage.Properties R
+open import Graded.Usage.Restrictions.Instance R
 open import Graded.Usage.Weakening R
 
 open import Definition.Untyped M
@@ -367,6 +369,7 @@ opaque
   -- A usage rule for substᵉ.
 
   ▸substᵉ :
+    ⦃ ok : JK-with-omega ⦄ →
     (s ≡ 𝕨 → Trivialᵐ → Trivial) →
     (s ≡ 𝕨 → Prodrec-allowed 𝟘ᵐ (𝟘 ∧ 𝟙) 𝟘 𝟘) →
     (s ≡ 𝕤 → Trivialᵐ → 𝟘 ≤ 𝟙) →
@@ -415,6 +418,7 @@ opaque
   -- A usage rule for Jᵉ.
 
   ▸Jᵉ :
+    ⦃ ok : JK-with-omega ⦄ →
     (s ≡ 𝕨 → Trivialᵐ → Trivial) →
     (s ≡ 𝕨 → Prodrec-allowed 𝟘ᵐ (𝟘 ∧ 𝟙) 𝟘 𝟘) →
     (s ≡ 𝕤 → Trivialᵐ → 𝟘 ≤ 𝟙) →

--- a/Graded/Derived/Erased/Usage/Zero-one.agda
+++ b/Graded/Derived/Erased/Usage/Zero-one.agda
@@ -24,9 +24,11 @@ open Usage-restrictions R
 
 open import Graded.Context 𝕄
 import Graded.Derived.Erased.Usage R s as U
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 open import Graded.Usage R
 open import Graded.Usage.Properties R
+open import Graded.Usage.Restrictions.Instance R
 
 open import Definition.Untyped M
 open import Definition.Untyped.Erased 𝕄 s
@@ -134,6 +136,7 @@ opaque
   -- A usage rule for substᵉ.
 
   ▸substᵉ :
+    ⦃ ok : JK-with-omega ⦄ →
     (s ≡ 𝕨 → ¬ T 𝟘ᵐ-allowed → Trivial) →
     (s ≡ 𝕨 → Prodrec-allowed 𝟘ᵐ? (𝟘 ∧ 𝟙) 𝟘 𝟘) →
     (s ≡ 𝕤 → ¬ T 𝟘ᵐ-allowed → 𝟘 ≤ 𝟙) →
@@ -155,6 +158,7 @@ opaque
   -- A usage rule for Jᵉ.
 
   ▸Jᵉ :
+    ⦃ ok : JK-with-omega ⦄ →
     (s ≡ 𝕨 → ¬ T 𝟘ᵐ-allowed → Trivial) →
     (s ≡ 𝕨 → Prodrec-allowed 𝟘ᵐ? (𝟘 ∧ 𝟙) 𝟘 𝟘) →
     (s ≡ 𝕤 → ¬ T 𝟘ᵐ-allowed → 𝟘 ≤ 𝟙) →

--- a/Graded/Derived/Identity.agda
+++ b/Graded/Derived/Identity.agda
@@ -19,11 +19,13 @@ open Usage-restrictions UR
 
 open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 open import Graded.Substitution.Properties UR
 open import Graded.Usage UR
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Properties UR
+open import Graded.Usage.Restrictions.Instance UR
 open import Graded.Usage.Weakening UR
 
 open import Definition.Untyped M
@@ -50,6 +52,7 @@ opaque
   -- A usage rule for subst.
 
   ▸subst :
+    ⦃ ok : JK-with-omega ⦄ →
     γ₁ ▸[ 𝟘ᵐ ] A →
     γ₂ ∙ ⌜ m ⌝ · p ▸[ m ] B →
     γ₃ ▸[ m ] t →
@@ -80,6 +83,7 @@ opaque
   -- A usage rule for subst 𝟘.
 
   ▸subst-𝟘 :
+    ⦃ ok : JK-with-omega ⦄ →
     erased-matches-for-J m ≡ not-none sem →
     γ₁ ▸[ m₁ ] A →
     γ₂ ∙ 𝟘 ▸[ m ] B →
@@ -98,6 +102,7 @@ opaque
   -- A usage rule for cong.
 
   ▸cong :
+    ⦃ ok : JK-with-omega ⦄ →
     γ₁ ▸[ 𝟘ᵐ ] A →
     γ₂ ▸[ m ] t →
     γ₃ ▸[ m ] u →
@@ -166,6 +171,7 @@ opaque
   -- A usage rule for cong 𝟘.
 
   ▸cong-𝟘 :
+    ⦃ ok : JK-with-omega ⦄ →
     erased-matches-for-J m ≡ not-none sem →
     γ₁ ▸[ 𝟘ᵐ ] A →
     γ₂ ▸[ m ] t →

--- a/Graded/Derived/Omega.agda
+++ b/Graded/Derived/Omega.agda
@@ -13,7 +13,7 @@ module Graded.Derived.Omega
   (UR : Usage-restrictions 𝕄 𝐌)
   where
 
-open Modality 𝕄 hiding (ω)
+open Modality 𝕄
 open IsMode 𝐌
 
 open import Graded.Context 𝕄

--- a/Graded/Derived/Omega/Zero-one.agda
+++ b/Graded/Derived/Omega/Zero-one.agda
@@ -15,7 +15,7 @@ module Graded.Derived.Omega.Zero-one
   (UR : Usage-restrictions 𝕄 Zero-one-isMode)
   where
 
-open Modality 𝕄 hiding (ω)
+open Modality 𝕄
 
 open import Graded.Context 𝕄
 import Graded.Derived.Omega UR as O

--- a/Graded/Derived/Unrestricted/Eta/Typed.agda
+++ b/Graded/Derived/Unrestricted/Eta/Typed.agda
@@ -11,6 +11,9 @@ module Graded.Derived.Unrestricted.Eta.Typed
   (open Modality 𝕄)
   (R : Type-restrictions 𝕄)
   (open Type-restrictions R)
+  -- The modality is assumed to have grade ω.
+  ⦃ has-omega : Has-omega _ 𝕄 ⦄
+  (open Has-omega has-omega)
   -- Strong unit types are assumed to be allowed.
   (Unit-ok : Unitˢ-allowed)
   -- It is assumed that strong Σ-types are allowed for the quantities

--- a/Graded/Derived/Unrestricted/Eta/Untyped.agda
+++ b/Graded/Derived/Unrestricted/Eta/Untyped.agda
@@ -7,9 +7,12 @@ open import Graded.Modality
 module Graded.Derived.Unrestricted.Eta.Untyped
   {a} {M : Set a}
   (𝕄 : Modality M)
+  -- It is assumed that the modality has the grade ω
+  ⦃ has-omega : Has-omega _ 𝕄 ⦄
   where
 
 open Modality 𝕄
+open Has-omega has-omega
 
 open import Definition.Untyped M
 

--- a/Graded/Derived/Unrestricted/Eta/Usage.agda
+++ b/Graded/Derived/Unrestricted/Eta/Usage.agda
@@ -11,6 +11,8 @@ module Graded.Derived.Unrestricted.Eta.Usage
   {𝕄 : Modality M}
   {𝐌 : IsMode Mode 𝕄}
   (R : Usage-restrictions 𝕄 𝐌)
+   -- It is assumed that the modality has a grade ω.
+  ⦃ has-ω : Has-omega _ 𝕄 ⦄
   where
 
 open Modality 𝕄
@@ -18,6 +20,7 @@ open IsMode 𝐌
 
 open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 open import Graded.Usage R
 open import Graded.Usage.Inversion R

--- a/Graded/Erasure/Consequences/Soundness.agda
+++ b/Graded/Erasure/Consequences/Soundness.agda
@@ -47,9 +47,11 @@ open import Definition.Typed.Well-formed TR
 open import Graded.Context 𝕄
 open import Graded.Derived.Erased.Usage UR
 open import Graded.Derived.Omega UR
+open import Graded.Modality.Omega-instances
 open import Graded.Usage UR
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Properties UR
+open import Graded.Usage.Restrictions.Instance UR
 open import Graded.Context.Properties 𝕄
 open import Graded.Modality.Properties 𝕄
 
@@ -399,15 +401,14 @@ opaque
        []ⱼ ([]-cong→Erased ok) (⊢zeroᵘ ⊢Id) (zeroⱼ ⊢Id))
       (zeroⱼ ⊢Id) ([]-congⱼ′ ok (⊢zeroᵘ ⊢Id) (var ⊢Id here)) ,
     (λ ()) ,
-    sub-≈ᶜ
-      (Jₘ-generalised (▸Erased s (level zeroᵘₘ) ℕₘ) (▸[] s zeroₘ)
+    Jₘ-generalised′ (▸Erased s (level zeroᵘₘ) ℕₘ) (▸[] s zeroₘ)
          (let open Tools.Reasoning.PartialOrder ≤ᶜ-poset in
           sub ℕₘ $ begin
             𝟘ᶜ ∙ 𝟙 · 𝟘 ∙ 𝟙 · 𝟘  ≈⟨ ≈ᶜ-refl ∙ ·-zeroʳ _ ∙ ·-zeroʳ _ ⟩
             𝟘ᶜ                  ∎)
-         zeroₘ (▸[] s zeroₘ)
-         ([]-congₘ (level zeroᵘₘ) ℕₘ zeroₘ zeroₘ var ok′))
-      (≈ᶜ-sym ω·ᶜ+ᶜ⁵𝟘ᶜ) ,
+         zeroₘ (▸[] s zeroₘ) ([]-congₘ (level zeroᵘₘ) ℕₘ zeroₘ zeroₘ var ok′)
+         (≤ᶜ-reflexive (≈ᶜ-sym ω·ᶜ+ᶜ⁵𝟘ᶜ))
+         (λ _ → ≤ᶜ-refl) ,
     (λ where
        (0 , whred J⇒ ⇨ˢ _) →
          whnfRedTerm J⇒ (ne (Jₙ ([]-congₙ (var _ _))))
@@ -449,20 +450,15 @@ opaque
       inhabited-consistent (⊢ˢʷ∷-sgSubst (rflⱼ (zeroⱼ εε)))
     , Jⱼ′ (⊢ℕ (J-motive-context (zeroⱼ ⊢Id))) (zeroⱼ ⊢Id) (var ⊢Id here)
     , (λ ())
-    , sub
-        (J₀ₘ₁-generalised {m₁ = 𝟙ᵐ} {m₂ = 𝟙ᵐ} {m₃ = 𝟙ᵐ} {m₄ = 𝟙ᵐ}
-          ≡not-none PE.refl PE.refl ℕₘ zeroₘ ℕₘ zeroₘ zeroₘ var)
-        (begin
-           𝟘ᶜ               ≈˘⟨ ω·ᶜ+ᶜ²𝟘ᶜ ⟩
-           ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ)  ∎)
+    , J₀ₘ₁-generalised′ {m₁ = 𝟙ᵐ} {m₂ = 𝟙ᵐ} {m₃ = 𝟙ᵐ} {m₄ = 𝟙ᵐ}
+          ≡not-none PE.refl PE.refl ℕₘ zeroₘ ℕₘ zeroₘ zeroₘ var
+          (≤ᶜ-reflexive (≈ᶜ-sym ω·ᶜ+ᶜ²𝟘ᶜ)) (λ _ → ≤ᶜ-refl)
     , (λ where
          (0    , whred J⇒ ⇨ˢ _) → whnfRedTerm J⇒ (ne (Jₙ (var _ _)))
          (1+ _ , whred J⇒ ⇨ˢ _) → whnfRedTerm J⇒ (ne (Jₙ (var _ _))))
     , sucⁿ≢ne {V = TL.Lift _ ⊤} ⦃ ok = possibly-nonempty ⦄
         _ (Jₙ (var _ _)) ∘→
       sym′ ∘→ proj₂ }
-    where
-    open Tools.Reasoning.PartialOrder ≤ᶜ-poset
 
 opaque
 
@@ -499,20 +495,15 @@ opaque
     , Kⱼ (⊢ℕ (K-motive-context (zeroⱼ ⊢Id))) (zeroⱼ ⊢Id) (var ⊢Id here)
         K-ok
     , (λ ())
-    , sub
-        (K₀ₘ₁-generalised {m₁ = 𝟙ᵐ} {m₂ = 𝟙ᵐ} {m₃ = 𝟙ᵐ}
-          ≡not-none PE.refl ℕₘ zeroₘ ℕₘ zeroₘ var)
-        (begin
-           𝟘ᶜ               ≈˘⟨ ω·ᶜ+ᶜ²𝟘ᶜ ⟩
-           ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ)  ∎)
+    , K₀ₘ₁-generalised′ {m₁ = 𝟙ᵐ} {m₂ = 𝟙ᵐ} {m₃ = 𝟙ᵐ}
+          ≡not-none PE.refl ℕₘ zeroₘ ℕₘ zeroₘ var
+          (≤ᶜ-reflexive (≈ᶜ-sym ω·ᶜ+ᶜ²𝟘ᶜ)) (λ _ → ≤ᶜ-refl)
     , (λ where
          (0    , whred K⇒ ⇨ˢ _) → whnfRedTerm K⇒ (ne (Kₙ (var _ _)))
          (1+ _ , whred K⇒ ⇨ˢ _) → whnfRedTerm K⇒ (ne (Kₙ (var _ _))))
     , sucⁿ≢ne {V = TL.Lift _ ⊤} ⦃ ok = possibly-nonempty ⦄
         _ (Kₙ (var _ _)) ∘→
       sym′ ∘→ proj₂ }
-    where
-    open Tools.Reasoning.PartialOrder ≤ᶜ-poset
 
 opaque
 
@@ -768,7 +759,7 @@ soundness-ℕ-only-target-not-counterexample₁ {p} ok
 ... | yes _ =
     0
   , (λ _ → refl-⇒ˢ⟨⟩*)
-  , subst ω ℕ² (Id ℕ pr zero) 0,0 (var x0) η rfl
+  , subst 𝟙 ℕ² (Id ℕ pr zero) 0,0 (var x0) η rfl
   , 0 , ε , id⊇
   , ⊢subst (Idⱼ′ ⊢pr (zeroⱼ (εε ∙[ ⊢ℕ² ] ∙[ ⊢ℕ² ])))
       (⊢Σʷ-η-prodʷ-fstʷ-sndʷ (var₀ (⊢ℕ² εε)))
@@ -972,9 +963,9 @@ opaque
   … | yes _  =
       _
     , (λ _ → refl-⇒ˢ⟨⟩*)
-    , subst ω Unitʷ
+    , subst 𝟙 Unitʷ
         (Id ℕ (unitrec 𝟘 𝟘 ℕ (var x0) zero) zero)
-        starʷ (var x0) (Unit-η 𝕨 ω (var x0)) rfl
+        starʷ (var x0) (Unit-η 𝕨 𝟙 (var x0)) rfl
     , 0 , ε , id⊇
     , ⊢subst
         (Idⱼ′
@@ -1036,6 +1027,7 @@ opaque
 
   no-run-time-canonicity-if-strict-and-arguments-removed :
     ⦃ 𝟘-well-behaved : Has-well-behaved-zero M 𝕄 ⦄ →
+    ⦃ has-ω : JK-with-omega ⦄ →
     Emptyrec-allowed 𝟙ᵐ 𝟘 →
     Π-allowed 𝟘 p →
     Π-allowed ω q →

--- a/Graded/Erasure/Extraction/Non-terminating.agda
+++ b/Graded/Erasure/Extraction/Non-terminating.agda
@@ -40,11 +40,12 @@ module Graded.Erasure.Extraction.Non-terminating
   (open Graded.Mode.Instances.Zero-one variant)
   (TR : Type-restrictions 𝕄)
   (UR : Usage-restrictions 𝕄 Zero-one-isMode)
+  (open Usage-restrictions UR)
+  ⦃ jk-ω : JK-with-omega ⦄
   where
 
 open Modality 𝕄
 open Type-restrictions TR
-open Usage-restrictions UR
 
 open import Definition.Typed TR
 open import Definition.Typed.Properties TR hiding (⊢cast)
@@ -59,10 +60,12 @@ open import Graded.Erasure.Extraction.Properties 𝕄
 open import Graded.Erasure.Target as T using (Strictness; strict)
 open import Graded.Erasure.Target.Non-terminating
 open import Graded.Erasure.Target.Properties
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 open import Graded.Usage UR
 open import Graded.Usage.Properties UR
 open import Graded.Usage.Properties.Zero-one variant UR
+open import Graded.Usage.Restrictions.Instance UR
 
 open import Tools.Bool using (Bool; true)
 open import Tools.Empty

--- a/Graded/Erasure/Extraction/Properties/Usage.agda
+++ b/Graded/Erasure/Extraction/Properties/Usage.agda
@@ -16,6 +16,7 @@ module Graded.Erasure.Extraction.Properties.Usage
   where
 
 open Modality 𝕄
+open Usage-restrictions R
 
 open import Graded.Modality.Nr-instances
 open import Graded.Modality.Properties 𝕄
@@ -288,23 +289,23 @@ opaque
     refl
   erase-[] _ rflₘ =
     refl
-  erase-[] ok (Jₘ _ _ _ _ _ ▸t _ _) =
+  erase-[] ok (Jₘ _ _ _ _ ▸t _ _) =
     erase-[]
       (x◂𝟘∈γ+δˡ refl ∘→ x◂𝟘∈γ+δʳ refl ∘→ x◂𝟘∈γ+δʳ refl ∘→
        x◂𝟘∈pγ refl ω≢𝟘 ∘→ ok)
       ▸t
-  erase-[] ok (J₀ₘ₁ _ _ _ _ _ _ ▸t _ _) =
+  erase-[] ok (J₀ₘ₁ _ _ _ _ _ ▸t _ _) =
     erase-[] (x◂𝟘∈γ+δʳ refl ∘→ x◂𝟘∈pγ refl ω≢𝟘 ∘→ ok) ▸t
-  erase-[] ok (J₀ₘ₂ _ _ _ _ ▸t _ _) =
+  erase-[] ok (J₀ₘ₂ _ _ _ ▸t _ _) =
     erase-[] ok ▸t
-  erase-[] ok (Kₘ _ _ _ _ _ ▸t _) =
+  erase-[] ok (Kₘ _ _ _ _ ▸t _) =
     erase-[]
       (x◂𝟘∈γ+δˡ refl ∘→ x◂𝟘∈γ+δʳ refl ∘→ x◂𝟘∈γ+δʳ refl ∘→
        x◂𝟘∈pγ refl ω≢𝟘 ∘→ ok)
       ▸t
-  erase-[] ok (K₀ₘ₁ _ _ _ _ _ ▸t _) =
+  erase-[] ok (K₀ₘ₁ _ _ _ _ ▸t _) =
     erase-[] (x◂𝟘∈γ+δʳ refl ∘→ x◂𝟘∈pγ refl ω≢𝟘 ∘→ ok) ▸t
-  erase-[] ok (K₀ₘ₂ _ _ _ _ ▸t _) =
+  erase-[] ok (K₀ₘ₂ _ _ _ ▸t _) =
     erase-[] ok ▸t
   erase-[] _ ([]-congₘ _ _ _ _ _ _) =
     refl

--- a/Graded/Erasure/LogicalRelation/Assumptions.agda
+++ b/Graded/Erasure/LogicalRelation/Assumptions.agda
@@ -185,6 +185,7 @@ opaque
   -- * if equality reflection is allowed.
 
   Id-is-reduction-relation :
+    ⦃ ok : Has-omega _ 𝕄 ⦄ →
     Transparent (Γ .defs) × Empty-con (Γ .vars) ⊎ Equality-reflection →
     Is-reduction-relation Γ (λ t u A → ∃ λ v → Γ ⊢ v ∷ Id A t u)
   Id-is-reduction-relation {Γ} ok = record

--- a/Graded/Erasure/LogicalRelation/Fundamental.agda
+++ b/Graded/Erasure/LogicalRelation/Fundamental.agda
@@ -24,6 +24,7 @@ module Graded.Erasure.LogicalRelation.Fundamental
   where
 
 open Type-restrictions TR
+open Usage-restrictions UR
 
 open Definition.Untyped M
 open Definition.Typed TR
@@ -32,6 +33,7 @@ open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
 open import Graded.Context.Weakening 𝕄
 open import Graded.Modality.Nr-instances
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 open import Graded.Usage UR
 open import Graded.Usage.Inversion UR
@@ -343,7 +345,7 @@ module Fundamental
       rflʳ ⊢t
     fundamental′ {γ} {m = 𝟙ᵐ} (Jⱼ _ ⊢B ⊢u _ ⊢w) ▸J (J _ _ _ <n₄ _ <n₆) =
       case inv-usage-J ▸J of λ where
-        (invUsageJ₀₂ em _ _ _ ▸u _ _ γ≤) →
+        (invUsageJ₀₂ ⦃ (em) ⦄ _ _ _ ▸u _ _ γ≤) →
           Jʳ ⊢B ⊢u ⊢w γ≤ (fundamental′ ⊢u ▸u <n₄)
             (inj₁ $ case closed-or-no-erased-matches of λ where
                (inj₂ k≡0) → k≡0 , PE.sym (glassify-idem _)
@@ -352,7 +354,7 @@ module Fundamental
                    PE.trans (PE.sym em)
                      (nem non-trivial .proj₂ .proj₂ .proj₂ .proj₁)
                  of λ ())
-        (invUsageJ₀₁ {γ₃} {γ₄} em _ _ _ _ _ ▸u _ _ γ≤) →
+        (invUsageJ₀₁ {γ₃} {γ₄} ⦃ (em) ⦄ _ _ _ _ _ ▸u _ _ γ≤) →
           subsumption-▸⊩ʳ∷[]
             (λ x →
                γ ⟨ x ⟩ PE.≡ 𝟘                      →⟨ ≤ᶜ→⟨⟩≡𝟘→⟨⟩≡𝟘 γ≤ ⟩
@@ -368,7 +370,7 @@ module Fundamental
                    PE.trans (PE.sym em)
                      (nem non-trivial .proj₂ .proj₂ .proj₂ .proj₁)
                  of λ ())
-        (invUsageJ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} _ _ _ _ _ ▸u _ ▸w γ≤) →
+        (invUsageJ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} _ _ _ _ ▸u _ ▸w γ≤) →
           subsumption-▸⊩ʳ∷[]
             (λ x →
                γ ⟨ x ⟩ PE.≡ 𝟘                                        →⟨ ≤ᶜ→⟨⟩≡𝟘→⟨⟩≡𝟘 γ≤ ⟩
@@ -390,7 +392,7 @@ module Fundamental
                   (_ , ∧ᶜ-decreasingʳ γ₄ _ , fundamental′ ⊢w ▸w <n₆)))
     fundamental′ {γ} {m = 𝟙ᵐ} (Kⱼ ⊢B ⊢u ⊢v ok) ▸K (K _ _ _ <n₄ <n₅) =
       case inv-usage-K ▸K of λ where
-        (invUsageK₀₂ em _ _ _ ▸u _ γ≤) →
+        (invUsageK₀₂ ⦃ (em) ⦄ _ _ _ ▸u _ γ≤) →
           Kʳ ⊢B ⊢u ⊢v ok γ≤ (fundamental′ ⊢u ▸u <n₄)
             (inj₁ $ case closed-or-no-erased-matches of λ where
                (inj₂ k≡0) → k≡0 , PE.sym (glassify-idem _)
@@ -399,7 +401,7 @@ module Fundamental
                    PE.trans (PE.sym em)
                      (nem non-trivial .proj₂ .proj₂ .proj₂ .proj₂)
                  of λ ())
-        (invUsageK₀₁ {γ₃} {γ₄} em _ _ _ _ ▸u _ γ≤) →
+        (invUsageK₀₁ {γ₃} {γ₄} ⦃ (em) ⦄ _ _ _ _ ▸u _ γ≤) →
           subsumption-▸⊩ʳ∷[]
             (λ x →
                γ ⟨ x ⟩ PE.≡ 𝟘                      →⟨ ≤ᶜ→⟨⟩≡𝟘→⟨⟩≡𝟘 γ≤ ⟩
@@ -415,7 +417,7 @@ module Fundamental
                    PE.trans (PE.sym em)
                      (nem non-trivial .proj₂ .proj₂ .proj₂ .proj₂)
                  of λ ())
-        (invUsageK {γ₂} {γ₃} {γ₄} {γ₅} _ _ _ _ _ ▸u ▸v γ≤) →
+        (invUsageK {γ₂} {γ₃} {γ₄} {γ₅} _ _ _ _ ▸u ▸v γ≤) →
           subsumption-▸⊩ʳ∷[]
             (λ x →
                γ ⟨ x ⟩ PE.≡ 𝟘                                  →⟨ ≤ᶜ→⟨⟩≡𝟘→⟨⟩≡𝟘 γ≤ ⟩

--- a/Graded/FullReduction.agda
+++ b/Graded/FullReduction.agda
@@ -252,21 +252,21 @@ module _ (as : Full-reduction-assumptions) where
             γ≤ }
       (J-cong A↑ t↑ B↑ u↑ v↑ w~ _) ▸∇ ▸J →
         case inv-usage-J ▸J of λ where
-          (invUsageJ ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v ▸w γ≤) →
-            sub (Jₘ ok₁ ok₂ (fullRedConv↑ A↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸A)
+          (invUsageJ ok ▸A ▸t ▸B ▸u ▸v ▸w γ≤) →
+            sub (Jₘ ok (fullRedConv↑ A↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸A)
                    (fullRedTermConv↑ t↑ ▸∇ ▸t) (fullRedConv↑ B↑ ▸∇ ▸B)
                    (fullRedTermConv↑ u↑ ▸∇ ▸u)
                    (fullRedTermConv↑ v↑ ▸∇ ▸v) (fullRedNe~↓ w~ ▸∇ ▸w))
               γ≤
-          (invUsageJ₀₁ ok p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸v ▸w γ≤) →
-            sub (J₀ₘ₁ ok p≡𝟘 q≡𝟘 (fullRedConv↑ A↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸A)
+          (invUsageJ₀₁ p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸v ▸w γ≤) →
+            sub (J₀ₘ₁ p≡𝟘 q≡𝟘 (fullRedConv↑ A↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸A)
                    (fullRedTermConv↑ t↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸t)
                    (fullRedConv↑ B↑ ▸∇ ▸B) (fullRedTermConv↑ u↑ ▸∇ ▸u)
                    (fullRedTermConv↑ v↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸v)
                    (fullRedNe~↓ w~ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸w))
               γ≤
-          (invUsageJ₀₂ ok ▸A ▸t ▸B ▸u ▸v ▸w γ≤) →
-            sub (J₀ₘ₂ ok (fullRedConv↑ A↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸A)
+          (invUsageJ₀₂ ▸A ▸t ▸B ▸u ▸v ▸w γ≤) →
+            sub (J₀ₘ₂ (fullRedConv↑ A↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸A)
                    (fullRedTermConv↑ t↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸t)
                    (fullRedConv↑ B↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸B)
                    (fullRedTermConv↑ u↑ ▸∇ ▸u)
@@ -275,19 +275,19 @@ module _ (as : Full-reduction-assumptions) where
               γ≤
       (K-cong A↑ t↑ B↑ u↑ v~ _ _) ▸∇ ▸K →
         case inv-usage-K ▸K of λ where
-          (invUsageK ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v γ≤) →
-            sub (Kₘ ok₁ ok₂ (fullRedConv↑ A↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸A)
+          (invUsageK ok ▸A ▸t ▸B ▸u ▸v γ≤) →
+            sub (Kₘ ok (fullRedConv↑ A↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸A)
                    (fullRedTermConv↑ t↑ ▸∇ ▸t) (fullRedConv↑ B↑ ▸∇ ▸B)
                    (fullRedTermConv↑ u↑ ▸∇ ▸u) (fullRedNe~↓ v~ ▸∇ ▸v))
               γ≤
-          (invUsageK₀₁ ok p≡𝟘 ▸A ▸t ▸B ▸u ▸v γ≤) →
-            sub (K₀ₘ₁ ok p≡𝟘 (fullRedConv↑ A↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸A)
+          (invUsageK₀₁ p≡𝟘 ▸A ▸t ▸B ▸u ▸v γ≤) →
+            sub (K₀ₘ₁ p≡𝟘 (fullRedConv↑ A↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸A)
                    (fullRedTermConv↑ t↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸t)
                    (fullRedConv↑ B↑ ▸∇ ▸B) (fullRedTermConv↑ u↑ ▸∇ ▸u)
                    (fullRedNe~↓ v~ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸v))
               γ≤
-          (invUsageK₀₂ ok ▸A ▸t ▸B ▸u ▸v γ≤) →
-            sub (K₀ₘ₂ ok (fullRedConv↑ A↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸A)
+          (invUsageK₀₂ ▸A ▸t ▸B ▸u ▸v γ≤) →
+            sub (K₀ₘ₂ (fullRedConv↑ A↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸A)
                    (fullRedTermConv↑ t↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸t)
                    (fullRedConv↑ B↑ (ε-▸-𝟘ᵐ? ∘→ ▸∇) ▸B)
                    (fullRedTermConv↑ u↑ ▸∇ ▸u)

--- a/Graded/Heap/Non-interference.agda
+++ b/Graded/Heap/Non-interference.agda
@@ -69,11 +69,13 @@ open import Definition.LogicalRelation.Unary TR
 open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
 open import Graded.Context.Weakening 𝕄
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 open import Graded.Usage UR
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Inversion UR
 open import Graded.Usage.Properties UR
+open import Graded.Usage.Restrictions.JK modality
 open import Graded.Usage.Restrictions.Natrec modality
 
 open Addition≡Meet +≡∧
@@ -162,23 +164,35 @@ record No-secret-matches : Set a where
     no-secret-[]-cong :
       ∀ {s m} → m ≤ ℓ₀ → []-cong-allowed-mode s m → 𝟘 ≤ ℓ₀
 
+  opaque instance
+
+    jk-with-omega : JK-with-omega
+    jk-with-omega =
+      erased-matches-for-JK-supports-ω
+        (PE.subst (_≤ᵉᵐ some) (PE.sym (no-secret-J ≤-refl)) _)
+
+
   -- If there are no secret matches then the multiplicity for Jₑ
   -- is equal to 𝟙.
 
   ∣J∣≡𝟙 :
     ∀ {m p q} → m ≤ ℓ₀ → ∣J erased-matches-for-J ⌞ m ⌟ , p , q ∣≡ 𝟙
-  ∣J∣≡𝟙 m≤ℓ₀ =
-    ∣J∣≡ω (PE.subst (_≤ᵉᵐ some) (PE.sym (no-secret-J m≤ℓ₀)) (none-≤ᵉᵐ {em = some}))
-      λ em≡some → case PE.trans (PE.sym (no-secret-J m≤ℓ₀)) em≡some of λ ()
+  ∣J∣≡𝟙 {p} {q} m≤ℓ₀ =
+    PE.subst₂ (λ x y → ∣J x , p , q ∣≡ y)
+      (PE.sym $ no-secret-J m≤ℓ₀)
+      (≤-antisym (ω≤𝟙 ⦃ JK-Any-erased-matches-has-omega jk-with-omega ⦄) 𝟙≤)
+      J-none
 
   -- If there are no secret matches then the multiplicity for Kₑ
   -- is equal to 𝟙.
 
   ∣K∣≡𝟙 :
     ∀ {m p} → m ≤ ℓ₀ → ∣K erased-matches-for-K ⌞ m ⌟ , p ∣≡ 𝟙
-  ∣K∣≡𝟙 m≤ℓ₀ =
-    ∣K∣≡ω (PE.subst (_≤ᵉᵐ some) (PE.sym (no-secret-K m≤ℓ₀)) (none-≤ᵉᵐ {em = some}))
-      (λ em≡some → case PE.trans (PE.sym (no-secret-K m≤ℓ₀)) em≡some of λ ())
+  ∣K∣≡𝟙 {p} m≤ℓ₀ =
+    PE.subst₂ (λ x y → ∣K x , p ∣≡ y)
+      (PE.sym $ no-secret-K m≤ℓ₀)
+      (≤-antisym (ω≤𝟙 ⦃ JK-Any-erased-matches-has-omega jk-with-omega ⦄) 𝟙≤)
+      K-none
 
 opaque
 

--- a/Graded/Heap/Untyped.agda
+++ b/Graded/Heap/Untyped.agda
@@ -45,9 +45,11 @@ open import Definition.Untyped M hiding (head)
 open import Definition.Untyped.Names-below M using (No-names)
 
 open import Graded.Modality.Nr-instances
+open import Graded.Modality.Omega-instances
 open import Graded.Mode
 open import Graded.Modality.Properties.Subtraction 𝕄
 open import Graded.Usage.Erased-matches
+open import Graded.Usage.Restrictions.Instance UR
 
 private variable
   n n′ m m′ m″ n″ k : Nat
@@ -169,9 +171,11 @@ data ∣J_,_,_∣≡_ : Erased-matches → M → M → M → Set a where
   J-all   : ∣J all  , p , q ∣≡ 𝟘
   J-some₀ : p ≡ 𝟘 → q ≡ 𝟘 →
             ∣J some , p , q ∣≡ 𝟘
-  J-some  : ¬ (p ≡ 𝟘 × q ≡ 𝟘) →
+  J-some  : ⦃ ok : JK-with-omega ⦄ →
+            ¬ (p ≡ 𝟘 × q ≡ 𝟘) →
             ∣J some , p , q ∣≡ ω
-  J-none  : ∣J none , p , q ∣≡ ω
+  J-none  : ⦃ ok : JK-with-omega ⦄ →
+            ∣J none , p , q ∣≡ ω
 
 -- The multiplicity of the Kₑ continuation, depending on which
 -- erased matches are used.
@@ -180,9 +184,11 @@ data ∣K_,_∣≡_ : Erased-matches → M → M → Set a where
   K-all   : ∣K all  , p ∣≡ 𝟘
   K-some₀ : p ≡ 𝟘 →
             ∣K some , p ∣≡ 𝟘
-  K-some  : p ≢ 𝟘 →
+  K-some  : ⦃ ok : JK-with-omega ⦄ →
+            p ≢ 𝟘 →
             ∣K some , p ∣≡ ω
-  K-none  : ∣K none , p ∣≡ ω
+  K-none  : ⦃ ok : JK-with-omega ⦄ →
+            ∣K none , p ∣≡ ω
 
 -- Multiplicity of an continuation, representing how many copies need to
 -- be evaluated.

--- a/Graded/Heap/Untyped/Properties.agda
+++ b/Graded/Heap/Untyped/Properties.agda
@@ -36,9 +36,12 @@ open import Tools.Reasoning.PropositionalEquality
 open import Tools.Sum
 
 open import Graded.Modality.Nr-instances
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
+open import Graded.Usage UR
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Restrictions.Instance UR
+open import Graded.Usage.Restrictions.JK 𝕄
 
 open import Definition.Untyped M
 open import Definition.Untyped.Names-below M
@@ -593,8 +596,8 @@ opaque
     ⊥-elim (false (p≡𝟘 , q≡𝟘))
   ∣J∣ᶜ-functional (J-some false) (J-some₀ p≡𝟘 q≡𝟘) =
     ⊥-elim (false (p≡𝟘 , q≡𝟘))
-  ∣J∣ᶜ-functional (J-some _) (J-some _) = refl
-  ∣J∣ᶜ-functional J-none J-none = refl
+  ∣J∣ᶜ-functional (J-some ⦃ (ok) ⦄ _) (J-some ⦃ (ok′) ⦄ _) = ω≡ω ok ok′
+  ∣J∣ᶜ-functional (J-none ⦃ (ok) ⦄) (J-none ⦃ (ok′) ⦄) = ω≡ω ok ok′
 
 opaque
 
@@ -607,8 +610,8 @@ opaque
     ⊥-elim (p≢𝟘 p≡𝟘)
   ∣K∣ᶜ-functional (K-some p≢𝟘) (K-some₀ p≡𝟘) =
     ⊥-elim (p≢𝟘 p≡𝟘)
-  ∣K∣ᶜ-functional (K-some _) (K-some _) = refl
-  ∣K∣ᶜ-functional K-none K-none = refl
+  ∣K∣ᶜ-functional (K-some ⦃ (ok) ⦄ _) (K-some ⦃ (ok′) ⦄ _) = ω≡ω ok ok′
+  ∣K∣ᶜ-functional (K-none ⦃ (ok) ⦄) (K-none ⦃ (ok′) ⦄) = ω≡ω ok ok′
 
 opaque
 
@@ -650,35 +653,43 @@ opaque
 
 opaque
 
-  -- The multiplicity relation for Jₑ is always inhabited
+  -- The multiplicity relation for Jₑ is always inhabited.
 
-  ∣J∣≡ : ∃ λ r → ∣J em , p , q ∣≡ r
-  ∣J∣≡ {em = none} = _ , J-none
-  ∣J∣≡ {em = all} = _ , J-all
-  ∣J∣≡ {em = some} {p} {q} =
+  ∣J∣≡ : ∃ λ r → ∣J erased-matches-for-J mo , p , q ∣≡ r
+  ∣J∣≡ {mo} {p} {q} with erased-matches-for-J mo in ok
+  … | all  = 𝟘 , J-all
+  … | none = _ , J-none ⦃ erased-matches-for-JK-supports-ω (subst (_≤ᵉᵐ some) (sym ok) _) ⦄
+  … | some =
     case is-𝟘? p of λ where
       (yes p≡𝟘) →
         case is-𝟘? q of λ where
-          (yes q≡𝟘) → _ , J-some₀ p≡𝟘 q≡𝟘
-          (no q≢𝟘) → _ , J-some λ (_ , q≡𝟘) → q≢𝟘 q≡𝟘
-      (no p≢𝟘) → _ , J-some (λ (p≡𝟘 , _) → p≢𝟘 p≡𝟘)
+          (yes q≡𝟘) →
+            𝟘 , J-some₀ p≡𝟘 q≡𝟘
+          (no q≢𝟘) →
+            _ , J-some ⦃ erased-matches-for-JK-supports-ω (subst (_≤ᵉᵐ some) (sym ok) _) ⦄ (q≢𝟘 ∘→ proj₂)
+      (no p≢𝟘) →
+        _ , J-some ⦃ erased-matches-for-JK-supports-ω (subst (_≤ᵉᵐ some) (sym ok) _) ⦄ (p≢𝟘 ∘→ proj₁)
 
 opaque
 
-  -- The multiplicity relation for Kₑ is always inhabited
+  -- The multiplicity relation for Kₑ is always inhabited.
 
-  ∣K∣≡ : ∃ λ r → ∣K em , p ∣≡ r
-  ∣K∣≡ {em = none} = _ , K-none
-  ∣K∣≡ {em = all} = _ , K-all
-  ∣K∣≡ {em = some} {p} =
+  ∣K∣≡ : ∃ λ r → ∣K erased-matches-for-K mo , p ∣≡ r
+  ∣K∣≡ {mo} {p} with erased-matches-for-K mo in ok
+  … | all = 𝟘 , K-all
+  … | none = _ , K-none ⦃ erased-matches-for-JK-supports-ω (subst (_≤ᵉᵐ some) (sym ok) _) ⦄
+  … | some =
     case is-𝟘? p of λ where
-      (yes p≡𝟘) → _ , K-some₀ p≡𝟘
-      (no p≢𝟘) → _ , K-some p≢𝟘
+      (yes p≡𝟘) →
+        𝟘 , K-some₀ p≡𝟘
+      (no p≢𝟘) →
+        _ , K-some ⦃ erased-matches-for-JK-supports-ω (subst (_≤ᵉᵐ some) (sym ok) _) ⦄ p≢𝟘
 
 opaque
 
   -- The multiplicity for a continuation c always exists if when c is
-  -- natrecₑ then the usage rule for natrec using an nr function is used.
+  -- natrecₑ then the usage rule for natrec using an nr function is used
+  -- and the usage restrictions allow all kinds of erased matches for J and K.
 
   ∣∣ᶜ≡ :
     (∀ {n p q r A u v ρ} → c ≡ natrecₑ {n = n} p q r A u v ρ → Nr-available) →
@@ -701,9 +712,11 @@ opaque
 
   -- The multiplicity relation for stacks is always inhabited is whenever
   -- the stack contains natrecₑ the usage rule for natrec using nr
-  -- functions is used.
+  -- functions is used and the usage restrictions allow all kinds of
+  -- erased matches for J and K.
 
-  ∣∣≡ : (∀ {p r} → natrec p , r ∈ S → Nr-available) → ∃ ∣ S ∣≡_
+  ∣∣≡ :
+    (∀ {p r} → natrec p , r ∈ S → Nr-available) → ∃ ∣ S ∣≡_
   ∣∣≡ {S = ε} _ = ∣ε∣ , ε
   ∣∣≡ {S = e ∙ S} has-nr =
     let _ , ∣S∣≡ = ∣∣≡ (has-nr ∘→ there)
@@ -715,7 +728,8 @@ opaque
   -- A variant of the above for it assumed that the stack does not
   -- contain any occurences of natrecₑ.
 
-  nr∉-∣∣≡ : (∀ {p r} → ¬ natrec p , r ∈ S) → ∃ ∣ S ∣≡_
+  nr∉-∣∣≡ :
+    (∀ {p r} → ¬ natrec p , r ∈ S) → ∃ ∣ S ∣≡_
   nr∉-∣∣≡ nr∉ = ∣∣≡ (λ nr∈ → ⊥-elim (nr∉ nr∈))
 
 opaque
@@ -731,42 +745,56 @@ opaque
   -- Under some conditions, the multiplicity of Jₑ is ω
 
   ∣J∣≡ω :
-    em ≤ᵉᵐ some → (em ≡ some → ¬ (p ≡ 𝟘 × q ≡ 𝟘)) →
-    ∣J em , p , q ∣≡ ω
-  ∣J∣≡ω {(none)} _ _ = J-none
-  ∣J∣≡ω {(all)} () _
-  ∣J∣≡ω {(some)} _ ≢𝟘 = J-some (≢𝟘 refl)
+    ⦃ ok : erased-matches-for-J mo ≤ᵉᵐ some ⦄ →
+    (erased-matches-for-J mo ≡ some → ¬ (p ≡ 𝟘 × q ≡ 𝟘)) →
+    ∣J erased-matches-for-J mo , p , q ∣≡ ω
+  ∣J∣≡ω ⦃ ok ⦄ ≢𝟘 = lemma _ ok ≢𝟘
+    where
+    lemma :
+      ∀ em → em ≤ᵉᵐ some →
+      (em ≡ some → ¬ (p ≡ 𝟘 × q ≡ 𝟘)) →
+      ∣J em , p , q ∣≡ ω
+    lemma none _ _ = J-none
+    lemma all () _
+    lemma some _ ≢𝟘 = J-some (≢𝟘 refl)
 
 opaque
 
   -- Under some conditions, the multiplicity of Kₑ is ω
 
   ∣K∣≡ω :
-    em ≤ᵉᵐ some → (em ≡ some → p ≢ 𝟘) →
-    ∣K em , p ∣≡ ω
-  ∣K∣≡ω {(none)} _ _ = K-none
-  ∣K∣≡ω {(all)} () _
-  ∣K∣≡ω {(some)} _ ≢𝟘 = K-some (≢𝟘 refl)
+    ⦃ ok : erased-matches-for-K mo ≤ᵉᵐ some ⦄ →
+    (erased-matches-for-K mo ≡ some → ¬ (p ≡ 𝟘)) →
+    ∣K erased-matches-for-K mo , p ∣≡ ω
+  ∣K∣≡ω ⦃ ok ⦄ ≢𝟘 = lemma _ ok ≢𝟘
+    where
+    lemma :
+      ∀ em → em ≤ᵉᵐ some →
+      (em ≡ some → ¬ (p ≡ 𝟘)) →
+      ∣K em , p ∣≡ ω
+    lemma none _ _ = K-none
+    lemma all () _
+    lemma some _ ≢𝟘 = K-some (≢𝟘 refl)
 
 opaque
 
   -- The multiplicity of Kₑ is either 𝟘 or ω
 
-  ∣K∣≡𝟘⊎ω : ∣K em , p ∣≡ q → q ≡ 𝟘 ⊎ q ≡ ω
+  ∣K∣≡𝟘⊎ω : ⦃ ok : JK-with-omega ⦄ → ∣K em , p ∣≡ q → q ≡ 𝟘 ⊎ q ≡ ω
   ∣K∣≡𝟘⊎ω K-all = inj₁ refl
   ∣K∣≡𝟘⊎ω (K-some₀ x) = inj₁ refl
-  ∣K∣≡𝟘⊎ω (K-some x) = inj₂ refl
-  ∣K∣≡𝟘⊎ω K-none = inj₂ refl
+  ∣K∣≡𝟘⊎ω ⦃ ok ⦄ (K-some ⦃ (ok′) ⦄ x) = inj₂ (ω≡ω ok′ ok)
+  ∣K∣≡𝟘⊎ω ⦃ ok ⦄ (K-none ⦃ (ok′) ⦄) = inj₂ (ω≡ω ok′ ok)
 
 opaque
 
   -- The multiplicity of Jₑ is either 𝟘 or ω
 
-  ∣J∣≡𝟘⊎ω : ∣J em , p , q ∣≡ r → r ≡ 𝟘 ⊎ r ≡ ω
+  ∣J∣≡𝟘⊎ω : ⦃ ok : JK-with-omega ⦄ → ∣J em , p , q ∣≡ r → r ≡ 𝟘 ⊎ r ≡ ω
   ∣J∣≡𝟘⊎ω J-all = inj₁ refl
   ∣J∣≡𝟘⊎ω (J-some₀ x x₁) = inj₁ refl
-  ∣J∣≡𝟘⊎ω (J-some x) = inj₂ refl
-  ∣J∣≡𝟘⊎ω J-none = inj₂ refl
+  ∣J∣≡𝟘⊎ω ⦃ ok ⦄ (J-some ⦃ (ok′) ⦄ x) = inj₂ (ω≡ω ok′ ok)
+  ∣J∣≡𝟘⊎ω ⦃ ok ⦄ (J-none ⦃ (ok′) ⦄) = inj₂ (ω≡ω ok′ ok)
 
 opaque
 

--- a/Graded/Heap/Usage/Properties/Zero-one.agda
+++ b/Graded/Heap/Usage/Properties/Zero-one.agda
@@ -27,7 +27,10 @@ open Modality 𝕄
 open import Definition.Untyped M
 open import Graded.Context 𝕄
 open import Graded.Modality.Nr-instances
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
+open import Graded.Usage.Erased-matches
+open import Graded.Usage.Restrictions.Instance UR
 open import Graded.Restrictions.Zero-one 𝕄 mode-variant
 
 open import Graded.Heap.Untyped type-variant UR factoring-nr 𝟙
@@ -62,8 +65,17 @@ private variable
   e′ : Entry _ _
 
 -- Some properties proven under some assumptions about erased matches
+-- and a well-behaved zero.
 
-module _ (nem : No-erased-matches′ type-variant UR) where
+module _
+  (nem : No-erased-matches′ type-variant UR)
+  ⦃ ok : Has-well-behaved-zero M 𝕄 ⦄
+  where
+
+  private opaque instance
+    jk-ok : JK-with-omega
+    jk-ok = erased-matches-for-JK-supports-ω (subst (_≤ᵉᵐ some)
+              (sym $ nem non-trivial .proj₂ .proj₂ .proj₂ .proj₁) _)
 
   opaque
 
@@ -71,7 +83,6 @@ module _ (nem : No-erased-matches′ type-variant UR) where
     -- unless it is an erased emptyrec
 
     ▸∣∣ᶜ≢𝟘 :
-      ⦃ Has-well-behaved-zero M 𝕄 ⦄ →
       γ ▸ᶜ[ 𝟙ᵐ ] c →
       ¬ ∣ c ∣ᶜ[ 𝟙ᵐ ]≡ 𝟘 ⊎
       ∃₃ λ n (A : Term n) ρ → c ≡ emptyrecₑ 𝟘 A ρ × Emptyrec-allowed 𝟙ᵐ 𝟘
@@ -95,12 +106,12 @@ module _ (nem : No-erased-matches′ type-variant UR) where
             (no p≢𝟘) → inj₁ (lemma p≢𝟘 emptyrecₑ)
         (Jₑ _) →
           inj₁ (lemma ω≢𝟘
-            (Jₑ (subst (∣J_, _ , _ ∣≡ _)
+            (Jₑ (subst (∣J_, _ , _ ∣≡ ω)
                   (sym (nem non-trivial .proj₂ .proj₂ .proj₂ .proj₁))
                   J-none)))
         (Kₑ _) →
           inj₁ (lemma ω≢𝟘
-            (Kₑ (subst (∣K_, _ ∣≡ _)
+            (Kₑ (subst (∣K_, _ ∣≡ ω)
                   (sym (nem non-trivial .proj₂ .proj₂ .proj₂ .proj₂))
                   K-none)))
         ([]-congₑ ok) →
@@ -117,8 +128,7 @@ module _ (nem : No-erased-matches′ type-variant UR) where
     -- The multiplicity of a well-resourced stack is either not zero
     -- or contains an erased application of emptyrec
 
-    ▸∣∣≢𝟘 : ⦃ Has-well-behaved-zero M 𝕄 ⦄
-           → γ ▸ˢ S → ¬ ∣ S ∣≡ 𝟘 ⊎ (emptyrec 𝟘 ∈ S × Emptyrec-allowed 𝟙ᵐ 𝟘)
+    ▸∣∣≢𝟘 :  γ ▸ˢ S → ¬ ∣ S ∣≡ 𝟘 ⊎ (emptyrec 𝟘 ∈ S × Emptyrec-allowed 𝟙ᵐ 𝟘)
     ▸∣∣≢𝟘 ε = inj₁ λ ≡𝟘 → non-trivial (∣∣-functional ε ≡𝟘)
     ▸∣∣≢𝟘 (▸ˢ∙ ∣S∣≡ ▸c ▸S) =
       case ▸∣∣≢𝟘 ▸S of λ where

--- a/Graded/Heap/Usage/Reduction.agda
+++ b/Graded/Heap/Usage/Reduction.agda
@@ -54,6 +54,7 @@ open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
 open import Graded.Context.Weakening 𝕄
 open import Graded.Modality.Nr-instances
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 open import Graded.Usage UR
 open import Graded.Usage.Erased-matches
@@ -643,9 +644,9 @@ opaque
       ∃₃ λ r′ δ η → δ ▸[ ⌞ r · r′ ⌟ ] w × η ▸[ ⌞ r ⌟ ] u ×
         (∣J erased-matches-for-J ⌞ r ⌟ , p , q ∣≡ r′) ×
         γ ≤ᶜ r′ ·ᶜ δ +ᶜ η
-    lemma {γ} (invUsageJ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} x x₁ _ _ _ ▸u _ ▸w γ≤) =
+    lemma {γ} (invUsageJ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} x _ _ _ ▸u _ ▸w γ≤) =
       _ , _ , _ , ▸-cong (trans (sym ᵐ·-identityʳ-ω) ⌞⌟·ᵐ) ▸w
-        , ▸u , ∣J∣≡ω x x₁ , (begin
+        , ▸u , ∣J∣≡ω x , (begin
           γ                                 ≤⟨ γ≤ ⟩
           ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
           ω ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)       ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
@@ -653,18 +654,18 @@ opaque
           ω ·ᶜ γ₄ +ᶜ ω ·ᶜ (γ₅ +ᶜ γ₆)        ≤⟨ +ᶜ-monotone ω·ᶜ-decreasing ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
           γ₄ +ᶜ ω ·ᶜ γ₆                     ≈⟨ +ᶜ-comm _ _ ⟩
           ω ·ᶜ γ₆ +ᶜ γ₄                     ∎)
-    lemma {γ} (invUsageJ₀₁ {γ₃} {γ₄} {γ₆} x p≡𝟘 q≡𝟘 _ _ _ ▸u _ ▸w γ≤) =
+    lemma {γ} (invUsageJ₀₁ {γ₃} {γ₄} {γ₆} ⦃ (ok) ⦄ p≡𝟘 q≡𝟘 _ _ _ ▸u _ ▸w γ≤) =
        _ , _ , _ , ▸-cong (sym (trans (⌞⌟-cong (·-zeroʳ _)) ⌞𝟘⌟)) ▸w , ▸u
-         , (subst (λ em → ∣J em , _ , _ ∣≡ 𝟘) (sym x) (J-some₀ p≡𝟘 q≡𝟘)) , (begin
+         , (subst (λ em → ∣J em , _ , _ ∣≡ 𝟘) (sym ok) (J-some₀ p≡𝟘 q≡𝟘)) , (begin
           γ               ≤⟨ γ≤ ⟩
           ω ·ᶜ (γ₃ +ᶜ γ₄) ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
           ω ·ᶜ γ₄         ≤⟨ ω·ᶜ-decreasing ⟩
           γ₄              ≈˘⟨ +ᶜ-identityˡ _ ⟩
           𝟘ᶜ +ᶜ γ₄        ≈˘⟨ +ᶜ-congʳ (·ᶜ-zeroˡ _) ⟩
           𝟘 ·ᶜ γ₆ +ᶜ γ₄   ∎)
-    lemma {γ} (invUsageJ₀₂ {γ₄} {γ₆} x _ _ _ ▸u _ ▸w γ≤) =
+    lemma {γ} (invUsageJ₀₂ {γ₄} {γ₆} ⦃ (ok) ⦄ _ _ _ ▸u _ ▸w γ≤) =
       _ , _ , _ , ▸-cong (sym (trans (⌞⌟-cong (·-zeroʳ _)) ⌞𝟘⌟)) ▸w , ▸u
-        , subst (λ em → ∣J em , _ , _ ∣≡ 𝟘) (sym x) J-all , (begin
+        , subst (λ em → ∣J em , _ , _ ∣≡ 𝟘) (sym ok) J-all , (begin
         γ             ≤⟨ γ≤ ⟩
         γ₄            ≈˘⟨ +ᶜ-identityˡ _ ⟩
         𝟘ᶜ +ᶜ γ₄      ≈˘⟨ +ᶜ-congʳ (·ᶜ-zeroˡ _) ⟩
@@ -690,9 +691,9 @@ opaque
       ∃₃ λ q δ η → δ ▸[ ⌞ r · q ⌟ ] v × η ▸[ ⌞ r ⌟ ] u ×
         (∣K erased-matches-for-K ⌞ r ⌟ , p ∣≡ q) ×
         γ ≤ᶜ q ·ᶜ δ +ᶜ η
-    lemma {γ} (invUsageK {γ₂} {γ₃} {γ₄} {γ₅} x x₁ _ _ _ ▸u ▸v γ≤) =
+    lemma {γ} (invUsageK {γ₂} {γ₃} {γ₄} {γ₅} x _ _ _ ▸u ▸v γ≤) =
       _ , _ , _ , ▸-cong (trans (sym ᵐ·-identityʳ-ω) ⌞⌟·ᵐ) ▸v
-        , ▸u , ∣K∣≡ω x x₁ , (begin
+        , ▸u , ∣K∣≡ω x , (begin
           γ                           ≤⟨ γ≤ ⟩
           ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
           ω ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅)       ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
@@ -700,18 +701,18 @@ opaque
           ω ·ᶜ γ₄ +ᶜ ω ·ᶜ γ₅          ≤⟨ +ᶜ-monotoneˡ ω·ᶜ-decreasing ⟩
           γ₄ +ᶜ ω ·ᶜ γ₅               ≈⟨ +ᶜ-comm _ _ ⟩
           ω ·ᶜ γ₅ +ᶜ γ₄               ∎)
-    lemma {γ} (invUsageK₀₁ {γ₃} {γ₄} {γ₅} x p≡𝟘 _ _ _ ▸u ▸v γ≤) =
+    lemma {γ} (invUsageK₀₁ {γ₃} {γ₄} {γ₅} ⦃ (ok) ⦄ p≡𝟘 _ _ _ ▸u ▸v γ≤) =
       _ , _ , _ , ▸-cong (sym (trans (⌞⌟-cong (·-zeroʳ _)) ⌞𝟘⌟)) ▸v , ▸u
-        , subst (λ em → ∣K em , _ ∣≡ 𝟘) (sym x) (K-some₀ p≡𝟘) , (begin
+        , subst (λ em → ∣K em , _ ∣≡ 𝟘) (sym ok) (K-some₀ p≡𝟘) , (begin
           γ               ≤⟨ γ≤ ⟩
           ω ·ᶜ (γ₃ +ᶜ γ₄) ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
           ω ·ᶜ γ₄         ≤⟨ ω·ᶜ-decreasing ⟩
           γ₄              ≈˘⟨ +ᶜ-identityˡ _ ⟩
           𝟘ᶜ +ᶜ γ₄        ≈˘⟨ +ᶜ-congʳ (·ᶜ-zeroˡ _) ⟩
           𝟘 ·ᶜ γ₅ +ᶜ γ₄   ∎)
-    lemma {γ} (invUsageK₀₂ {γ₄} {γ₅} x _ _ _ ▸u ▸v γ≤) =
+    lemma {γ} (invUsageK₀₂ {γ₄} {γ₅} ⦃ (ok) ⦄ _ _ _ ▸u ▸v γ≤) =
       _ , _ , _ , ▸-cong (sym (trans (⌞⌟-cong (·-zeroʳ _)) ⌞𝟘⌟)) ▸v , ▸u
-        , subst (λ em → ∣K em , _ ∣≡ 𝟘) (sym x) K-all , (begin
+        , subst (λ em → ∣K em , _ ∣≡ 𝟘) (sym ok) K-all , (begin
         γ             ≤⟨ γ≤ ⟩
         γ₄            ≈˘⟨ +ᶜ-identityˡ _ ⟩
         𝟘ᶜ +ᶜ γ₄      ≈˘⟨ +ᶜ-congʳ (·ᶜ-zeroˡ _) ⟩

--- a/Graded/Modality.agda
+++ b/Graded/Modality.agda
@@ -31,10 +31,10 @@ record Modality : Set a where
 
   field
     -- A modality structure consists of a type M with three binary
-    -- operations (addition, multiplication and meet), and three
+    -- operations (addition, multiplication and meet), and two
     -- special elements.
     _+_ _·_ _∧_ : Op₂ M
-    𝟘 𝟙 ω       : M
+    𝟘 𝟙         : M
 
     -- + and · form a semiring with 𝟙 as multiplicative unit and 𝟘 as
     -- zero
@@ -56,12 +56,6 @@ record Modality : Set a where
   p < q = p ≤ q × p ≢ q
 
   field
-    -- In some modalities the grade ω stands for "an unlimited number
-    -- of uses". This grade must be bounded from above by 𝟙.
-    ω≤𝟙 : ω ≤ 𝟙
-
-    -- Furthermore ω · (p + q) must be bounded by ω · q.
-    ω·+≤ω·ʳ : ω · (p + q) ≤ ω · q
 
     -- It is decidable whether a grade is equal to 𝟘.
     is-𝟘? : (p : M) → Dec (p ≡ 𝟘)
@@ -186,6 +180,25 @@ record Has-well-behaved-zero (𝕄 : Modality) : Set a where
     -- Definition.Modality.Properties.Has-well-behaved-zero.∧-positiveʳ.)
     ∧-positiveˡ : {p q : M} → p ∧ q ≡ 𝟘 → p ≡ 𝟘
 
+-- The property of having the grade ω
+
+record Has-omega (𝕄 : Modality) : Set a where
+  no-eta-equality
+  pattern
+  open Modality 𝕄
+  field
+
+    -- The grade ω
+    ω : M
+
+    -- In some modalities the grade ω stands for "an unlimited number
+    -- of uses". This grade must be bounded from above by 𝟙.
+    ω≤𝟙 : ω ≤ 𝟙
+
+    -- Furthermore ω · (p + q) must be bounded by ω · q.
+    ω·+≤ω·ʳ : ω · (p + q) ≤ ω · q
+
+
 -- The property of having an nr function (a "natrec usage function").
 -- Such a function is used in one of the usage rules for natrec.
 
@@ -237,9 +250,10 @@ record Has-nr (𝕄 : Modality) : Set a where
 
   -- Another property that nr functions can satisfy.
 
-  Linearity-like-nr-for-𝟙 : Set a
-  Linearity-like-nr-for-𝟙 =
+  Linearity-like-nr-for-𝟙 : ⦃ ok : Has-omega 𝕄 ⦄ → Set a
+  Linearity-like-nr-for-𝟙 ⦃ ok ⦄ =
     ∀ {p z s n} →
+    let open Has-omega ok in
     nr p 𝟙 z s n ≡ (𝟙 + p) · n + ω · s + z
 
 -- The property of having an nr function that factors in a certain way
@@ -283,7 +297,6 @@ record Has-well-behaved-GLBs (𝕄 : Modality) : Set a where
       Greatest-lower-bound p (nrᵢ r z₁ s₁) →
       Greatest-lower-bound p′ (nrᵢ r z₂ s₂) →
       ∃ λ q → Greatest-lower-bound q (nrᵢ r (z₁ + z₂) (s₁ + s₂)) × p + p′ ≤ q
-
 
 -- The property of having a natrec-star operator.
 record Has-star (r : Modality) : Set a where

--- a/Graded/Modality/Extended.agda
+++ b/Graded/Modality/Extended.agda
@@ -67,6 +67,9 @@ record Extended-modality a : Set (lsuc a) where
     -- The modality has well-behaved GLBs.
     NO-NR-GLB : Has-well-behaved-GLBs _ 𝕄
 
+    -- The modality has grade ω.
+    HAS-ω : Has-omega _ 𝕄
+
   open Has-nr (Natrec-mode-Has-nr 𝕄 NR) public
 
   field
@@ -74,7 +77,7 @@ record Extended-modality a : Set (lsuc a) where
     NR₀ : Linearity-like-nr-for-𝟘
 
     -- The dedicated nr function satisfies Linearity-like-nr-for-𝟙.
-    NR₁ : Linearity-like-nr-for-𝟙
+    NR₁ : Linearity-like-nr-for-𝟙 ⦃ HAS-ω ⦄
 
     -- The modality supports subtraction
     SUB : Supports-subtraction 𝕄
@@ -82,6 +85,10 @@ record Extended-modality a : Set (lsuc a) where
   open Type-restrictions TR public
   open Usage-restrictions UR public
   open Full-reduction-assumptions FA public
+
+  instance
+    has-omega : Has-omega _ 𝕄
+    has-omega = HAS-ω
 
 private variable
   𝕄 𝕄₁ 𝕄₂ 𝕄₃ : Extended-modality _

--- a/Graded/Modality/Extended/K-allowed.agda
+++ b/Graded/Modality/Extended/K-allowed.agda
@@ -158,6 +158,7 @@ Trivial = λ where
     .NR₀ → U.nr-linearity-like-for-𝟘
     .NR₁ → U.nr-linearity-like-for-𝟙
     .SUB → U.unit-supports-subtraction
+    .HAS-ω → U.unit-has-omega
   where
   open Extended-modality
 
@@ -203,6 +204,7 @@ Erasure = λ where
     .UA      → Assumptions-UR′ E._≟_
     .NR      → Nr ⦃ EM.erasure-has-nr ⦄
     .NO-NR-GLB → EP.Erasure-supports-factoring-nr-rule
+    .HAS-ω   → EM.erasure-has-omega
     .NR₀ {z} → EP.nr-linearity-like-for-𝟘 {z = z}
     .NR₁ {z} → EP.nr-linearity-like-for-𝟙 {z = z}
     .SUB     → EP.supports-subtraction
@@ -251,6 +253,7 @@ Affine-types = λ where
     .UA          → Assumptions-UR′ A._≟_
     .NR          → Nr ⦃ A.zero-one-many-has-nr ⦄
     .NO-NR-GLB   → A.zero-one-many-supports-glb-for-natrec
+    .HAS-ω       → A.zero-one-many-has-omega
     .NR₀ {p}     → A.nr-linearity-like-for-𝟘 {p = p}
     .NR₁ {p} {z} → A.nr-linearity-like-for-𝟙 {p = p} {z = z}
     .SUB         → A.supports-subtraction
@@ -310,6 +313,7 @@ Linearity = λ where
     .UA          → Assumptions-UR′ L._≟_
     .NR          → Nr ⦃ L.zero-one-many-has-nr ⦄
     .NO-NR-GLB   → L.zero-one-many-supports-glb-for-natrec
+    .HAS-ω       → L.zero-one-many-has-omega
     .NR₀ {p}     → L.nr-linearity-like-for-𝟘 {p = p}
     .NR₁ {p} {z} → L.nr-linearity-like-for-𝟙 {p = p} {z = z}
     .SUB         → L.supports-subtraction
@@ -373,6 +377,7 @@ Linear-or-affine-types = λ where
     .UA          → Assumptions-UR′ LA._≟_
     .NR          → Nr ⦃ LA.linear-or-affine-has-nr ⦄
     .NO-NR-GLB   → LA.linear-or-affine-supports-glb-for-natrec
+    .HAS-ω       → LA.linear-or-affine-has-omega
     .NR₀ {p}     → LA.nr-linearity-like-for-𝟘 {p = p}
     .NR₁ {p} {s} → LA.nr-linearity-like-for-𝟙 {p = p} {s = s}
     .SUB {r}     → LA.supports-subtraction {r = r}

--- a/Graded/Modality/Extended/K-not-allowed/Erased-matches.agda
+++ b/Graded/Modality/Extended/K-not-allowed/Erased-matches.agda
@@ -39,6 +39,7 @@ open import Graded.Modality.Morphism.Type-restrictions
 open import Graded.Modality.Morphism.Type-restrictions.Examples
 open import Graded.Modality.Morphism.Usage-restrictions
 open import Graded.Modality.Morphism.Usage-restrictions.Examples
+open import Graded.Modality.Omega-instances
 open import Graded.Mode.Instances.Zero-one.Variant
 open import Graded.Mode.Instances.Zero-one
 open import Graded.Restrictions.Zero-one
@@ -116,6 +117,7 @@ private
 
   TR′ :
     {M : Set} {𝕄 : Modality M} →
+    ⦃ ok : Has-omega M 𝕄 ⦄ →
     Mode-variant 𝕄 →
     Type-restrictions 𝕄
   TR′ v =
@@ -128,6 +130,7 @@ private
 
     Assumptions-TR′ :
       {M : Set} {𝕄 : Modality M} →
+      ⦃ ok : Has-omega M 𝕄 ⦄ →
       (v : Mode-variant 𝕄) →
       Decidable (_≡_ {A = M}) →
       TD.Assumptions (TR′ {𝕄 = 𝕄} v)
@@ -140,6 +143,7 @@ private
   UR′ :
     {M : Set} {𝕄 : Modality M}
     {v : Mode-variant 𝕄} →
+    ⦃ ok : Has-omega M 𝕄 ⦄ →
     Has-nr M 𝕄 →
     Usage-restrictions 𝕄 (Zero-one-isMode v)
   UR′ has-nr =
@@ -152,6 +156,7 @@ private
       {M : Set} {𝕄 : Modality M}
       {v : Mode-variant 𝕄} →
       {has-nr : Has-nr _ 𝕄} →
+      ⦃ ok : Has-omega M 𝕄 ⦄ →
       Decidable (_≡_ {A = M}) →
       UD.Assumptions (UR′ {𝕄 = 𝕄} {v = v} has-nr)
     Assumptions-UR′ {has-nr} =
@@ -172,6 +177,7 @@ Trivial = λ where
     .UA  → Assumptions-UR′ U._≟_
     .NR  → Nr ⦃ U.unit-has-nr ⦄
     .NO-NR-GLB → U.unit-supports-glb-for-nr
+    .HAS-ω → U.unit-has-omega
     .NR₀ → U.nr-linearity-like-for-𝟘
     .NR₁ → U.nr-linearity-like-for-𝟙
     .SUB → U.unit-supports-subtraction
@@ -228,6 +234,7 @@ Erasure = λ where
     .UA      → Assumptions-UR′ E._≟_
     .NR      → Nr ⦃ EM.erasure-has-nr ⦄
     .NO-NR-GLB → EP.Erasure-supports-factoring-nr-rule
+    .HAS-ω → EM.erasure-has-omega
     .NR₀ {z} → EP.nr-linearity-like-for-𝟘 {z = z}
     .NR₁ {z} → EP.nr-linearity-like-for-𝟙 {z = z}
     .SUB     → EP.supports-subtraction
@@ -284,6 +291,7 @@ Affine-types = λ where
     .UA          → Assumptions-UR′ A._≟_
     .NR          → Nr ⦃ A.zero-one-many-has-nr ⦄
     .NO-NR-GLB   → A.zero-one-many-supports-glb-for-natrec
+    .HAS-ω       → A.zero-one-many-has-omega
     .NR₀ {p}     → A.nr-linearity-like-for-𝟘 {p = p}
     .NR₁ {p} {z} → A.nr-linearity-like-for-𝟙 {p = p} {z = z}
     .SUB         → A.supports-subtraction
@@ -351,6 +359,7 @@ Linearity = λ where
     .UA          → Assumptions-UR′ L._≟_
     .NR          → Nr ⦃ L.zero-one-many-has-nr ⦄
     .NO-NR-GLB   → L.zero-one-many-supports-glb-for-natrec
+    .HAS-ω       → L.zero-one-many-has-omega
     .NR₀ {p}     → L.nr-linearity-like-for-𝟘 {p = p}
     .NR₁ {p} {z} → L.nr-linearity-like-for-𝟙 {p = p} {z = z}
     .SUB         → L.supports-subtraction
@@ -422,6 +431,7 @@ Linear-or-affine-types = λ where
     .UA          → Assumptions-UR′ LA._≟_
     .NR          → Nr ⦃ LA.linear-or-affine-has-nr ⦄
     .NO-NR-GLB   → LA.linear-or-affine-supports-glb-for-natrec
+    .HAS-ω       → LA.linear-or-affine-has-omega
     .NR₀ {p}     → LA.nr-linearity-like-for-𝟘 {p = p}
     .NR₁ {p} {s} → LA.nr-linearity-like-for-𝟙 {p = p} {s = s}
     .SUB {r}     → LA.supports-subtraction {r = r}
@@ -561,7 +571,7 @@ Trivial⇨Erasure = λ where
     are-preserving-usage-restrictions :
       Are-preserving-usage-restrictions E₁.UR E₂.UR tr tr
     are-preserving-usage-restrictions =
-      Are-preserving-usage-restrictions-not-all-erased-matches-JK $
+      Are-preserving-usage-restrictions-not-all-erased-matches-JK unit⇨erasure-omega-preserving $
         Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
           case Nr-available-propositional _ has-nr₁ (Nr ⦃ U.unit-has-nr ⦄) of λ {
@@ -575,7 +585,7 @@ Trivial⇨Erasure = λ where
     are-reflecting-usage-restrictions :
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
-      Are-reflecting-usage-restrictions-not-all-erased-matches-JK $
+      Are-reflecting-usage-restrictions-not-all-erased-matches-JK unit⇨erasure-omega-reflecting $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₂ refl) Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -665,7 +675,7 @@ Erasure⇨Affine-types = λ where
     are-preserving-usage-restrictions :
       Are-preserving-usage-restrictions E₁.UR E₂.UR tr tr
     are-preserving-usage-restrictions =
-      Are-preserving-usage-restrictions-not-all-erased-matches-JK $
+      Are-preserving-usage-restrictions-not-all-erased-matches-JK erasure⇨zero-one-many-omega-preserving $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
           case Nr-available-propositional _ has-nr₁ (Nr ⦃ EM.erasure-has-nr ⦄) of λ {
@@ -679,7 +689,7 @@ Erasure⇨Affine-types = λ where
     are-reflecting-usage-restrictions :
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
-      Are-reflecting-usage-restrictions-not-all-erased-matches-JK $
+      Are-reflecting-usage-restrictions-not-all-erased-matches-JK erasure⇨zero-one-many-omega-reflecting $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₁ _) Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -769,7 +779,7 @@ Erasure⇨Linearity = λ where
     are-preserving-usage-restrictions :
       Are-preserving-usage-restrictions E₁.UR E₂.UR tr tr
     are-preserving-usage-restrictions =
-      Are-preserving-usage-restrictions-not-all-erased-matches-JK $
+      Are-preserving-usage-restrictions-not-all-erased-matches-JK erasure⇨zero-one-many-omega-preserving $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
           case Nr-available-propositional _ has-nr₁ (Nr ⦃ EM.erasure-has-nr ⦄) of λ {
@@ -783,7 +793,7 @@ Erasure⇨Linearity = λ where
     are-reflecting-usage-restrictions :
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
-      Are-reflecting-usage-restrictions-not-all-erased-matches-JK $
+      Are-reflecting-usage-restrictions-not-all-erased-matches-JK erasure⇨zero-one-many-omega-reflecting $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₁ _) Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -874,7 +884,7 @@ Affine-types⇨Linear-or-affine-types = λ where
     are-preserving-usage-restrictions :
       Are-preserving-usage-restrictions E₁.UR E₂.UR tr tr
     are-preserving-usage-restrictions =
-      Are-preserving-usage-restrictions-not-all-erased-matches-JK $
+      Are-preserving-usage-restrictions-not-all-erased-matches-JK affine⇨linear-or-affine-omega-preserving $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
           case Nr-available-propositional _ has-nr₁ (Nr ⦃ A.zero-one-many-has-nr ⦄) of λ {
@@ -888,7 +898,7 @@ Affine-types⇨Linear-or-affine-types = λ where
     are-reflecting-usage-restrictions :
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
-      Are-reflecting-usage-restrictions-not-all-erased-matches-JK $
+      Are-reflecting-usage-restrictions-not-all-erased-matches-JK affine⇨linear-or-affine-omega-reflecting $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₁ _) Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -979,7 +989,7 @@ Linearity⇨Linear-or-affine-types = λ where
     are-preserving-usage-restrictions :
       Are-preserving-usage-restrictions E₁.UR E₂.UR tr tr
     are-preserving-usage-restrictions =
-      Are-preserving-usage-restrictions-not-all-erased-matches-JK $
+      Are-preserving-usage-restrictions-not-all-erased-matches-JK linearity⇨linear-or-affine-omega-preserving $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
           case Nr-available-propositional _ has-nr₁ (Nr ⦃ L.zero-one-many-has-nr ⦄) of λ {
@@ -993,7 +1003,7 @@ Linearity⇨Linear-or-affine-types = λ where
     are-reflecting-usage-restrictions :
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
-      Are-reflecting-usage-restrictions-not-all-erased-matches-JK $
+      Are-reflecting-usage-restrictions-not-all-erased-matches-JK linearity⇨linear-or-affine-omega-reflecting $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₁ _) Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →

--- a/Graded/Modality/Extended/K-not-allowed/No-erased-matches.agda
+++ b/Graded/Modality/Extended/K-not-allowed/No-erased-matches.agda
@@ -39,6 +39,7 @@ open import Graded.Modality.Morphism.Type-restrictions
 open import Graded.Modality.Morphism.Type-restrictions.Examples
 open import Graded.Modality.Morphism.Usage-restrictions
 open import Graded.Modality.Morphism.Usage-restrictions.Examples
+open import Graded.Modality.Omega-instances
 open import Graded.Mode.Instances.Zero-one.Variant
 open import Graded.Mode.Instances.Zero-one
 open import Graded.Restrictions.Zero-one
@@ -118,6 +119,7 @@ private
 
   TR′ :
     {M : Set} {𝕄 : Modality M} →
+    ⦃ ok : Has-omega M 𝕄 ⦄ →
     Mode-variant 𝕄 →
     Type-restrictions 𝕄
   TR′ v =
@@ -131,6 +133,7 @@ private
 
     Assumptions-TR′ :
       {M : Set} {𝕄 : Modality M} →
+      ⦃ ok : Has-omega M 𝕄 ⦄ →
       (v : Mode-variant 𝕄) →
       Decidable (_≡_ {A = M}) →
       TD.Assumptions (TR′ {𝕄 = 𝕄} v)
@@ -144,6 +147,7 @@ private
   UR′ :
     {M : Set} {𝕄 : Modality M}
     {v : Mode-variant 𝕄} →
+    ⦃ ok : Has-omega M 𝕄 ⦄ →
     Has-nr M 𝕄 →
     Usage-restrictions 𝕄 (Zero-one-isMode v)
   UR′ {v} has-nr =
@@ -156,6 +160,7 @@ private
       {M : Set} {𝕄 : Modality M}
       {v : Mode-variant 𝕄} →
       {has-nr : Has-nr M 𝕄} →
+      ⦃ ok : Has-omega M 𝕄 ⦄ →
       Decidable (_≡_ {A = M}) →
       UD.Assumptions (UR′ {𝕄 = 𝕄} {v = v} has-nr)
     Assumptions-UR′ {v} {has-nr} =
@@ -176,6 +181,7 @@ Trivial = λ where
     .UA  → Assumptions-UR′ U._≟_
     .NR  → Nr ⦃ U.unit-has-nr ⦄
     .NO-NR-GLB → U.unit-supports-glb-for-nr
+    .HAS-ω → U.unit-has-omega
     .NR₀ → U.nr-linearity-like-for-𝟘
     .NR₁ → U.nr-linearity-like-for-𝟙
     .SUB → U.unit-supports-subtraction
@@ -233,6 +239,7 @@ Erasure = λ where
     .UA      → Assumptions-UR′ E._≟_
     .NR      → Nr ⦃ EM.erasure-has-nr ⦄
     .NO-NR-GLB → EP.Erasure-supports-factoring-nr-rule
+    .HAS-ω   → EM.erasure-has-omega
     .NR₀ {z} → EP.nr-linearity-like-for-𝟘 {z = z}
     .NR₁ {z} → EP.nr-linearity-like-for-𝟙 {z = z}
     .SUB     → EP.supports-subtraction
@@ -304,6 +311,7 @@ Affine-types = λ where
     .UA          → Assumptions-UR′ A._≟_
     .NR          → Nr ⦃ A.zero-one-many-has-nr ⦄
     .NO-NR-GLB   → A.zero-one-many-supports-glb-for-natrec
+    .HAS-ω       → A.zero-one-many-has-omega
     .NR₀ {p}     → A.nr-linearity-like-for-𝟘 {p = p}
     .NR₁ {p} {z} → A.nr-linearity-like-for-𝟙 {p = p} {z = z}
     .SUB         → A.supports-subtraction
@@ -386,6 +394,7 @@ Linearity = λ where
     .UA          → Assumptions-UR′ L._≟_
     .NR          → Nr ⦃ L.zero-one-many-has-nr ⦄
     .NO-NR-GLB   → L.zero-one-many-supports-glb-for-natrec
+    .HAS-ω       → L.zero-one-many-has-omega
     .NR₀ {p}     → L.nr-linearity-like-for-𝟘 {p = p}
     .NR₁ {p} {z} → L.nr-linearity-like-for-𝟙 {p = p} {z = z}
     .SUB         → L.supports-subtraction
@@ -472,6 +481,7 @@ Linear-or-affine-types = λ where
     .UA          → Assumptions-UR′ LA._≟_
     .NR          → Nr ⦃ LA.linear-or-affine-has-nr ⦄
     .NO-NR-GLB   → LA.linear-or-affine-supports-glb-for-natrec
+    .HAS-ω       → LA.linear-or-affine-has-omega
     .NR₀ {p}     → LA.nr-linearity-like-for-𝟘 {p = p}
     .NR₁ {p} {s} → LA.nr-linearity-like-for-𝟙 {p = p} {s = s}
     .SUB {r}     → LA.supports-subtraction {r = r}
@@ -634,7 +644,8 @@ Trivial⇨Erasure = λ where
       Are-preserving-usage-restrictions E₁.UR E₂.UR tr tr
     are-preserving-usage-restrictions =
       Are-preserving-usage-restrictions-no-erased-matches-UR
-        (λ _ → inj₂ (λ ())) are-preserving-type-restrictions $
+        (λ _ → inj₂ (λ ())) unit⇨erasure-omega-preserving
+        are-preserving-type-restrictions $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
           case Nr-available-propositional _ has-nr₁ (Nr ⦃ U.unit-has-nr ⦄) of λ {
@@ -649,7 +660,8 @@ Trivial⇨Erasure = λ where
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
       Are-reflecting-usage-restrictions-no-erased-matches-UR
-        (⊥-elim ∘→ (_$ refl)) are-reflecting-type-restrictions $
+        (⊥-elim ∘→ (_$ refl)) unit⇨erasure-omega-reflecting
+        are-reflecting-type-restrictions $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₂ refl) Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -753,6 +765,7 @@ Erasure⇨Affine-types = λ where
                      {p = E.𝟘} refl → refl
                      {p = E.ω} ())
                 ))
+        erasure⇨zero-one-many-omega-preserving
         are-preserving-type-restrictions $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -768,7 +781,7 @@ Erasure⇨Affine-types = λ where
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
       Are-reflecting-usage-restrictions-no-erased-matches-UR
-        (λ _ → (λ ()) , (λ { refl → refl }))
+        (λ _ → (λ ()) , (λ { refl → refl })) erasure⇨zero-one-many-omega-reflecting
         are-reflecting-type-restrictions $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₁ _) Nr≈Nr
@@ -873,6 +886,7 @@ Erasure⇨Linearity = λ where
                      {p = E.𝟘} refl → refl
                      {p = E.ω} ())
                 ))
+        erasure⇨zero-one-many-omega-preserving
         are-preserving-type-restrictions $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -888,7 +902,7 @@ Erasure⇨Linearity = λ where
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
       Are-reflecting-usage-restrictions-no-erased-matches-UR
-        (λ _ → (λ ()) , (λ { refl → refl }))
+        (λ _ → (λ ()) , (λ { refl → refl })) erasure⇨zero-one-many-omega-reflecting
         are-reflecting-type-restrictions $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₁ _) Nr≈Nr
@@ -995,6 +1009,7 @@ Affine-types⇨Linear-or-affine-types = λ where
                      {p = A.𝟙} ()
                      {p = A.ω} ())
                 ))
+        affine⇨linear-or-affine-omega-preserving
         are-preserving-type-restrictions $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -1010,7 +1025,7 @@ Affine-types⇨Linear-or-affine-types = λ where
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
       Are-reflecting-usage-restrictions-no-erased-matches-UR
-        (λ _ → (λ ()) , (λ { refl → refl }))
+        (λ _ → (λ ()) , (λ { refl → refl })) affine⇨linear-or-affine-omega-reflecting
         are-reflecting-type-restrictions $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₁ _) Nr≈Nr
@@ -1117,6 +1132,7 @@ Linearity⇨Linear-or-affine-types = λ where
                      {p = L.𝟙} ()
                      {p = L.ω} ())
                 ))
+        linearity⇨linear-or-affine-omega-preserving
         are-preserving-type-restrictions $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -1132,7 +1148,7 @@ Linearity⇨Linear-or-affine-types = λ where
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
       Are-reflecting-usage-restrictions-no-erased-matches-UR
-        (λ _ → (λ ()) , (λ { refl → refl }))
+        (λ _ → (λ ()) , (λ { refl → refl })) linearity⇨linear-or-affine-omega-reflecting
         are-reflecting-type-restrictions $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₁ _) Nr≈Nr

--- a/Graded/Modality/Extended/K-not-allowed/Only-some-erased-matches.agda
+++ b/Graded/Modality/Extended/K-not-allowed/Only-some-erased-matches.agda
@@ -40,6 +40,7 @@ open import Graded.Modality.Morphism.Type-restrictions
 open import Graded.Modality.Morphism.Type-restrictions.Examples
 open import Graded.Modality.Morphism.Usage-restrictions
 open import Graded.Modality.Morphism.Usage-restrictions.Examples
+open import Graded.Modality.Omega-instances
 open import Graded.Mode.Instances.Zero-one.Variant
 open import Graded.Mode.Instances.Zero-one
 open import Graded.Restrictions.Zero-one
@@ -117,6 +118,7 @@ private
 
   TR′ :
     {M : Set} {𝕄 : Modality M} →
+    ⦃ ok : Has-omega M 𝕄 ⦄ →
     Mode-variant 𝕄 →
     Type-restrictions 𝕄
   TR′ v =
@@ -130,6 +132,7 @@ private
 
     Assumptions-TR′ :
       {M : Set} {𝕄 : Modality M} →
+      ⦃ ok : Has-omega M 𝕄 ⦄ →
       (v : Mode-variant 𝕄) →
       Decidable (_≡_ {A = M}) →
       TD.Assumptions (TR′ {𝕄 = 𝕄} v)
@@ -143,6 +146,7 @@ private
   UR′ :
     {M : Set} {𝕄 : Modality M}
     {v : Mode-variant 𝕄} →
+    ⦃ ok : Has-omega M 𝕄 ⦄ →
     Has-nr M 𝕄 →
     Usage-restrictions 𝕄 (Zero-one-isMode v)
   UR′ has-nr =
@@ -155,6 +159,7 @@ private
       {M : Set} {𝕄 : Modality M}
       {v : Mode-variant 𝕄} →
       {has-nr : Has-nr _ 𝕄} →
+      ⦃ ok : Has-omega M 𝕄 ⦄ →
       Decidable (_≡_ {A = M}) →
       UD.Assumptions (UR′ {𝕄 = 𝕄} {v = v} has-nr)
     Assumptions-UR′ {has-nr} =
@@ -175,6 +180,7 @@ Trivial = λ where
     .UA  → Assumptions-UR′ U._≟_
     .NR  → Nr ⦃ U.unit-has-nr ⦄
     .NO-NR-GLB → U.unit-supports-glb-for-nr
+    .HAS-ω → U.unit-has-omega
     .NR₀ → U.nr-linearity-like-for-𝟘
     .NR₁ → U.nr-linearity-like-for-𝟙
     .SUB → U.unit-supports-subtraction
@@ -232,6 +238,7 @@ Erasure = λ where
     .UA      → Assumptions-UR′ E._≟_
     .NR      → Nr ⦃ EM.erasure-has-nr ⦄
     .NO-NR-GLB → EP.Erasure-supports-factoring-nr-rule
+    .HAS-ω → EM.erasure-has-omega
     .NR₀ {z} → EP.nr-linearity-like-for-𝟘 {z = z}
     .NR₁ {z} → EP.nr-linearity-like-for-𝟙 {z = z}
     .SUB     → EP.supports-subtraction
@@ -296,6 +303,7 @@ Affine-types = λ where
     .UA          → Assumptions-UR′ A._≟_
     .NR          → Nr ⦃ A.zero-one-many-has-nr ⦄
     .NO-NR-GLB   → A.zero-one-many-supports-glb-for-natrec
+    .HAS-ω       → A.zero-one-many-has-omega
     .NR₀ {p}     → A.nr-linearity-like-for-𝟘 {p = p}
     .NR₁ {p} {z} → A.nr-linearity-like-for-𝟙 {p = p} {z = z}
     .SUB         → A.supports-subtraction
@@ -371,6 +379,7 @@ Linearity = λ where
     .UA          → Assumptions-UR′ L._≟_
     .NR          → Nr ⦃ L.zero-one-many-has-nr ⦄
     .NO-NR-GLB   → L.zero-one-many-supports-glb-for-natrec
+    .HAS-ω       → L.zero-one-many-has-omega
     .NR₀ {p}     → L.nr-linearity-like-for-𝟘 {p = p}
     .NR₁ {p} {z} → L.nr-linearity-like-for-𝟙 {p = p} {z = z}
     .SUB         → L.supports-subtraction
@@ -450,6 +459,7 @@ Linear-or-affine-types = λ where
     .UA          → Assumptions-UR′ LA._≟_
     .NR          → Nr ⦃ LA.linear-or-affine-has-nr ⦄
     .NO-NR-GLB   → LA.linear-or-affine-supports-glb-for-natrec
+    .HAS-ω       → LA.linear-or-affine-has-omega
     .NR₀ {p}     → LA.nr-linearity-like-for-𝟘 {p = p}
     .NR₁ {p} {s} → LA.nr-linearity-like-for-𝟙 {p = p} {s = s}
     .SUB {r}     → LA.supports-subtraction {r = r}
@@ -605,7 +615,7 @@ Trivial⇨Erasure = λ where
       Are-preserving-usage-restrictions E₁.UR E₂.UR tr tr
     are-preserving-usage-restrictions =
       Are-preserving-usage-restrictions-only-some-erased-matches
-        (λ _ → inj₂ (λ ())) $
+        (λ _ → inj₂ (λ ())) unit⇨erasure-omega-preserving $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
           case Nr-available-propositional _ has-nr₁ (Nr ⦃ U.unit-has-nr ⦄) of λ {
@@ -620,7 +630,7 @@ Trivial⇨Erasure = λ where
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
       Are-reflecting-usage-restrictions-only-some-erased-matches
-        (⊥-elim ∘→ (_$ refl)) $
+        (⊥-elim ∘→ (_$ refl))unit⇨erasure-omega-reflecting  $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₂ refl) Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -723,7 +733,8 @@ Erasure⇨Affine-types = λ where
                 , (λ where
                      {p = E.𝟘} refl → refl
                      {p = E.ω} ())
-                )) $
+                ))
+        erasure⇨zero-one-many-omega-preserving $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
           case Nr-available-propositional _ has-nr₁ (Nr ⦃ EM.erasure-has-nr ⦄) of λ {
@@ -738,7 +749,7 @@ Erasure⇨Affine-types = λ where
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
       Are-reflecting-usage-restrictions-only-some-erased-matches
-        (λ _ → (λ ()) , (λ { refl → refl })) $
+        (λ _ → (λ ()) , (λ { refl → refl })) erasure⇨zero-one-many-omega-reflecting $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₁ _) Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -841,7 +852,8 @@ Erasure⇨Linearity = λ where
                 , (λ where
                      {p = E.𝟘} refl → refl
                      {p = E.ω} ())
-                )) $
+                ))
+        erasure⇨zero-one-many-omega-preserving $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
           case Nr-available-propositional _ has-nr₁ (Nr ⦃ EM.erasure-has-nr ⦄) of λ {
@@ -856,7 +868,7 @@ Erasure⇨Linearity = λ where
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
       Are-reflecting-usage-restrictions-only-some-erased-matches
-        (λ _ → (λ ()) , (λ { refl → refl })) $
+        (λ _ → (λ ()) , (λ { refl → refl })) erasure⇨zero-one-many-omega-reflecting $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₁ _) Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -961,7 +973,8 @@ Affine-types⇨Linear-or-affine-types = λ where
                      {p = A.𝟘} refl → refl
                      {p = A.𝟙} ()
                      {p = A.ω} ())
-                )) $
+                ))
+        affine⇨linear-or-affine-omega-preserving $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
           case Nr-available-propositional _ has-nr₁ (Nr ⦃ A.zero-one-many-has-nr ⦄) of λ {
@@ -976,7 +989,7 @@ Affine-types⇨Linear-or-affine-types = λ where
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
       Are-reflecting-usage-restrictions-only-some-erased-matches
-        (λ _ → (λ ()) , (λ { refl → refl })) $
+        (λ _ → (λ ()) , (λ { refl → refl })) affine⇨linear-or-affine-omega-reflecting $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₁ _) Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
@@ -1081,7 +1094,8 @@ Linearity⇨Linear-or-affine-types = λ where
                      {p = L.𝟘} refl → refl
                      {p = L.𝟙} ()
                      {p = L.ω} ())
-                )) $
+                ))
+        linearity⇨linear-or-affine-omega-preserving $
       Are-preserving-usage-restrictions-no-usage-restrictions _ Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →
           case Nr-available-propositional _ has-nr₁ (Nr ⦃ L.zero-one-many-has-nr ⦄) of λ {
@@ -1096,7 +1110,7 @@ Linearity⇨Linear-or-affine-types = λ where
       Are-reflecting-usage-restrictions E₁.UR E₂.UR tr tr
     are-reflecting-usage-restrictions =
       Are-reflecting-usage-restrictions-only-some-erased-matches
-        (λ _ → (λ ()) , (λ { refl → refl })) $
+        (λ _ → (λ ()) , (λ { refl → refl })) linearity⇨linear-or-affine-omega-reflecting $
       Are-reflecting-usage-restrictions-no-usage-restrictions
         _ (λ _ → inj₁ _) Nr≈Nr
         (λ ⦃ has-nr₁ ⦄ ⦃ has-nr₂ ⦄ →

--- a/Graded/Modality/Instances/Affine.agda
+++ b/Graded/Modality/Instances/Affine.agda
@@ -306,6 +306,14 @@ instance
     Has-well-behaved-zero affineModality
   affine-has-well-behaved-zero = zero-one-many-has-well-behaved-zero
 
+instance
+
+  -- The "affine types" modality has grade ω.
+
+  affine-has-omega :
+    Has-omega affineModality
+  affine-has-omega = zero-one-many-has-omega
+
 -- 𝟘 is the largest element.
 
 ≤𝟘 : p ≤ 𝟘

--- a/Graded/Modality/Instances/Bounded-distributive-lattice.agda
+++ b/Graded/Modality/Instances/Bounded-distributive-lattice.agda
@@ -44,9 +44,6 @@ modality = record
   ; _∧_           = _∧_
   ; 𝟘             = ⊤
   ; 𝟙             = ⊥
-  ; ω             = ⊥
-  ; ω≤𝟙           = ⊥≤ _
-  ; ω·+≤ω·ʳ       = ⊥∨∧≤⊥∨ʳ
   ; is-𝟘?         = is-⊤?
   ; +-·-Semiring  = record
     { isSemiringWithoutAnnihilatingZero = record
@@ -101,16 +98,6 @@ modality = record
       ⊤ ∨ (⊤ ∧ p)  ≡⟨ ∨-absorbs-∧ _ _ ⟩
       ⊤            ∎
 
-  opaque
-
-    ⊥∨∧≤⊥∨ʳ : ⊥ ∨ (p ∧ q) ≤ ⊥ ∨ q
-    ⊥∨∧≤⊥∨ʳ {p} {q} =
-      ⊥ ∨ (p ∧ q)              ≡⟨ ∨-identityˡ _ ⟩
-      p ∧ q                    ≡˘⟨ cong (_ ∧_) (∧-idem _) ⟩
-      p ∧ (q ∧ q)              ≡˘⟨ ∧-assoc _ _ _ ⟩
-      (p ∧ q) ∧ q              ≡˘⟨ cong₂ _∧_ (∨-identityˡ _) (∨-identityˡ _) ⟩
-      (⊥ ∨ (p ∧ q)) ∧ (⊥ ∨ q)  ∎
-
 -- One can define natrec-star operators for bounded, distributive
 -- lattices (if equality with ⊤ is decidable).
 
@@ -124,6 +111,30 @@ opaque
 
   has-nr : Has-nr modality
   has-nr = Star.has-nr modality ⦃ has-star ⦄
+
+instance
+
+  -- The modality has grade ω.
+
+  has-omega : Has-omega modality
+  has-omega = record
+    { ω             = ⊥
+    ; ω≤𝟙           = ⊥≤ _
+    ; ω·+≤ω·ʳ       = ⊥∨∧≤⊥∨ʳ
+    }
+    where
+    open Tools.Reasoning.PropositionalEquality
+
+    opaque
+
+      ⊥∨∧≤⊥∨ʳ : ⊥ ∨ (p ∧ q) ≤ ⊥ ∨ q
+      ⊥∨∧≤⊥∨ʳ {p} {q} =
+        ⊥ ∨ (p ∧ q)              ≡⟨ ∨-identityˡ _ ⟩
+        p ∧ q                    ≡˘⟨ cong (_ ∧_) (∧-idem _) ⟩
+        p ∧ (q ∧ q)              ≡˘⟨ ∧-assoc _ _ _ ⟩
+        (p ∧ q) ∧ q              ≡˘⟨ cong₂ _∧_ (∨-identityˡ _) (∨-identityˡ _) ⟩
+        (⊥ ∨ (p ∧ q)) ∧ (⊥ ∨ q)  ∎
+
 
 opaque
   unfolding has-nr

--- a/Graded/Modality/Instances/Erasure/Combined/Equivalent.agda
+++ b/Graded/Modality/Instances/Erasure/Combined/Equivalent.agda
@@ -13,6 +13,7 @@ open import Definition.Typed.Restrictions
 
 open import Graded.Modality.Instances.Erasure.Modality
 open import Graded.Usage.Restrictions
+open import Graded.Usage.Restrictions.JK ErasureModality
 open import Graded.Mode.Instances.Zero-one.Variant ErasureModality
 open import Graded.Mode.Instances.Zero-one 𝟘ᵐ-Allowed
 
@@ -32,6 +33,9 @@ private
   𝕄 = ErasureModality
 
   module M = Modality 𝕄
+
+  ω′ : ⦃ ok : JK-Any-erased-matches JK-supported-erased-matches ⦄ → _
+  ω′ ⦃ ok ⦄ = Has-omega.ω (JK-Any-erased-matches-has-omega ok)
 
 open import Graded.Context 𝕄
 open import Graded.Modality.Instances.Erasure
@@ -158,6 +162,12 @@ private opaque
   [⌞⌟≡𝟙ᵐ→≤ω]→≤ : (⌞ p ⌟ PE.≡ 𝟙ᵐ → q ≤ ω) → q ≤ p
   [⌞⌟≡𝟙ᵐ→≤ω]→≤ {p = 𝟘} _   = greatest-elem _
   [⌞⌟≡𝟙ᵐ→≤ω]→≤ {p = ω} hyp = hyp ⌞𝟙⌟
+
+  ω′≡ω :
+    ⦃ ok : JK-Any-erased-matches JK-supported-erased-matches ⦄ →
+    ω′ PE.≡ ω
+  ω′≡ω ⦃ ok ⦄ =
+    erasure-has-omega-unique (JK-Any-erased-matches-has-omega ok)
 
 ------------------------------------------------------------------------
 -- From the combined system to the other ones
@@ -392,33 +402,34 @@ opaque mutual
         ▸w = ⊢∷[]→▸ ⊢w
     in
     case J-view p′ q ⌞ p ⌟ of λ where
-      (is-all ≡all) →
+      (is-all ⦃ (≡all) ⦄) →
         case hyp₃ ≡all of λ {
           (PE.refl , _ , PE.refl , PE.refl) →
-        J₀ₘ₂ ≡all ▸A
+        J₀ₘ₂ ▸A
           (PE.subst (flip (_▸[_]_ _) _) ⌞𝟘⌟≡𝟘ᵐ? ▸t)
           (PE.subst₂ (_▸[_] B)
              (PE.cong₂ _∙_ (PE.cong (_∙_ _) 𝟘≡⌜𝟘ᵐ?⌝·) 𝟘≡⌜𝟘ᵐ?⌝·) ⌞𝟘⌟≡𝟘ᵐ?
              (⊢[]→▸ ⊢B))
           ▸u (PE.subst (flip (_▸[_]_ _) _) ⌞𝟘⌟≡𝟘ᵐ? ▸v)
           (PE.subst (flip (_▸[_]_ _) _) ⌞𝟘⌟≡𝟘ᵐ? ▸w) }
-      (is-some-yes ≡some (p′≡𝟘 , q≡𝟘)) →
+      (is-some-yes ⦃ (≡some) ⦄ (p′≡𝟘 , q≡𝟘)) →
         case hyp₂ ≡some p′≡𝟘 q≡𝟘 of λ {
           (PE.refl , _ , PE.refl , PE.refl) →
         sub
-          (J₀ₘ₁ ≡some p′≡𝟘 q≡𝟘 ▸A
+          (J₀ₘ₁ p′≡𝟘 q≡𝟘 ▸A
              (PE.subst (flip (_▸[_]_ _) _) ⌞𝟘⌟≡𝟘ᵐ? ▸t) ▸B ▸u
              (PE.subst (flip (_▸[_]_ _) _) ⌞𝟘⌟≡𝟘ᵐ? ▸v)
              (PE.subst (flip (_▸[_]_ _) _) ⌞𝟘⌟≡𝟘ᵐ? ▸w))
-          (begin
+          ((begin
              γ              ≡˘⟨ +ᶜ-idem _ ⟩
              γ +ᶜ γ         ≈˘⟨ ·ᶜ-identityˡ _ ⟩
-             ω ·ᶜ (γ +ᶜ γ)  ∎) }
-      (is-other ≤some ¬[p′≡𝟘×q≡𝟘]) →
+             ω ·ᶜ (γ +ᶜ γ)  ≈˘⟨ ·ᶜ-congʳ ω′≡ω ⟩
+             ω′ ·ᶜ (γ +ᶜ γ)  ∎)) }
+      (is-other ⦃ (≤some) ⦄ ¬[p′≡𝟘×q≡𝟘]) →
         case hyp₁ ≤some ¬[p′≡𝟘×q≡𝟘] of λ {
           (PE.refl , PE.refl , PE.refl , PE.refl) →
-        sub (Jₘ ≤some ¬[p′≡𝟘×q≡𝟘] ▸A ▸t (∙∙▸→∙⌜⌝·∙⌜⌝·▸ ▸B) ▸u ▸v ▸w)
-          (begin
+        sub (Jₘ ¬[p′≡𝟘×q≡𝟘] ▸A ▸t (∙∙▸→∙⌜⌝·∙⌜⌝·▸ ▸B) ▸u ▸v ▸w)
+          ((begin
              γ                             ≡˘⟨ PE.trans
                                                  (PE.cong (_ +ᶜ_)
                                                     (PE.trans
@@ -428,7 +439,8 @@ opaque mutual
                                                      +ᶜ-idem _)) $
                                                +ᶜ-idem _ ⟩
              γ +ᶜ γ +ᶜ γ +ᶜ γ +ᶜ γ         ≈˘⟨ ·ᶜ-identityˡ _ ⟩
-             ω ·ᶜ (γ +ᶜ γ +ᶜ γ +ᶜ γ +ᶜ γ)  ∎) }
+             ω ·ᶜ (γ +ᶜ γ +ᶜ γ +ᶜ γ +ᶜ γ)  ≈˘⟨ ·ᶜ-congʳ ω′≡ω ⟩
+             ω′ ·ᶜ (γ +ᶜ γ +ᶜ γ +ᶜ γ +ᶜ γ) ∎)) }
     where
     open ≤ᶜ-reasoning
   ⊢∷[]→▸
@@ -442,37 +454,39 @@ opaque mutual
         ▸v = ⊢∷[]→▸ ⊢v
     in
     case K-view p′ ⌞ p ⌟ of λ where
-      (is-all ≡all) →
+      (is-all ⦃ (≡all) ⦄) →
         case hyp₃ ≡all of λ {
           (PE.refl , _ , PE.refl , PE.refl) →
-        K₀ₘ₂ ≡all ▸A
+        K₀ₘ₂ ▸A
           (PE.subst (flip (_▸[_]_ _) _) ⌞𝟘⌟≡𝟘ᵐ? ▸t)
           (PE.subst₂ (_▸[_] B) (PE.cong (_∙_ _) 𝟘≡⌜𝟘ᵐ?⌝·) ⌞𝟘⌟≡𝟘ᵐ?
              (⊢[]→▸ ⊢B))
           ▸u (PE.subst (flip (_▸[_]_ _) _) ⌞𝟘⌟≡𝟘ᵐ? ▸v) }
-      (is-some-yes ≡some p′≡𝟘) →
+      (is-some-yes ⦃ (≡some) ⦄ p′≡𝟘) →
         case hyp₂ ≡some p′≡𝟘 of λ {
           (PE.refl , _ , PE.refl , PE.refl) →
         sub
-          (K₀ₘ₁ ≡some p′≡𝟘 ▸A
+          (K₀ₘ₁ p′≡𝟘 ▸A
              (PE.subst (flip (_▸[_]_ _) _) ⌞𝟘⌟≡𝟘ᵐ? ▸t) ▸B ▸u
              (PE.subst (flip (_▸[_]_ _) _) ⌞𝟘⌟≡𝟘ᵐ? ▸v))
           (begin
              γ              ≡˘⟨ +ᶜ-idem _ ⟩
              γ +ᶜ γ         ≈˘⟨ ·ᶜ-identityˡ _ ⟩
-             ω ·ᶜ (γ +ᶜ γ)  ∎) }
-      (is-other ≤some p′≢𝟘) →
+             ω ·ᶜ (γ +ᶜ γ) ≈˘⟨ ·ᶜ-congʳ ω′≡ω ⟩
+             ω′ ·ᶜ (γ +ᶜ γ)  ∎) }
+      (is-other ⦃ (≤some) ⦄ p′≢𝟘) →
         case hyp₁ ≤some p′≢𝟘 of λ {
           (PE.refl , PE.refl , PE.refl , PE.refl) →
-        sub (Kₘ ≤some p′≢𝟘 ▸A ▸t (∙▸→∙⌜⌝·▸ ▸B) ▸u ▸v)
-          (begin
+        sub (Kₘ p′≢𝟘 ▸A ▸t (∙▸→∙⌜⌝·▸ ▸B) ▸u ▸v)
+          ((begin
              γ                        ≡˘⟨ PE.trans
                                             (PE.cong (_ +ᶜ_)
                                                (PE.trans (PE.cong (_ +ᶜ_) (+ᶜ-idem _)) $
                                                 +ᶜ-idem _)) $
                                           +ᶜ-idem _ ⟩
              γ +ᶜ γ +ᶜ γ +ᶜ γ         ≈˘⟨ ·ᶜ-identityˡ _ ⟩
-             ω ·ᶜ (γ +ᶜ γ +ᶜ γ +ᶜ γ)  ∎) }
+             ω ·ᶜ (γ +ᶜ γ +ᶜ γ +ᶜ γ)  ≈˘⟨ ·ᶜ-congʳ ω′≡ω ⟩
+             ω′ ·ᶜ (γ +ᶜ γ +ᶜ γ +ᶜ γ) ∎)) }
     where
     open ≤ᶜ-reasoning
   ⊢∷[]→▸ ([]-cong _ ok ⊢l ⊢A ⊢t ⊢u ⊢v) =
@@ -1040,20 +1054,20 @@ module _ (ok : Allowed-at-𝟘ᵐ) where
         (Jⱼ {p} {q} ⊢t ⊢B ⊢u ⊢v ⊢w) PE.refl →
           let _ , ⊢A , _  = ∙∙⊢→⊢-<ˢ ⊢B in
           case J-view p q ⌞ 𝟘 ⌟ of λ where
-            (is-all ≡all) →
+            (is-all ⦃ (≡all) ⦄) →
               J (λ ≤some → case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ())
                 (λ ≡some _ _ →
                    case PE.trans (PE.sym ≡some) ≡all of λ ())
                 (λ _ → PE.refl , PE.refl , PE.refl , PE.refl)
                 (⊢←⊢-<ˢ ⊢A) (⊢∷←⊢∷ ⊢t) (⊢←⊢ ⊢B) (⊢∷←⊢∷ ⊢u) (⊢∷←⊢∷ ⊢v)
                 (⊢∷←⊢∷ ⊢w)
-            (is-some-yes ≡some p≡𝟘×q≡𝟘) →
+            (is-some-yes ⦃ (≡some) ⦄ p≡𝟘×q≡𝟘) →
               J (λ _ ¬[p≡𝟘×q≡𝟘] → ⊥-elim (¬[p≡𝟘×q≡𝟘] ≡some p≡𝟘×q≡𝟘))
                 (λ _ _ _ → PE.refl , PE.refl , PE.refl , PE.refl)
                 (λ ≡all → case PE.trans (PE.sym ≡some) ≡all of λ ())
                 (⊢←⊢-<ˢ ⊢A) (⊢∷←⊢∷ ⊢t) (⊢←⊢ ⊢B) (⊢∷←⊢∷ ⊢u) (⊢∷←⊢∷ ⊢v)
                 (⊢∷←⊢∷ ⊢w)
-            (is-other ≤some ¬[p≡𝟘×q≡𝟘]) →
+            (is-other ⦃ (≤some) ⦄ ¬[p≡𝟘×q≡𝟘]) →
               J (λ _ _ → PE.refl , PE.refl , PE.refl , PE.refl)
                 (λ ≡some p≡𝟘 q≡𝟘 → ⊥-elim (¬[p≡𝟘×q≡𝟘] ≡some (p≡𝟘 , q≡𝟘)))
                 (λ ≡all → case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ())
@@ -1064,19 +1078,19 @@ module _ (ok : Allowed-at-𝟘ᵐ) where
               ⊢A , ⊢t , _ = inversion-Id-⊢-<ˢ ⊢Id
           in
           case K-view p ⌞ 𝟘 ⌟ of λ where
-            (is-all ≡all) →
+            (is-all ⦃ (≡all) ⦄) →
               K (λ ≤some → case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ())
                 (λ ≡some _ → case PE.trans (PE.sym ≡some) ≡all of λ ())
                 (λ _ → PE.refl , PE.refl , PE.refl , PE.refl)
                 ok (⊢←⊢-<ˢ ⊢A) (⊢∷←⊢∷-<ˢ ⊢t) (⊢←⊢ ⊢B) (⊢∷←⊢∷ ⊢u)
                 (⊢∷←⊢∷ ⊢v)
-            (is-some-yes ≡some p≡𝟘) →
+            (is-some-yes ⦃ (≡some) ⦄ p≡𝟘) →
               K (λ _ p≢𝟘 → ⊥-elim (p≢𝟘 ≡some p≡𝟘))
                 (λ _ _ → PE.refl , PE.refl , PE.refl , PE.refl)
                 (λ ≡all → case PE.trans (PE.sym ≡some) ≡all of λ ())
                 ok (⊢←⊢-<ˢ ⊢A) (⊢∷←⊢∷-<ˢ ⊢t) (⊢←⊢ ⊢B) (⊢∷←⊢∷ ⊢u)
                 (⊢∷←⊢∷ ⊢v)
-            (is-other ≤some p≢𝟘) →
+            (is-other ⦃ (≤some) ⦄ p≢𝟘) →
               K (λ _ _ → PE.refl , PE.refl , PE.refl , PE.refl)
                 (λ ≡some p≡𝟘 → ⊥-elim (p≢𝟘 ≡some p≡𝟘))
                 (λ ≡all → case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ())
@@ -1660,11 +1674,12 @@ module _ (ok : Allowed-at-𝟘ᵐ) where
         case inv-usage-J ▸J of λ where
           (invUsageJ
              {γ₂} {γ₃} {γ₄} {γ₅} {γ₆}
-             ≤some ¬[p≡𝟘×q≡𝟘] _ ▸t ▸B ▸u ▸v ▸w γ≤) →
+             ⦃ (≤some) ⦄ ¬[p≡𝟘×q≡𝟘] _ ▸t ▸B ▸u ▸v ▸w γ≤) →
             let γ≤ = begin
-                  γ                                    ≤⟨ γ≤ ⟩
-                  M.ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)  ≈⟨ ·ᶜ-identityˡ _ ⟩
-                  γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆           ∎
+                  γ                                  ≤⟨ γ≤ ⟩
+                  ω′ ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ≈⟨ ·ᶜ-congʳ ω′≡ω ⟩
+                  ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)  ≈⟨ ·ᶜ-identityˡ _ ⟩
+                  γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆         ∎
                 γ≤′ = begin
                   γ                           ≤⟨ γ≤ ⟩
                   γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆  ≤⟨ +ᶜ-decreasingʳ _ _ ⟩
@@ -1708,9 +1723,10 @@ module _ (ok : Allowed-at-𝟘ᵐ) where
                  γ₅ +ᶜ γ₆  ≤⟨ +ᶜ-decreasingʳ _ _ ⟩
                  γ₆        ∎)
           (invUsageJ₀₁
-             {γ₃} {γ₄} ≡some PE.refl PE.refl _ _ ▸B ▸u _ _ γ≤) →
+             {γ₃} {γ₄} ⦃ (≡some) ⦄ PE.refl PE.refl _ _ ▸B ▸u _ _ γ≤) →
             let γ≤γ₃+γ₄ = begin
                   γ                ≤⟨ γ≤ ⟩
+                  ω′ ·ᶜ (γ₃ +ᶜ γ₄) ≈⟨ ·ᶜ-congʳ ω′≡ω ⟩
                   ω ·ᶜ (γ₃ +ᶜ γ₄)  ≈⟨ ·ᶜ-identityˡ _ ⟩
                   γ₃ +ᶜ γ₄         ∎
             in
@@ -1730,7 +1746,7 @@ module _ (ok : Allowed-at-𝟘ᵐ) where
                  γ₃ +ᶜ γ₄  ≤⟨ +ᶜ-decreasingʳ _ _ ⟩
                  γ₄        ∎)
               (⊢∷←⊢∷ ⊢v) (⊢∷←⊢∷ ⊢w)
-          (invUsageJ₀₂ ≡all _ _ _ ▸u _ _ γ≤) →
+          (invUsageJ₀₂ ⦃ (≡all) ⦄ _ _ _ ▸u _ _ γ≤) →
             J (λ ≤some → case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ())
               (λ ≡some _ _ → case PE.trans (PE.sym ≡some) ≡all of λ ())
               (λ _ → PE.refl , PE.refl , PE.refl , PE.refl)
@@ -1742,11 +1758,12 @@ module _ (ok : Allowed-at-𝟘ᵐ) where
             ⊢A          = ⊢←⊢ ⊢A
         in
         case inv-usage-K ▸K of λ where
-          (invUsageK {γ₂} {γ₃} {γ₄} {γ₅} ≤some p≢𝟘 _ ▸t ▸B ▸u ▸v γ≤) →
+          (invUsageK {γ₂} {γ₃} {γ₄} {γ₅} ⦃ (≤some) ⦄ p≢𝟘 _ ▸t ▸B ▸u ▸v γ≤) →
             let γ≤ = begin
-                  γ                              ≤⟨ γ≤ ⟩
-                  M.ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅)  ≈⟨ ·ᶜ-identityˡ _ ⟩
-                  γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅           ∎
+                  γ                            ≤⟨ γ≤ ⟩
+                  ω′ ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ≈⟨ ·ᶜ-congʳ ω′≡ω ⟩
+                  ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅)  ≈⟨ ·ᶜ-identityˡ _ ⟩
+                  γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅         ∎
                 γ≤′ = begin
                   γ                     ≤⟨ γ≤ ⟩
                   γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅  ≤⟨ +ᶜ-decreasingʳ _ _ ⟩
@@ -1780,9 +1797,10 @@ module _ (ok : Allowed-at-𝟘ᵐ) where
                  γ         ≤⟨ γ≤″ ⟩
                  γ₄ +ᶜ γ₅  ≤⟨ +ᶜ-decreasingʳ _ _ ⟩
                  γ₅        ∎)
-          (invUsageK₀₁ {γ₃} {γ₄} ≡some PE.refl _ _ ▸B ▸u _ γ≤) →
+          (invUsageK₀₁ {γ₃} {γ₄} ⦃ (≡some) ⦄ PE.refl _ _ ▸B ▸u _ γ≤) →
             let γ≤γ₃+γ₄ = begin
                   γ                ≤⟨ γ≤ ⟩
+                  ω′ ·ᶜ (γ₃ +ᶜ γ₄) ≈⟨ ·ᶜ-congʳ ω′≡ω ⟩
                   ω ·ᶜ (γ₃ +ᶜ γ₄)  ≈⟨ ·ᶜ-identityˡ _ ⟩
                   γ₃ +ᶜ γ₄         ∎
             in
@@ -1801,7 +1819,7 @@ module _ (ok : Allowed-at-𝟘ᵐ) where
                  γ₃ +ᶜ γ₄  ≤⟨ +ᶜ-decreasingʳ _ _ ⟩
                  γ₄        ∎)
               (⊢∷←⊢∷ ⊢v)
-          (invUsageK₀₂ ≡all _ _ _ ▸u _ γ≤) →
+          (invUsageK₀₂ ⦃ (≡all) ⦄ _ _ _ ▸u _ γ≤) →
             K (λ ≤some → case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ())
               (λ ≡some _ → case PE.trans (PE.sym ≡some) ≡all of λ ())
               (λ _ → PE.refl , PE.refl , PE.refl , PE.refl)

--- a/Graded/Modality/Instances/Erasure/Combined/Erased.agda
+++ b/Graded/Modality/Instances/Erasure/Combined/Erased.agda
@@ -38,6 +38,7 @@ open import Graded.Modality.Instances.Erasure.Combined.Equivalent TR UR
 open import Graded.Modality.Instances.Erasure.Properties
 open import Graded.Usage UR
 open import Graded.Usage.Properties UR
+open import Graded.Usage.Restrictions.JK 𝕄
 
 open import Definition.Typed.Inversion TR
 open import Definition.Typed.Properties TR
@@ -58,6 +59,17 @@ private variable
   γ                                               : Conₘ _
   p q                                             : Erasure
   s                                               : Strength
+
+private
+
+  ω′ : ⦃ ok : JK-Any-erased-matches JK-supported-erased-matches ⦄ → _
+  ω′ ⦃ ok ⦄ = Has-omega.ω (JK-Any-erased-matches-has-omega ok)
+
+  ω′≡ω :
+    ⦃ ok : JK-Any-erased-matches JK-supported-erased-matches ⦄ →
+    ω′ PE.≡ ω
+  ω′≡ω ⦃ ok ⦄ =
+    erasure-has-omega-unique (JK-Any-erased-matches-has-omega ok)
 
 -- The following properties are proven under the asuumption that certain
 -- things must always be allowed when the mode is 𝟘ᵐ[ ok ].
@@ -310,6 +322,7 @@ module _ (ok-𝟘ᵐ : Allowed-at-𝟘ᵐ) where
     -- A typing/usage rule for Jᵉ.
 
     ⊢∷-Jᵉ :
+      ⦃ ok : JK-with-omega ⦄ →
       let open Erased s in
       []-cong-allowed s →
       []-cong-allowed-mode s ⌞ p ⌟ →
@@ -336,7 +349,8 @@ module _ (ok-𝟘ᵐ : Allowed-at-𝟘ᵐ) where
            (begin
               γ              ≡˘⟨ +ᶜ-idem _ ⟩
               γ +ᶜ γ         ≈˘⟨ ·ᶜ-identityˡ _ ⟩
-              ω ·ᶜ (γ +ᶜ γ)  ∎))
+              ω ·ᶜ (γ +ᶜ γ)  ≈˘⟨ ·ᶜ-congʳ ω′≡ω ⟩
+              ω′ ·ᶜ (γ +ᶜ γ) ∎))
       where
       open ≤ᶜ-reasoning
 

--- a/Graded/Modality/Instances/Erasure/Combined/Properties.agda
+++ b/Graded/Modality/Instances/Erasure/Combined/Properties.agda
@@ -205,14 +205,14 @@ opaque mutual
     rfl ⊢Γ
   sub-⊢∷ {p = r} (J {p} {q} hyp₁ hyp₂ hyp₃ ⊢A ⊢t ⊢B ⊢u ⊢v ⊢w) δ≤γ =
     case J-view p q ⌞ r ⌟ of λ where
-      (is-all ≡all) →
+      (is-all ⦃ (≡all) ⦄) →
         case hyp₃ ≡all of λ {
           (PE.refl , PE.refl , PE.refl , PE.refl) →
         J (λ ≤some → case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ())
           (λ ≡some _ _ → case PE.trans (PE.sym ≡some) ≡all of λ ())
           (λ _ → PE.refl , PE.refl , PE.refl , PE.refl)
           ⊢A ⊢t ⊢B (sub-⊢∷ ⊢u δ≤γ) ⊢v ⊢w }
-      (is-some-yes ≡some (PE.refl , PE.refl)) →
+      (is-some-yes ⦃ (≡some) ⦄ (PE.refl , PE.refl)) →
         case hyp₂ ≡some PE.refl PE.refl of λ {
           (PE.refl , PE.refl , PE.refl , PE.refl) →
         J (λ _ ¬[p≡𝟘×q≡𝟘] →
@@ -221,7 +221,7 @@ opaque mutual
           (λ ≡all → case PE.trans (PE.sym ≡some) ≡all of λ ())
           ⊢A ⊢t (sub-⊢ ⊢B (δ≤γ ∙ ≤-refl ∙ ≤-refl)) (sub-⊢∷ ⊢u δ≤γ) ⊢v
           ⊢w }
-      (is-other ≤some ¬[p≡𝟘×q≡𝟘]) →
+      (is-other ⦃ (≤some) ⦄ ¬[p≡𝟘×q≡𝟘]) →
         case hyp₁ ≤some ¬[p≡𝟘×q≡𝟘] of λ {
           (PE.refl , PE.refl , PE.refl , PE.refl) →
         J (λ _ _ → PE.refl , PE.refl , PE.refl , PE.refl)
@@ -231,21 +231,21 @@ opaque mutual
           (sub-⊢∷ ⊢u δ≤γ) (sub-⊢∷ ⊢v δ≤γ) (sub-⊢∷ ⊢w δ≤γ) }
   sub-⊢∷ {p = r} (K {p} hyp₁ hyp₂ hyp₃ ok ⊢A ⊢t ⊢B ⊢u ⊢v) δ≤γ =
     case K-view p ⌞ r ⌟ of λ where
-      (is-all ≡all) →
+      (is-all ⦃ (≡all) ⦄) →
         case hyp₃ ≡all of λ {
           (PE.refl , PE.refl , PE.refl , PE.refl) →
         K (λ ≤some → case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ())
           (λ ≡some _ → case PE.trans (PE.sym ≡some) ≡all of λ ())
           (λ _ → PE.refl , PE.refl , PE.refl , PE.refl)
           ok ⊢A ⊢t ⊢B (sub-⊢∷ ⊢u δ≤γ) ⊢v }
-      (is-some-yes ≡some PE.refl) →
+      (is-some-yes ⦃ (≡some) ⦄ PE.refl) →
         case hyp₂ ≡some PE.refl of λ {
           (PE.refl , PE.refl , PE.refl , PE.refl) →
         K (λ _ p≢𝟘 → ⊥-elim (p≢𝟘 ≡some PE.refl))
           (λ _ _ → PE.refl , PE.refl , PE.refl , PE.refl)
           (λ ≡all → case PE.trans (PE.sym ≡some) ≡all of λ ())
           ok ⊢A ⊢t (sub-⊢ ⊢B (δ≤γ ∙ ≤-refl)) (sub-⊢∷ ⊢u δ≤γ) ⊢v }
-      (is-other ≤some p≢𝟘) →
+      (is-other ⦃ (≤some) ⦄ p≢𝟘) →
         case hyp₁ ≤some p≢𝟘 of λ {
           (PE.refl , PE.refl , PE.refl , PE.refl) →
         K (λ _ _ → PE.refl , PE.refl , PE.refl , PE.refl)

--- a/Graded/Modality/Instances/Erasure/Modality.agda
+++ b/Graded/Modality/Instances/Erasure/Modality.agda
@@ -23,9 +23,6 @@ ErasureModality = record
   ; _∧_ = _∧_
   ; 𝟘 = 𝟘
   ; 𝟙 = ω
-  ; ω = ω
-  ; ω·+≤ω·ʳ = λ {p = p} → +-decreasingʳ p
-  ; ω≤𝟙 = refl
   ; is-𝟘? = _≟ 𝟘
   ; +-·-Semiring = +-·-Semiring
   ; ∧-Semilattice = +-Semilattice
@@ -53,6 +50,17 @@ instance
     ; ∧-positiveˡ = λ where
         {p = 𝟘} _ → refl
         {p = ω} ()
+    }
+
+instance
+
+  -- The erasure modality has grade ω.
+
+  erasure-has-omega : Has-omega ErasureModality
+  erasure-has-omega = record
+    { ω = ω
+    ; ω·+≤ω·ʳ = λ {p = p} → +-decreasingʳ p
+    ; ω≤𝟙 = refl
     }
 
 instance

--- a/Graded/Modality/Instances/Erasure/Properties.agda
+++ b/Graded/Modality/Instances/Erasure/Properties.agda
@@ -525,7 +525,7 @@ opaque instance
     }
     where
     open Modality ErasureModality
-      hiding (_+_; _·_; _≤_; 𝟘; ω)
+      hiding (_+_; _·_; _≤_; 𝟘)
 
     +-GLBˡ′ : {p q : Erasure} {pᵢ : Sequence Erasure} →
             Greatest-lower-bound p pᵢ →
@@ -611,6 +611,16 @@ opaque
       η +ᶜ ω ·ᶜ η ≈⟨ +ᶜ-congˡ (·ᶜ-identityˡ _) ⟩
       η +ᶜ η      ≡⟨ +ᶜ-idem _ ⟩
       η           ∎
+
+opaque
+
+  -- ω is the only omega grade.
+
+  erasure-has-omega-unique :
+    (p : Has-omega ErasureModality) →
+    Has-omega.ω p ≡ ω
+  erasure-has-omega-unique p =
+    least-elem′ (Has-omega.ω p) (Has-omega.ω≤𝟙 p)
 
 ------------------------------------------------------------------------
 -- Properties relating to the mode structure Zero-one

--- a/Graded/Modality/Instances/Exact-or-at-most.agda
+++ b/Graded/Modality/Instances/Exact-or-at-most.agda
@@ -200,6 +200,23 @@ _∧_ : Op₂ Exact-or-at-most
 ≈/≤1+ b m ∧ ∞ = ∞
 ∞ ∧ q = ∞
 
+private opaque
+
+  -- Meet is idempotent.
+
+  ∧-idem : Idempotent _∧_
+  ∧-idem 𝟘 = refl
+  ∧-idem (≈/≤1+ b m) =
+    cong₂ ≈/≤1+ lemma (N.⊔-idem m)
+    where
+    open RPe
+    lemma : (b B.∧ b) B.∧ (m N.== m) ≡ b
+    lemma = begin
+      (b B.∧ b) B.∧ (m N.== m) ≡⟨ cong₂ B._∧_ (B.∧-idem b) (N.==-refl m) ⟩
+      b B.∧ true               ≡⟨ B.∧-identityʳ b ⟩
+      b                        ∎
+  ∧-idem ∞ = refl
+
 _≤_ : (p q : Exact-or-at-most) → Set
 p ≤ q = p ≡ p ∧ q
 
@@ -235,7 +252,6 @@ exact-or-at-most-modality = record
   ; _∧_ = _∧_
   ; 𝟘 = 𝟘
   ; 𝟙 = 𝟙
-  ; ω = ∞
   ; +-·-Semiring = record
     { isSemiringWithoutAnnihilatingZero = record
       { +-isCommutativeMonoid = record
@@ -273,8 +289,6 @@ exact-or-at-most-modality = record
     }
   ; ·-distrib-∧ = ·-distribˡ-∧ , (comm∧distrˡ⇒distrʳ ·-comm ·-distribˡ-∧)
   ; +-distrib-∧ = +-distribˡ-∧ , (comm∧distrˡ⇒distrʳ +-comm +-distribˡ-∧)
-  ; ω≤𝟙 = refl
-  ; ω·+≤ω·ʳ = ω·+≤ω·ʳ
   ; is-𝟘? = λ p → p ≟ 𝟘
   }
   where
@@ -447,18 +461,6 @@ exact-or-at-most-modality = record
     lemma (1+ m) 0 (1+ m₂) = refl
     lemma (1+ m) (1+ m₁) 0 = B.∧-zeroʳ _
     lemma (1+ m) (1+ m₁) (1+ m₂) = lemma m m₁ m₂
-  ∧-idem : Idempotent _∧_
-  ∧-idem 𝟘 = refl
-  ∧-idem (≈/≤1+ b m) =
-    cong₂ ≈/≤1+ lemma (N.⊔-idem m)
-    where
-    open RPe
-    lemma : (b B.∧ b) B.∧ (m N.== m) ≡ b
-    lemma = begin
-      (b B.∧ b) B.∧ (m N.== m) ≡⟨ cong₂ B._∧_ (B.∧-idem b) (N.==-refl m) ⟩
-      b B.∧ true               ≡⟨ B.∧-identityʳ b ⟩
-      b                        ∎
-  ∧-idem ∞ = refl
 
   ∧-comm : Commutative _∧_
   ∧-comm 𝟘 𝟘 = refl
@@ -594,12 +596,23 @@ exact-or-at-most-modality = record
   +-distribˡ-∧ (≈/≤1+ b m) ∞ r = refl
   +-distribˡ-∧ ∞ q r = refl
 
-  ω·+≤ω·ʳ : ∞ · (p + q) ≤ ∞ · q
-  ω·+≤ω·ʳ {(𝟘)} = sym (∧-idem _)
-  ω·+≤ω·ʳ {≈/≤1+ b m} {(𝟘)} = refl
-  ω·+≤ω·ʳ {≈/≤1+ b m} {≈/≤1+ b₁ m₁} = refl
-  ω·+≤ω·ʳ {≈/≤1+ b m} {(∞)} = refl
-  ω·+≤ω·ʳ {(∞)} = refl
+instance
+
+  -- The modality has grade ω
+
+  exact-or-at-most-has-omega : Has-omega exact-or-at-most-modality
+  exact-or-at-most-has-omega = record
+    { ω = ∞
+    ; ω≤𝟙 = refl
+    ; ω·+≤ω·ʳ = ω·+≤ω·ʳ
+    }
+    where
+    ω·+≤ω·ʳ : ∞ · (p + q) ≤ ∞ · q
+    ω·+≤ω·ʳ {(𝟘)} = sym (∧-idem _)
+    ω·+≤ω·ʳ {≈/≤1+ b m} {(𝟘)} = refl
+    ω·+≤ω·ʳ {≈/≤1+ b m} {≈/≤1+ b₁ m₁} = refl
+    ω·+≤ω·ʳ {≈/≤1+ b m} {(∞)} = refl
+    ω·+≤ω·ʳ {(∞)} = refl
 
 opaque instance
 

--- a/Graded/Modality/Instances/Information-flow.agda
+++ b/Graded/Modality/Instances/Information-flow.agda
@@ -188,16 +188,6 @@ L≤M≤H = record
   ; _∧_     = _∧_
   ; 𝟘       = H
   ; 𝟙       = L
-  ; ω       = L
-  ; ω≤𝟙     = refl
-  ; ω·+≤ω·ʳ = λ where
-      {p = L}         → refl
-      {p = M} {q = L} → refl
-      {p = M} {q = M} → refl
-      {p = M} {q = H} → refl
-      {p = H} {q = L} → refl
-      {p = H} {q = M} → refl
-      {p = H} {q = H} → refl
   ; is-𝟘? = λ where
       L → no (λ ())
       M → no (λ ())
@@ -441,6 +431,22 @@ instance
         {p = M} {q = H} ()
         {p = H}         _  → refl
     }
+
+-- L≤M≤H has grade ω.
+
+L≤M≤H-has-omega : Has-omega L≤M≤H
+L≤M≤H-has-omega = record
+  { ω       = L
+  ; ω≤𝟙     = refl
+  ; ω·+≤ω·ʳ = λ where
+      {p = L}         → refl
+      {p = M} {q = L} → refl
+      {p = M} {q = M} → refl
+      {p = M} {q = H} → refl
+      {p = H} {q = L} → refl
+      {p = H} {q = M} → refl
+      {p = H} {q = H} → refl
+  }
 
 -- A natrec-star operator can be defined for L≤M≤H.
 

--- a/Graded/Modality/Instances/Linear-or-affine.agda
+++ b/Graded/Modality/Instances/Linear-or-affine.agda
@@ -365,9 +365,6 @@ linear-or-affine  = record
   ; _∧_          = _∧_
   ; 𝟘            = 𝟘
   ; 𝟙            = 𝟙
-  ; ω            = ≤ω
-  ; ω≤𝟙          = refl
-  ; ω·+≤ω·ʳ      = λ {p = p} → ≤ω·+≤≤ω·ʳ p
   ; is-𝟘?        = _≟ 𝟘
   ; +-·-Semiring = record
     { isSemiringWithoutAnnihilatingZero = record
@@ -798,6 +795,18 @@ linear-or-affine  = record
     ≤ω ≤ω 𝟙  → refl
     ≤ω ≤ω ≤𝟙 → refl
     ≤ω ≤ω ≤ω → refl
+
+instance
+
+  -- The modality has grade ω.
+
+  linear-or-affine-has-omega :
+    Has-omega linear-or-affine
+  linear-or-affine-has-omega = record
+    { ω            = ≤ω
+    ; ω≤𝟙          = refl
+    ; ω·+≤ω·ʳ      = λ {p = p} → ≤ω·+≤≤ω·ʳ p
+    }
 
 instance
 
@@ -4158,7 +4167,7 @@ opaque
       +-congʳ (·-congʳ (sym (𝟙∧𝟙+p≡1+p p)))
     nr-factoring p ≤𝟙 z s n rewrite ·-zeroʳ (≤𝟙 + p) =
       +-congʳ (·-congʳ (sym (𝟙∧≤𝟙+p≡≤1+p p)))
-    nr-factoring p ≤ω z s n rewrite ≤ω+ p = ·-distribˡ-+ ω n (s + z)
+    nr-factoring p ≤ω z s n rewrite ≤ω+ p = ·-distribˡ-+ ≤ω n (s + z)
 
 opaque
 
@@ -4294,7 +4303,7 @@ opaque
     open Multiplication linear-or-affine
     open PartialOrder linear-or-affine
     open Modality linear-or-affine
-      hiding (𝟘; 𝟙; ω; _+_; _·_; _∧_; _≤_)
+      hiding (𝟘; 𝟙; _+_; _·_; _∧_; _≤_)
     open Tools.Reasoning.PartialOrder ≤-poset
     lemma : nr′ p r z s n ≤ ≤ω → nr′ p r z s n ≤ nr p r z s n
     lemma {p} {r} {z} {s} {n} nr′≤ω =
@@ -4711,7 +4720,7 @@ opaque
       ≤ω → lemma-ω _ _
     where
     open Modality linear-or-affine
-      hiding (𝟘; 𝟙; ω; _∧_; _·_; _+_)
+      hiding (𝟘; 𝟙; _∧_; _·_; _+_)
     open GLB linear-or-affine
     open Natrec linear-or-affine
     open PartialOrder linear-or-affine
@@ -4813,7 +4822,7 @@ opaque
     }
     where
     open Modality linear-or-affine
-      hiding (𝟘; 𝟙; ω; _+_; _·_; _∧_; _≤_)
+      hiding (𝟘; 𝟙; _+_; _·_; _∧_; _≤_)
     open GLB linear-or-affine
     open Multiplication linear-or-affine
     open PartialOrder linear-or-affine

--- a/Graded/Modality/Instances/Linearity.agda
+++ b/Graded/Modality/Instances/Linearity.agda
@@ -61,6 +61,14 @@ instance
     Has-well-behaved-zero linearityModality
   linearity-has-well-behaved-zero = zero-one-many-has-well-behaved-zero
 
+instance
+
+  -- The "linear types" modality has grade ω.
+
+  linearity-has-omega :
+    Has-omega linearityModality
+  linearity-has-omega = zero-one-many-has-omega
+
 open Graded.Modality.Properties linearityModality
 open Graded.Mode.Instances.Zero-one.Variant linearityModality
 

--- a/Graded/Modality/Instances/Nat-plus-infinity.agda
+++ b/Graded/Modality/Instances/Nat-plus-infinity.agda
@@ -491,9 +491,6 @@ opaque
   ; _∧_          = _∧_
   ; 𝟘            = ⌞ 0 ⌟
   ; 𝟙            = ⌞ 1 ⌟
-  ; ω            = ∞
-  ; ω≤𝟙          = ∞≤ ⌞ 1 ⌟
-  ; ω·+≤ω·ʳ      = ∞·+≤∞·ʳ
   ; is-𝟘?        = _≟ ⌞ 0 ⌟
   ; +-·-Semiring = record
     { isSemiringWithoutAnnihilatingZero = record
@@ -751,6 +748,17 @@ opaque
   +-distrib-∧ : _+_ DistributesOver _∧_
   +-distrib-∧ =
     +-distribˡ-∧ , comm∧distrˡ⇒distrʳ +-comm +-distribˡ-∧
+
+instance
+
+  -- The modality has grade ω.
+
+  ℕ⊎∞-has-omega : Has-omega ℕ⊎∞-modality
+  ℕ⊎∞-has-omega = record
+    { ω       = ∞
+    ; ω≤𝟙     = ∞≤ ⌞ 1 ⌟
+    ; ω·+≤ω·ʳ = ∞·+≤∞·ʳ
+    }
 
 instance
 
@@ -1170,14 +1178,15 @@ opaque
       open Tools.Reasoning.PartialOrder ≤-poset
       lemma′ : ∞ · (z + s) ≤ z
       lemma′ = begin
-        ∞ · (z + s) ≤⟨ ω·+≤ω·ˡ ⟩
-        ∞ · z       ≤⟨ ·-monotoneˡ ω≤𝟙 ⟩
+        ∞ · (z + s) ≡⟨ ·-congˡ (+-comm _ _) ⟩
+        ∞ · (s + z) ≤⟨ ∞·+≤∞·ʳ ⟩
+        ∞ · z       ≤⟨ ·-monotoneˡ (∞≤ 𝟙) ⟩
         𝟙 · z       ≡⟨ ·-identityˡ _ ⟩
         z           ∎
       lemma : ∀ r → nr₃ r z s ≤ z
       lemma ⌞ 0 ⌟ = ∧-decreasingˡ _ _
       lemma ⌞ 1 ⌟ = begin
-        z + ∞ · s ≤⟨ +-monotoneʳ (·-monotoneˡ {q = 𝟘} ω≤𝟘) ⟩
+        z + ∞ · s ≤⟨ +-monotoneʳ (·-monotoneˡ {q = 𝟘} (∞≤ 𝟘)) ⟩
         z + 𝟘 · s ≡⟨⟩
         z + 𝟘     ≡⟨ +-identityʳ _ ⟩
         z         ∎
@@ -1409,7 +1418,7 @@ opaque
       s + p · 𝟘 + r · nr′ p r z s 𝟘 ≡⟨ +-congˡ (+-congʳ (·-zeroʳ p)) ⟩
       s + 𝟘 + r · nr′ p r z s 𝟘     ≡⟨ +-congˡ (+-identityˡ _) ⟩
       s + r · nr′ p r z s 𝟘         ∎
-    nr′p∞≤ : ∀ {z s n p} → ¬ (z ≡ 𝟘 × s ≡ 𝟘 × n ≡ 𝟘) → nr′ p ∞ z s n ≤ nr p ω z s n
+    nr′p∞≤ : ∀ {z s n p} → ¬ (z ≡ 𝟘 × s ≡ 𝟘 × n ≡ 𝟘) → nr′ p ∞ z s n ≤ nr p ∞ z s n
     nr′p∞≤ {z} {s} {n} {p} ≢𝟘 = lemma $ begin
       nr′ p ∞ z s n                 ≤⟨ nr-suc ⟩
       s + p · n + ∞ · nr′ p ∞ z s n ≡⟨ +-congˡ {s} (+-congˡ (∞·≢𝟘 (≢𝟘 ∘→ nr′-positive))) ⟩

--- a/Graded/Modality/Instances/Nat.agda
+++ b/Graded/Modality/Instances/Nat.agda
@@ -55,15 +55,10 @@ opaque
     ; _∧_ = _⊔_
     ; 𝟘 = 0
     ; 𝟙 = 1
-    ; ω = 1
     ; +-·-Semiring = +-*-isSemiring
     ; ∧-Semilattice = ⊔-isSemilattice
     ; ·-distrib-∧ = *-distribˡ-⊔ , *-distribʳ-⊔
     ; +-distrib-∧ = +-distribˡ-⊔ , +-distribʳ-⊔
-    ; ω≤𝟙 = refl
-    ; ω·+≤ω·ʳ = λ {p} {q} →
-      sym (m≥n⇒m⊔n≡m (≤-trans (m≤n+m (q + 0) p)
-        (≤-reflexive (sym (+-assoc p q 0)))))
     ; is-𝟘? = _≟ 0
     }
     where

--- a/Graded/Modality/Instances/Relevancy.agda
+++ b/Graded/Modality/Instances/Relevancy.agda
@@ -205,7 +205,6 @@ relevancy-modality = record
   ; _∧_ = _∧_
   ; 𝟘 = 𝟘
   ; 𝟙 = ≥𝟙
-  ; ω = ω
   ; +-·-Semiring = record
     { isSemiringWithoutAnnihilatingZero = record
       { +-isCommutativeMonoid = record
@@ -295,8 +294,6 @@ relevancy-modality = record
   ; +-distrib-∧ =
         +-distrib-∧ˡ
       , comm∧distrˡ⇒distrʳ +-comm +-distrib-∧ˡ
-  ; ω≤𝟙 = refl
-  ; ω·+≤ω·ʳ = ω·+≤ω·ʳ _ _
   ; is-𝟘? = _≟ 𝟘
   }
   where
@@ -377,27 +374,40 @@ relevancy-modality = record
     ω ≥𝟙 ω  → refl
     ω ω _   → refl
 
-  ω·+≤ω·ʳ : ∀ p q → ω · (p + q) ≤ ω · q
-  ω·+≤ω·ʳ = λ where
-    𝟘 𝟘  → refl
-    𝟘 ≥𝟙 → refl
-    𝟘 ω  → refl
-    ≥𝟙 _ → refl
-    ω 𝟘  → refl
-    ω ≥𝟙 → refl
-    ω ω  → refl
-
 open Modality relevancy-modality
-  hiding (_+_;_·_;_∧_;𝟘;ω;_≤_)
+  hiding (_+_;_·_;_∧_;𝟘;_≤_)
 open Addition relevancy-modality
 open GLB relevancy-modality
 open Natrec relevancy-modality
 open PartialOrder relevancy-modality
 open Subtraction relevancy-modality
 
--- The modality has a well-behaved zero
+instance
+
+  -- The modality has grade ω.
+
+  relevancy-has-omega :
+    Has-omega relevancy-modality
+  relevancy-has-omega = record
+    { ω = ω
+    ; ω≤𝟙 = refl
+    ; ω·+≤ω·ʳ = ω·+≤ω·ʳ _ _
+    }
+    where
+    ω·+≤ω·ʳ : ∀ p q → ω · (p + q) ≤ ω · q
+    ω·+≤ω·ʳ = λ where
+      𝟘 𝟘  → refl
+      𝟘 ≥𝟙 → refl
+      𝟘 ω  → refl
+      ≥𝟙 _ → refl
+      ω 𝟘  → refl
+      ω ≥𝟙 → refl
+      ω ω  → refl
 
 instance
+
+  -- The modality has a well-behaved zero
+
   relevancy-has-well-behaved-zero :
     Has-well-behaved-zero relevancy-modality
   relevancy-has-well-behaved-zero = record

--- a/Graded/Modality/Instances/Set/Interval.agda
+++ b/Graded/Modality/Instances/Set/Interval.agda
@@ -1018,9 +1018,6 @@ record Is-non-empty-interval (S : Set a) : Set (lsuc (lsuc a)) where
       ; _·_     = _·_
       ; 𝟘       = 𝟘
       ; 𝟙       = 𝟙
-      ; ω       = ℕ
-      ; ω≤𝟙     = ℕ-least
-      ; ω·+≤ω·ʳ = ℕ·+≤ℕ·ʳ
       ; is-𝟘?   = λ xs → case is-𝟘? xs of λ where
           (inj₁ xs≡𝟘) → yes (xs≡𝟘 ext)
           (inj₂ xs≢𝟘) → no xs≢𝟘
@@ -1047,6 +1044,15 @@ record Is-non-empty-interval (S : Set a) : Set (lsuc (lsuc a)) where
       ; ∧-positiveˡ  = proj₁ ∘→ ∪-positive
       ; +-positiveˡ  = proj₁ ∘→ +-positive
       ; zero-product = zero-product
+      }
+
+    -- The modality has grade ω.
+
+    has-omega : Has-omega modality
+    has-omega = record
+      { ω       = ℕ
+      ; ω≤𝟙     = ℕ-least
+      ; ω·+≤ω·ʳ = ℕ·+≤ℕ·ʳ
       }
 
     private

--- a/Graded/Modality/Instances/Unit.agda
+++ b/Graded/Modality/Instances/Unit.agda
@@ -170,15 +170,23 @@ UnitModality = record
   ; _∧_ = _+_
   ; 𝟘 = tt
   ; 𝟙 = tt
-  ; ω = tt
-  ; ω≤𝟙 = refl
-  ; ω·+≤ω·ʳ = refl
   ; is-𝟘? = _≟ tt
   ; +-·-Semiring = +-+-Semiring
   ; ∧-Semilattice = +-Semilattice
   ; ·-distrib-∧ = +-Distributiveˡ , +-Distributiveʳ
   ; +-distrib-∧ = +-Distributiveˡ , +-Distributiveʳ
   }
+
+instance
+
+  -- The unit modality has grade ω.
+
+  unit-has-omega : Has-omega UnitModality
+  unit-has-omega = record
+    { ω = tt
+    ; ω≤𝟙 = refl
+    ; ω·+≤ω·ʳ = refl
+    }
 
 -- A natrec-star operator can be defined for the trivial modality
 -- structure

--- a/Graded/Modality/Instances/Zero-below-one.agda
+++ b/Graded/Modality/Instances/Zero-below-one.agda
@@ -138,9 +138,6 @@ _≟_ = λ where
   ; _∧_     = _∧_
   ; 𝟘       = 𝟘
   ; 𝟙       = 𝟙
-  ; ω       = 𝟘
-  ; ω≤𝟙     = refl
-  ; ω·+≤ω·ʳ = refl
   ; is-𝟘?   = λ where
       𝟘 → yes refl
       𝟙 → no (λ ())
@@ -294,6 +291,15 @@ _≟_ = λ where
   +-distrib-∧ : _+_ DistributesOver _∧_
   +-distrib-∧ =
     +-distribˡ-∧ , comm∧distrˡ⇒distrʳ +-comm +-distribˡ-∧
+
+-- The modality has grade ω.
+
+𝟘≤𝟙-has-omega : Has-omega 𝟘≤𝟙
+𝟘≤𝟙-has-omega = record
+  { ω       = 𝟘
+  ; ω≤𝟙     = refl
+  ; ω·+≤ω·ʳ = refl
+  }
 
 -- A natrec-star operator can be defined for Grade.
 

--- a/Graded/Modality/Instances/Zero-one-many.agda
+++ b/Graded/Modality/Instances/Zero-one-many.agda
@@ -119,7 +119,7 @@ Meet-requirements-required M@record{} refl refl 𝟘∧𝟙≢𝟘 ω≤ =
        𝟙 ∧ 𝟘  ≡⟨ 𝟙∧𝟘≡𝟘 ⟩
        𝟘      ∎))
   where
-  open Modality M hiding (𝟘; 𝟙; ω)
+  open Modality M hiding (𝟘; 𝟙)
   open Meet M
   open PartialOrder M
   open Tools.Reasoning.PropositionalEquality
@@ -497,9 +497,6 @@ zero-one-many-modality = record
   ; _∧_          = _∧_
   ; 𝟘            = 𝟘
   ; 𝟙            = 𝟙
-  ; ω            = ω
-  ; ω≤𝟙          = refl
-  ; ω·+≤ω·ʳ      = λ {p = p} → ω·+≤ω·ʳ p
   ; is-𝟘?        = _≟ 𝟘
   ; +-·-Semiring = record
     { isSemiringWithoutAnnihilatingZero = record
@@ -704,6 +701,18 @@ zero-one-many-modality = record
 
 instance
 
+  -- The zero-one-many instance has a grade ω.
+
+  zero-one-many-has-omega :
+    Has-omega zero-one-many-modality
+  zero-one-many-has-omega = record
+    { ω      = ω
+    ; ω≤𝟙    = refl
+    ; ω·+≤ω·ʳ = λ {p = p} → ω·+≤ω·ʳ p
+    }
+
+instance
+
   zero-one-many-has-well-behaved-zero :
     Has-well-behaved-zero zero-one-many-modality
   zero-one-many-has-well-behaved-zero = record
@@ -817,7 +826,7 @@ Star-requirements-required′
       , ⊛-ineq₂ _ _ _
       , ⊛-ineq₂ _ _ _
   where
-  open Modality M hiding (𝟘; 𝟙; ω; _+_; _·_; _∧_; _≤_)
+  open Modality M hiding (𝟘; 𝟙; _+_; _·_; _∧_; _≤_)
   open PartialOrder M
   open Meet M
   open Tools.Reasoning.PartialOrder ≤-poset
@@ -1095,7 +1104,7 @@ zero-one-many-greatest-star = record
   where
 
   open Modality zero-one-many-modality
-    hiding (𝟘; 𝟙; ω; _+_; _·_; _∧_; _≤_)
+    hiding (𝟘; 𝟙; _+_; _·_; _∧_; _≤_)
   open PartialOrder zero-one-many-modality
   open Addition zero-one-many-modality
   open Meet zero-one-many-modality
@@ -1273,7 +1282,7 @@ opaque
     open Has-nr zero-one-many-greatest-star-nr
     open Is-factoring-nr factoring
     open Modality zero-one-many-modality
-      hiding (𝟘; 𝟙; ω; _+_; _·_)
+      hiding (𝟘; 𝟙; _+_; _·_)
     open Tools.Reasoning.PropositionalEquality
     𝟙≡ω : 𝟙 ≡ ω
     𝟙≡ω = begin
@@ -1448,7 +1457,7 @@ nr≡nr′ : ∀ p r → nr p r z s n ≡ nr′ p r z s n
 nr≡nr′ p r = lemma _ _ _ _ _ (nr′-view p r _ _ _)
   where
   open Modality zero-one-many-modality
-    hiding (𝟘; 𝟙; ω; _+_; _·_; _∧_)
+    hiding (𝟘; 𝟙; _+_; _·_; _∧_)
   open Tools.Reasoning.PropositionalEquality
 
   lemma :
@@ -1625,7 +1634,7 @@ zero-one-many-has-nr = record
   }
   where
   open Modality zero-one-many-modality
-    hiding (𝟘; 𝟙; ω; _+_; _·_; _∧_; _≤_)
+    hiding (𝟘; 𝟙; _+_; _·_; _∧_; _≤_)
   open Addition zero-one-many-modality
   open Meet zero-one-many-modality
   open Multiplication zero-one-many-modality
@@ -1810,7 +1819,7 @@ opaque
     where
     open Tools.Reasoning.PropositionalEquality
     open Modality zero-one-many-modality
-           hiding (𝟘; 𝟙; ω; _+_; _·_; _∧_)
+           hiding (𝟘; 𝟙; _+_; _·_; _∧_)
     nr₂ : Op₂ Zero-one-many
     nr₂ p r = 𝟙 ∧ (r + p)
     𝟙+p≡𝟙∧𝟙+p : ∀ p → 𝟙 + p ≡ 𝟙 ∧ (𝟙 + p)
@@ -1932,7 +1941,7 @@ opaque
     open Natrec zero-one-many-modality renaming (nr-𝟘 to nr″-𝟘)
     open PartialOrder zero-one-many-modality
     open Modality zero-one-many-modality
-      hiding (𝟘; 𝟙; ω; _+_; _·_; _∧_; _≤_)
+      hiding (𝟘; 𝟙; _+_; _·_; _∧_; _≤_)
     open Tools.Reasoning.PartialOrder ≤-poset
     lemma : nr″ p r z s n ≤ ω → nr″ p r z s n ≤ nr p r z s n
     lemma {p} {r} {z} {s} {n} nr″≤ω =
@@ -2103,7 +2112,7 @@ opaque
       ω → lemma-ω _ _
     where
     open Modality zero-one-many-modality
-      hiding (𝟘; 𝟙; ω; _∧_; _·_; _+_)
+      hiding (𝟘; 𝟙; _∧_; _·_; _+_)
     open GLB zero-one-many-modality
     open Natrec zero-one-many-modality
     open PartialOrder zero-one-many-modality
@@ -2164,7 +2173,7 @@ opaque
     GLB.GLB-congʳ zero-one-many-modality (+-comm (ω · q) p) (nr-nrᵢ-GLB {z = p} {s = q} 𝟙)
     where
     open Modality zero-one-many-modality
-      hiding (𝟙; ω; _·_; _+_)
+      hiding (𝟙; _·_; _+_)
 
 opaque
 
@@ -2178,7 +2187,7 @@ opaque
     GLB.GLB-congʳ zero-one-many-modality (·-congˡ (+-comm q p)) (nr-nrᵢ-GLB {z = p} {s = q} ω)
     where
     open Modality zero-one-many-modality
-      hiding (ω; _·_; _+_)
+      hiding (_·_; _+_)
 
 opaque
 
@@ -2194,7 +2203,7 @@ opaque
     }
     where
     open Modality zero-one-many-modality
-      hiding (_+_; _·_; _≤_; 𝟘; 𝟙; ω)
+      hiding (_+_; _·_; _≤_; 𝟘; 𝟙)
     open GLB zero-one-many-modality
     open Multiplication zero-one-many-modality
     open PartialOrder zero-one-many-modality

--- a/Graded/Modality/Morphism.agda
+++ b/Graded/Modality/Morphism.agda
@@ -18,6 +18,7 @@ open import Tools.Sum using (_⊎_; inj₁; inj₂)
 
 open import Graded.Modality
 open import Graded.Modality.Nr-instances
+open import Graded.Modality.Omega-instances
 import Graded.Modality.Properties
 
 private variable
@@ -63,9 +64,6 @@ record Is-morphism
 
     -- The translation of 𝟙 is bounded by 𝟙.
     tr-𝟙 : tr M₁.𝟙 ≤ M₂.𝟙
-
-    -- The translation of ω is bounded by ω.
-    tr-ω : tr M₁.ω ≤ M₂.ω
 
     -- The translation commutes with addition.
     tr-+ : ∀ {p q} → tr (p M₁.+ q) ≡ tr p M₂.+ tr q
@@ -181,9 +179,6 @@ record Is-order-embedding
     -- 𝟙.
     tr-≤-𝟙 : ∀ {p} → tr p M₂.≤ M₂.𝟙 → p M₁.≤ M₁.𝟙
 
-    -- The translation of ω is equal to ω.
-    tr-ω : tr M₁.ω ≡ M₂.ω
-
     -- If the translation of p is bounded by q + r, then there are q′
     -- and r′ such that the translation of q′ is bounded by q, the
     -- translation of r′ is bounded by r, and p is bounded by q′ + r′.
@@ -208,7 +203,7 @@ record Is-order-embedding
       tr p M₂.≤ q M₂.∧ r →
       ∃₂ λ q′ r′ → tr q′ M₂.≤ q × tr r′ M₂.≤ r × p M₁.≤ q′ M₁.∧ r′
 
-  open Is-morphism tr-morphism public hiding (tr-ω)
+  open Is-morphism tr-morphism public
 
   -- The translation is injective.
 
@@ -216,43 +211,6 @@ record Is-order-embedding
   tr-injective tr-p≡tr-q = P₁.≤-antisym
     (tr-order-reflecting (P₂.≤-reflexive tr-p≡tr-q))
     (tr-order-reflecting (P₂.≤-reflexive (sym tr-p≡tr-q)))
-
-  opaque
-
-    -- If the translation of p is bounded by M₂.ω · q, then there is a
-    -- q′ such that the translation of q′ is bounded by q, and p is
-    -- bounded by M₁.ω · q′.
-
-    tr-≤-ω· :
-      tr p M₂.≤ M₂.ω M₂.· q →
-      ∃ λ q′ → tr q′ M₂.≤ q × p M₁.≤ M₁.ω M₁.· q′
-    tr-≤-ω· {p} {q} tr-p≤ωq =
-      tr-≤-· $ begin
-        tr p            ≤⟨ tr-p≤ωq ⟩
-        M₂.ω M₂.· q     ≡˘⟨ M₂.·-congʳ tr-ω ⟩
-        tr M₁.ω M₂.· q  ∎
-      where
-      open Tools.Reasoning.PartialOrder P₂.≤-poset
-
-  opaque
-
-    -- A combination of tr-≤-ω· and tr-≤-+.
-
-    tr-≤-ω·+ :
-      tr p M₂.≤ M₂.ω M₂.· (q M₂.+ r) →
-      ∃₂ λ q′ r′ →
-        tr q′ M₂.≤ q × tr r′ M₂.≤ r × p M₁.≤ M₁.ω M₁.· (q′ M₁.+ r′)
-    tr-≤-ω·+ {p} {q} {r} tr-p≤ω[q+r] =
-      case tr-≤-ω· tr-p≤ω[q+r] of λ
-        (s , tr-s≤q+r , p≤ωs) →
-      case tr-≤-+ tr-s≤q+r of λ
-        (q′ , r′ , tr-q′≤q , tr-r′≤r , s≤q′+r′) →
-      q′ , r′ , tr-q′≤q , tr-r′≤r , (begin
-        p                       ≤⟨ p≤ωs ⟩
-        M₁.ω M₁.· s             ≤⟨ P₁.·-monotoneʳ s≤q′+r′ ⟩
-        M₁.ω M₁.· (q′ M₁.+ r′)  ∎)
-      where
-      open Tools.Reasoning.PartialOrder P₁.≤-poset
 
 -- The property of being a Σ-morphism (with respect to a given
 -- function).
@@ -349,6 +307,88 @@ record Is-Σ-order-embedding
       tr p M₂.≤ tr-Σ q M₂.· r → ∃ λ r′ → tr r′ M₂.≤ r × p M₁.≤ q M₁.· r′
 
   open Is-Σ-morphism tr-Σ-morphism public
+
+-- The property of being an "ω preserving" morphism.
+
+record Is-omega-preserving-morphism
+  {M₁ : Set a₁} {M₂ : Set a₂}
+  (𝕄₁ : Modality M₁) (𝕄₂ : Modality M₂)
+  ⦃ has-ω₁ : Has-omega M₁ 𝕄₁ ⦄
+  ⦃ has-ω₂ : Has-omega M₂ 𝕄₂ ⦄
+  (tr : M₁ → M₂) : Set (a₁ ⊔ a₂) where
+
+  no-eta-equality
+
+  open Modality 𝕄₂
+
+  field
+    -- The translation of ω is bounded by ω.
+    tr-ω : tr ω ≤ ω
+
+-- The property of being an "ω reflecting" morphism.
+
+record Is-omega-reflecting-morphism
+  {M₁ : Set a₁} {M₂ : Set a₂}
+  (𝕄₁ : Modality M₁) (𝕄₂ : Modality M₂)
+  ⦃ has-ω₁ : Has-omega M₁ 𝕄₁ ⦄
+  ⦃ has-ω₂ : Has-omega M₂ 𝕄₂ ⦄
+  (tr : M₁ → M₂) : Set (a₁ ⊔ a₂) where
+
+  no-eta-equality
+
+  private
+    module M₁  = Modality 𝕄₁
+    module M₂  = Modality 𝕄₂
+    module P₁ = Graded.Modality.Properties 𝕄₁
+    module P₂ = Graded.Modality.Properties 𝕄₂
+
+  field
+    -- The translation of ω is equal to ω.
+    tr-ω : tr ω ≡ ω
+
+  -- Some properties that hold if the morphism is an order-embedding
+
+  opaque
+
+    -- If the translation of p is bounded by M₂.ω · q, then there is a
+    -- q′ such that the translation of q′ is bounded by q, and p is
+    -- bounded by M₁.ω · q′.
+
+    tr-≤-ω· :
+      Is-order-embedding 𝕄₁ 𝕄₂ tr →
+      tr p M₂.≤ ω M₂.· q →
+      ∃ λ q′ → tr q′ M₂.≤ q × p M₁.≤ ω M₁.· q′
+    tr-≤-ω· {p} {q} ok tr-p≤ωq =
+      tr-≤-· $ begin
+        tr p         ≤⟨ tr-p≤ωq ⟩
+        ω M₂.· q     ≡˘⟨ M₂.·-congʳ tr-ω ⟩
+        tr ω M₂.· q  ∎
+      where
+      open Is-order-embedding ok
+      open Tools.Reasoning.PartialOrder P₂.≤-poset
+
+  opaque
+
+    -- A combination of tr-≤-ω· and tr-≤-+.
+
+    tr-≤-ω·+ :
+      Is-order-embedding 𝕄₁ 𝕄₂ tr →
+      tr p M₂.≤ ω M₂.· (q M₂.+ r) →
+      ∃₂ λ q′ r′ →
+        tr q′ M₂.≤ q × tr r′ M₂.≤ r × p M₁.≤ ω M₁.· (q′ M₁.+ r′)
+    tr-≤-ω·+ {p} {q} {r} ok tr-p≤ω[q+r] =
+      case tr-≤-ω· ok tr-p≤ω[q+r] of λ
+        (s , tr-s≤q+r , p≤ωs) →
+      case tr-≤-+ tr-s≤q+r of λ
+        (q′ , r′ , tr-q′≤q , tr-r′≤r , s≤q′+r′) →
+      q′ , r′ , tr-q′≤q , tr-r′≤r , (begin
+        p                    ≤⟨ p≤ωs ⟩
+        ω M₁.· s             ≤⟨ P₁.·-monotoneʳ s≤q′+r′ ⟩
+        ω M₁.· (q′ M₁.+ r′)  ∎)
+      where
+      open Is-order-embedding ok
+      open Tools.Reasoning.PartialOrder P₁.≤-poset
+
 
 -- The property of being an "nr-preserving" morphism (related to
 -- the usage rule for natrec with an nr function).
@@ -517,13 +557,11 @@ Is-order-embedding-id {𝕄 = 𝕄} = λ where
     .tr-order-reflecting → idᶠ
     .tr-≤                → _ , ≤-refl
     .tr-≤-𝟙              → idᶠ
-    .tr-ω                → refl
     .tr-≤-+ hyp          → _ , _ , ≤-refl , ≤-refl , hyp
     .tr-≤-· hyp          → _ , ≤-refl , hyp
     .tr-≤-∧ hyp          → _ , _ , ≤-refl , ≤-refl , hyp
     .tr-morphism         → λ where
       .tr-𝟙                                    → ≤-refl
-      .tr-ω                                    → ≤-refl
       .tr-𝟘-≤                                  → ≤-refl
       .trivial-⊎-tr-≡-𝟘-⇔                      → inj₂ (idᶠ , idᶠ)
       .tr-+                                    → refl
@@ -534,6 +572,23 @@ Is-order-embedding-id {𝕄 = 𝕄} = λ where
   open Graded.Modality.Properties 𝕄
   open Is-morphism
   open Is-order-embedding
+
+Is-omega-preserving-morphism-id :
+  ⦃ has-ω : Has-omega _ 𝕄 ⦄ →
+  Is-omega-preserving-morphism 𝕄 𝕄 idᶠ
+Is-omega-preserving-morphism-id {𝕄} = λ where
+    .tr-ω → ≤-refl
+  where
+  open Is-omega-preserving-morphism
+  open Graded.Modality.Properties 𝕄
+
+Is-omega-reflecting-morphism-id :
+  ⦃ has-ω : Has-omega _ 𝕄 ⦄ →
+  Is-omega-reflecting-morphism 𝕄 𝕄 idᶠ
+Is-omega-reflecting-morphism-id {𝕄} = λ where
+    .tr-ω → refl
+  where
+  open Is-omega-reflecting-morphism
 
 Is-nr-preserving-morphism-id :
   ⦃ has-nr : Has-nr _ 𝕄 ⦄ →
@@ -583,7 +638,7 @@ Is-morphism-∘ :
   Is-morphism 𝕄₁ 𝕄₂ tr₂ →
   Is-morphism 𝕄₁ 𝕄₃ (tr₁ ∘→ tr₂)
 Is-morphism-∘
-  {𝕄₂ = 𝕄₂} {𝕄₃ = 𝕄₃} {tr₁ = tr₁} {𝕄₁ = 𝕄₁} {tr₂ = tr₂} f g = λ where
+  {𝕄₂} {𝕄₃} {tr₁} {𝕄₁} {tr₂} f g = λ where
     .Is-morphism.first-trivial-if-second-trivial →
       G.first-trivial-if-second-trivial ∘→
       F.first-trivial-if-second-trivial
@@ -602,10 +657,6 @@ Is-morphism-∘
        tr₁ (tr₂ M₁.𝟙)  ≤⟨ F.tr-monotone G.tr-𝟙 ⟩
        tr₁ M₂.𝟙        ≤⟨ F.tr-𝟙 ⟩
        M₃.𝟙            ∎
-    .Is-morphism.tr-ω → let open R in begin
-       tr₁ (tr₂ M₁.ω)  ≤⟨ F.tr-monotone G.tr-ω ⟩
-       tr₁ M₂.ω        ≤⟨ F.tr-ω ⟩
-       M₃.ω            ∎
     .Is-morphism.tr-+ {p = p} {q = q} →
       let open Tools.Reasoning.PropositionalEquality in
       tr₁ (tr₂ (p M₁.+ q))          ≡⟨ cong tr₁ G.tr-+ ⟩
@@ -637,7 +688,7 @@ Is-order-embedding-∘ :
   Is-order-embedding 𝕄₁ 𝕄₂ tr₂ →
   Is-order-embedding 𝕄₁ 𝕄₃ (tr₁ ∘→ tr₂)
 Is-order-embedding-∘
-  {𝕄₂ = 𝕄₂} {𝕄₃ = 𝕄₃} {tr₁ = tr₁} {𝕄₁ = 𝕄₁} {tr₂ = tr₂} f g = λ where
+  {𝕄₂} {𝕄₃} {tr₁} {𝕄₁} {tr₂} f g = λ where
     .Is-order-embedding.tr-morphism →
       Is-morphism-∘ F.tr-morphism G.tr-morphism
     .Is-order-embedding.tr-order-reflecting →
@@ -653,11 +704,6 @@ Is-order-embedding-∘
            p             ∎)
     .Is-order-embedding.tr-≤-𝟙 →
       G.tr-≤-𝟙 ∘→ F.tr-≤-𝟙
-    .Is-order-embedding.tr-ω →
-      let open Tools.Reasoning.PropositionalEquality in
-      tr₁ (tr₂ M₁.ω)  ≡⟨ cong tr₁ G.tr-ω ⟩
-      tr₁ M₂.ω        ≡⟨ F.tr-ω ⟩
-      M₃.ω            ∎
     .Is-order-embedding.tr-≤-+ {q = q} {r = r} tr-p≤q+r →
       case F.tr-≤-+ tr-p≤q+r of
         λ (q′ , r′ , tr-q′≤q , tr-r′≤r , tr-p≤q′+r′) →
@@ -777,6 +823,45 @@ Is-Σ-order-embedding-∘
   module G = Is-Σ-order-embedding g
   open Graded.Modality.Properties 𝕄₃
   open Tools.Reasoning.PartialOrder ≤-poset
+
+Is-omega-preserving-morphism-∘ :
+  ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄ →
+  ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
+  ⦃ has-ω₃ : Has-omega _ 𝕄₃ ⦄ →
+  Is-morphism 𝕄₂ 𝕄₃ tr₁ →
+  Is-omega-preserving-morphism 𝕄₂ 𝕄₃ tr₁ →
+  Is-omega-preserving-morphism 𝕄₁ 𝕄₂ tr₂ →
+  Is-omega-preserving-morphism 𝕄₁ 𝕄₃ (tr₁ ∘→ tr₂)
+Is-omega-preserving-morphism-∘ {𝕄₃} {tr₁} {tr₂} m f g = λ where
+    .tr-ω → begin
+       tr₁ (tr₂ ω)  ≤⟨ tr-monotone G.tr-ω ⟩
+       tr₁ ω        ≤⟨ F.tr-ω ⟩
+       ω            ∎
+  where
+  open Is-omega-preserving-morphism
+  module F = Is-omega-preserving-morphism f
+  module G = Is-omega-preserving-morphism g
+  open Is-morphism m
+  open Graded.Modality.Properties 𝕄₃
+  open ≤-reasoning
+
+Is-omega-reflecting-morphism-∘ :
+  ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄ →
+  ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
+  ⦃ has-ω₃ : Has-omega _ 𝕄₃ ⦄ →
+  Is-omega-reflecting-morphism 𝕄₂ 𝕄₃ tr₁ →
+  Is-omega-reflecting-morphism 𝕄₁ 𝕄₂ tr₂ →
+  Is-omega-reflecting-morphism 𝕄₁ 𝕄₃ (tr₁ ∘→ tr₂)
+Is-omega-reflecting-morphism-∘ {tr₁} {tr₂} f g = λ where
+    .tr-ω → begin
+      tr₁ (tr₂ ω)  ≡⟨ cong tr₁ G.tr-ω ⟩
+      tr₁ ω        ≡⟨ F.tr-ω ⟩
+      ω            ∎
+  where
+  open Is-omega-reflecting-morphism
+  module F = Is-omega-reflecting-morphism f
+  module G = Is-omega-reflecting-morphism g
+  open Tools.Reasoning.PropositionalEquality
 
 Is-nr-preserving-morphism-∘ :
   ⦃ has-nr₁ : Has-nr _ 𝕄₁ ⦄ →

--- a/Graded/Modality/Morphism/Backward-instances.agda
+++ b/Graded/Modality/Morphism/Backward-instances.agda
@@ -17,6 +17,8 @@ module Graded.Modality.Morphism.Backward-instances
   (cp : Common-properties R₁ R₂)
   where
 
+open import Tools.Product
+
 open Common-properties cp
 
 module R₁ = Usage-restrictions R₁
@@ -45,3 +47,11 @@ instance
   no-nr-glb-in-first-if-in-second′ :
     ⦃ no-nr : R₂.Nr-not-available-GLB ⦄ → R₁.Nr-not-available-GLB
   no-nr-glb-in-first-if-in-second′ = no-nr-glb-in-first-if-in-second
+
+  -- If the target modality allows grade ω for J and K then so does
+  -- the source one.
+
+  JK-with-omega-in-first-if-in-second :
+    ⦃ ok : R₂.JK-with-omega ⦄ → R₁.JK-with-omega
+  JK-with-omega-in-first-if-in-second ⦃ ok ⦄ =
+    JK-with-omega-preserved .proj₂ ok

--- a/Graded/Modality/Morphism/Examples.agda
+++ b/Graded/Modality/Morphism/Examples.agda
@@ -43,6 +43,13 @@ private variable
   v₁-ok v₂-ok     : A
   p q₁ q₂ q₃ q₄ r : M
 
+-- An instance used below
+
+private instance
+
+  zero-one-many-has-omega′ : Has-omega _ (zero-one-many-modality 𝟙≤𝟘)
+  zero-one-many-has-omega′ = ZOM.zero-one-many-has-omega _
+
 ------------------------------------------------------------------------
 -- Some translation functions
 
@@ -154,7 +161,6 @@ unit⇨erasure = λ where
     .tr-order-reflecting _ → refl
     .tr-≤                  → _ , refl
     .tr-≤-𝟙 _              → refl
-    .tr-ω                  → refl
     .tr-≤-+ _              → _ , _ , refl , refl , refl
     .tr-≤-· _              → _ , refl , refl
     .tr-≤-∧ _              → _ , _ , refl , refl , refl
@@ -164,7 +170,6 @@ unit⇨erasure = λ where
       .tr-𝟘-≤                               → refl
       .trivial-⊎-tr-≡-𝟘-⇔                   → inj₁ refl
       .tr-𝟙                                 → refl
-      .tr-ω                                 → refl
       .tr-+                                 → refl
       .tr-·                                 → refl
       .tr-∧                                 → refl
@@ -195,7 +200,6 @@ erasure⇨zero-one-many {𝟙≤𝟘} =
   λ where
     .Is-order-embedding.tr-≤                → ω , refl
     .Is-order-embedding.tr-≤-𝟙              → tr-≤-𝟙 _
-    .Is-order-embedding.tr-ω                → refl
     .Is-order-embedding.tr-≤-+              → tr-≤-+ _ _ _
     .Is-order-embedding.tr-≤-·              → tr-≤-· _ _ _
     .Is-order-embedding.tr-≤-∧              → tr-≤-∧ _ _ _
@@ -209,7 +213,6 @@ erasure⇨zero-one-many {𝟙≤𝟘} =
                                                     , λ { refl → refl }
                                                     )
       .Is-morphism.tr-𝟙                      → refl
-      .Is-morphism.tr-ω                      → refl
       .Is-morphism.tr-+ {p = p}              → tr-+ p _
       .Is-morphism.tr-· {p = p}              → tr-· p _
       .Is-morphism.tr-∧ {p = p}              → ≤-reflexive (tr-∧ p _)
@@ -311,7 +314,6 @@ zero-one-many⇨erasure {𝟙≤𝟘} = λ where
                                                   , λ { refl → refl }
                                                   )
     .Is-morphism.tr-𝟙                      → refl
-    .Is-morphism.tr-ω                      → refl
     .Is-morphism.tr-+ {p = p}              → tr-+ p _
     .Is-morphism.tr-· {p = p}              → tr-· p _
     .Is-morphism.tr-∧ {p = p}              → ≤-reflexive (tr-∧ p _)
@@ -449,7 +451,6 @@ linearity⇨linear-or-affine :
 linearity⇨linear-or-affine = λ where
     .Is-order-embedding.tr-≤                → ω , refl
     .Is-order-embedding.tr-≤-𝟙              → tr-≤-𝟙 _
-    .Is-order-embedding.tr-ω                → refl
     .Is-order-embedding.tr-≤-+              → tr-≤-+ _ _ _
     .Is-order-embedding.tr-≤-·              → tr-≤-· _ _ _
     .Is-order-embedding.tr-≤-∧              → tr-≤-∧ _ _ _
@@ -462,7 +463,6 @@ linearity⇨linear-or-affine = λ where
                                                     , λ { refl → refl }
                                                     )
       .Is-morphism.tr-𝟙                      → refl
-      .Is-morphism.tr-ω                      → refl
       .Is-morphism.tr-+ {p = p}              → tr-+ p _
       .Is-morphism.tr-·                      → tr-· _ _
       .Is-morphism.tr-∧                      → tr-∧ _ _
@@ -651,7 +651,6 @@ linear-or-affine⇨linearity = λ where
                                                   , λ { refl → refl }
                                                   )
     .Is-morphism.tr-𝟙                      → refl
-    .Is-morphism.tr-ω                      → refl
     .Is-morphism.tr-+ {p = p}              → tr-+ p _
     .Is-morphism.tr-·                      → tr-· _ _
     .Is-morphism.tr-∧                      → ≤-reflexive (tr-∧ _ _)
@@ -742,7 +741,6 @@ affine⇨linear-or-affine :
 affine⇨linear-or-affine = λ where
     .Is-order-embedding.tr-≤                → ω , refl
     .Is-order-embedding.tr-≤-𝟙              → tr-≤-𝟙 _
-    .Is-order-embedding.tr-ω                → refl
     .Is-order-embedding.tr-≤-+              → tr-≤-+ _ _ _
     .Is-order-embedding.tr-≤-·              → tr-≤-· _ _ _
     .Is-order-embedding.tr-≤-∧              → tr-≤-∧ _ _ _
@@ -755,7 +753,6 @@ affine⇨linear-or-affine = λ where
                                                     , λ { refl → refl }
                                                     )
       .Is-morphism.tr-𝟙                      → refl
-      .Is-morphism.tr-ω                      → refl
       .Is-morphism.tr-+ {p = p}              → tr-+ p _
       .Is-morphism.tr-·                      → tr-· _ _
       .Is-morphism.tr-∧                      → ≤-reflexive (tr-∧ _ _)
@@ -945,7 +942,6 @@ linear-or-affine⇨affine = λ where
                                                   , λ { refl → refl }
                                                   )
     .Is-morphism.tr-𝟙                      → refl
-    .Is-morphism.tr-ω                      → refl
     .Is-morphism.tr-+ {p = p}              → tr-+ p _
     .Is-morphism.tr-·                      → tr-· _ _
     .Is-morphism.tr-∧                      → ≤-reflexive (tr-∧ _ _)
@@ -1039,7 +1035,6 @@ affine⇨linearity = λ where
                                                   , λ { refl → refl }
                                                   )
     .Is-morphism.tr-𝟙                      → refl
-    .Is-morphism.tr-ω                      → refl
     .Is-morphism.tr-+ {p = p}              → tr-+ p _
     .Is-morphism.tr-·                      → tr-· _ _
     .Is-morphism.tr-∧ {p = p}              → ≤-reflexive (tr-∧ p _)
@@ -1111,7 +1106,6 @@ linearity⇨affine = λ where
                                                   , λ { refl → refl }
                                                   )
     .Is-morphism.tr-𝟙                      → refl
-    .Is-morphism.tr-ω                      → refl
     .Is-morphism.tr-+ {p = p}              → tr-+ p _
     .Is-morphism.tr-·                      → tr-· _ _
     .Is-morphism.tr-∧ {p = p}              → tr-∧ p _
@@ -1381,6 +1375,252 @@ affine→linearity-Σ-not-monotone mono =
     (𝟘 , () , _)
     (𝟙 , _  , ())
     (ω , _  , ())
+
+------------------------------------------------------------------------
+-- omega-preserving morphisms
+
+opaque
+
+  unit⇨erasure-omega-preserving :
+    Is-omega-preserving-morphism
+      UnitModality
+      ErasureModality
+      unit→erasure
+  unit⇨erasure-omega-preserving = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-preserving-morphism
+
+opaque
+
+  erasure⇨unit-omega-preserving :
+    Is-omega-preserving-morphism
+      ErasureModality
+      UnitModality
+      erasure→unit
+  erasure⇨unit-omega-preserving = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-preserving-morphism
+
+opaque
+
+  erasure⇨zero-one-many-omega-preserving :
+    Is-omega-preserving-morphism
+      ErasureModality
+      (zero-one-many-modality 𝟙≤𝟘)
+      erasure→zero-one-many
+  erasure⇨zero-one-many-omega-preserving = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-preserving-morphism
+
+opaque
+
+  zero-one-many⇨erasure-omega-preserving :
+    Is-omega-preserving-morphism
+      (zero-one-many-modality 𝟙≤𝟘)
+      ErasureModality
+      zero-one-many→erasure
+  zero-one-many⇨erasure-omega-preserving = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-preserving-morphism
+
+opaque
+
+  linearity⇨linear-or-affine-omega-preserving :
+    Is-omega-preserving-morphism
+      linearityModality
+      linear-or-affine
+      linearity→linear-or-affine
+  linearity⇨linear-or-affine-omega-preserving = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-preserving-morphism
+
+opaque
+
+  linear-or-affine⇨linearity-omega-preserving :
+    Is-omega-preserving-morphism
+      linear-or-affine
+      linearityModality
+      linear-or-affine→linearity
+  linear-or-affine⇨linearity-omega-preserving = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-preserving-morphism
+
+opaque
+
+  affine⇨linear-or-affine-omega-preserving :
+    Is-omega-preserving-morphism
+      affineModality
+      linear-or-affine
+      affine→linear-or-affine
+  affine⇨linear-or-affine-omega-preserving = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-preserving-morphism
+
+opaque
+
+  linear-or-affine⇨affine-omega-preserving :
+    Is-omega-preserving-morphism
+      linear-or-affine
+      affineModality
+      linear-or-affine→affine
+  linear-or-affine⇨affine-omega-preserving = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-preserving-morphism
+
+opaque
+
+  affine⇨linearity-omega-preserving :
+    Is-omega-preserving-morphism
+      affineModality
+      linearityModality
+      affine→linearity
+  affine⇨linearity-omega-preserving = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-preserving-morphism
+
+opaque
+
+  linearity⇨affine-omega-preserving :
+    Is-omega-preserving-morphism
+      linearityModality
+      affineModality
+      linearity→affine
+  linearity⇨affine-omega-preserving = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-preserving-morphism
+
+------------------------------------------------------------------------
+-- omega-reflecting morphisms
+
+opaque
+
+  unit⇨erasure-omega-reflecting :
+    Is-omega-reflecting-morphism
+      UnitModality
+      ErasureModality
+      unit→erasure
+  unit⇨erasure-omega-reflecting = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-reflecting-morphism
+
+opaque
+
+  erasure⇨unit-omega-reflecting :
+    Is-omega-reflecting-morphism
+      ErasureModality
+      UnitModality
+      erasure→unit
+  erasure⇨unit-omega-reflecting = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-reflecting-morphism
+
+opaque
+
+  erasure⇨zero-one-many-omega-reflecting :
+    Is-omega-reflecting-morphism
+      ErasureModality
+      (zero-one-many-modality 𝟙≤𝟘)
+      erasure→zero-one-many
+  erasure⇨zero-one-many-omega-reflecting = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-reflecting-morphism
+
+opaque
+
+  zero-one-many⇨erasure-omega-reflecting :
+    Is-omega-reflecting-morphism
+      (zero-one-many-modality 𝟙≤𝟘)
+      ErasureModality
+      zero-one-many→erasure
+  zero-one-many⇨erasure-omega-reflecting = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-reflecting-morphism
+
+opaque
+
+  linearity⇨linear-or-affine-omega-reflecting :
+    Is-omega-reflecting-morphism
+      linearityModality
+      linear-or-affine
+      linearity→linear-or-affine
+  linearity⇨linear-or-affine-omega-reflecting = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-reflecting-morphism
+
+opaque
+
+  linear-or-affine⇨linearity-omega-reflecting :
+    Is-omega-reflecting-morphism
+      linear-or-affine
+      linearityModality
+      linear-or-affine→linearity
+  linear-or-affine⇨linearity-omega-reflecting = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-reflecting-morphism
+
+opaque
+
+  affine⇨linear-or-affine-omega-reflecting :
+    Is-omega-reflecting-morphism
+      affineModality
+      linear-or-affine
+      affine→linear-or-affine
+  affine⇨linear-or-affine-omega-reflecting = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-reflecting-morphism
+
+opaque
+
+  linear-or-affine⇨affine-omega-reflecting :
+    Is-omega-reflecting-morphism
+      linear-or-affine
+      affineModality
+      linear-or-affine→affine
+  linear-or-affine⇨affine-omega-reflecting = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-reflecting-morphism
+
+opaque
+
+  affine⇨linearity-omega-reflecting :
+    Is-omega-reflecting-morphism
+      affineModality
+      linearityModality
+      affine→linearity
+  affine⇨linearity-omega-reflecting = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-reflecting-morphism
+
+opaque
+
+  linearity⇨affine-omega-reflecting :
+    Is-omega-reflecting-morphism
+      linearityModality
+      affineModality
+      linearity→affine
+  linearity⇨affine-omega-reflecting = λ where
+      .tr-ω → refl
+    where
+    open Is-omega-reflecting-morphism
 
 ------------------------------------------------------------------------
 -- nr-preserving, no-nr-preserving and no-nr-glb-preserving morphisms

--- a/Graded/Modality/Morphism/Forward-instances.agda
+++ b/Graded/Modality/Morphism/Forward-instances.agda
@@ -17,6 +17,8 @@ module Graded.Modality.Morphism.Forward-instances
   (cp : Common-properties R₁ R₂)
   where
 
+open import Tools.Product
+
 open Common-properties cp
 
 module R₁ = Usage-restrictions R₁
@@ -45,3 +47,11 @@ instance
   no-nr-glb-in-second-if-in-first′ :
     ⦃ no-nr : R₁.Nr-not-available-GLB ⦄ → R₂.Nr-not-available-GLB
   no-nr-glb-in-second-if-in-first′ = no-nr-glb-in-second-if-in-first
+
+  -- If the source modality allows grade ω for J and K then so does
+  -- the target one.
+
+  JK-with-omega-in-second-if-in-first :
+    ⦃ ok : R₁.JK-with-omega ⦄ → R₂.JK-with-omega
+  JK-with-omega-in-second-if-in-first ⦃ ok ⦄ =
+    JK-with-omega-preserved .proj₁ ok

--- a/Graded/Modality/Morphism/Type-restrictions/Examples.agda
+++ b/Graded/Modality/Morphism/Type-restrictions/Examples.agda
@@ -30,7 +30,7 @@ open import Graded.Modality.Instances.Linearity
   using (linearityModality)
 open import Graded.Modality.Instances.Unit using (UnitModality)
 open import Graded.Modality.Instances.Zero-one-many
-  using (𝟘; 𝟙; ω; zero-one-many-modality)
+  using (𝟘; 𝟙; ω; zero-one-many-modality; zero-one-many-has-omega)
 open import Graded.Modality.Morphism.Examples
 open import Graded.Modality.Morphism.Type-restrictions
 import Graded.Modality.Properties
@@ -52,6 +52,14 @@ private variable
   𝐌₁ 𝐌₂     : IsMode _ _
   tr tr-Σ     : M₁ → M₂
   v₁-ok v₂-ok : ¬ _
+
+-- An instance used below
+
+private instance
+  zero-one-many-has-omega′ : Has-omega _ (zero-one-many-modality 𝟙≤𝟘)
+  zero-one-many-has-omega′ = zero-one-many-has-omega _
+
+  {-# OVERLAPPABLE zero-one-many-has-omega′ #-}
 
 ------------------------------------------------------------------------
 -- Preserving/reflecting no type restrictions
@@ -231,17 +239,18 @@ Are-reflecting-type-restrictions-second-ΠΣ-quantities-𝟘 tr-𝟘 r = record
 -- second-ΠΣ-quantities-𝟘-or-ω, given that certain assumptions hold.
 
 Are-preserving-type-restrictions-second-ΠΣ-quantities-𝟘-or-ω :
+  ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄ ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
   (Modality.𝟙 𝕄₁ ≢ Modality.𝟘 𝕄₁ →
    tr (Modality.𝟘 𝕄₁) ≡ Modality.𝟘 𝕄₂) →
-  (∀ {p} → tr p ≡ Modality.ω 𝕄₂ ⇔ p ≡ Modality.ω 𝕄₁) →
-  (∀ {p} → tr-Σ p ≡ Modality.ω 𝕄₂ ⇔ p ≡ Modality.ω 𝕄₁) →
+  (∀ {p} → tr p ≡ Has-omega.ω has-ω₂ ⇔ p ≡ Has-omega.ω has-ω₁) →
+  (∀ {p} → tr-Σ p ≡ Has-omega.ω has-ω₂ ⇔ p ≡ Has-omega.ω has-ω₁) →
   Are-preserving-type-restrictions R₁ R₂ tr tr-Σ →
   Are-preserving-type-restrictions
     (second-ΠΣ-quantities-𝟘-or-ω 𝕄₁ 𝐌₁ R₁)
     (second-ΠΣ-quantities-𝟘-or-ω 𝕄₂ 𝐌₂ R₂)
     tr tr-Σ
 Are-preserving-type-restrictions-second-ΠΣ-quantities-𝟘-or-ω
-  {𝕄₁} {tr} {𝕄₂} {tr-Σ} tr-𝟘 tr-ω tr-Σ-ω r = record
+  {𝕄₁} {𝕄₂} {tr} {tr-Σ} ⦃ has-ω₁ ⦄ ⦃ has-ω₂ ⦄ tr-𝟘 tr-ω tr-Σ-ω r = record
   { unfolding-mode-preserved = unfolding-mode-preserved
   ; level-support-preserved  = level-support-preserved
   ; Omega-plus-preserved     = Omega-plus-preserved
@@ -262,23 +271,23 @@ Are-preserving-type-restrictions-second-ΠΣ-quantities-𝟘-or-ω
 
   lemma₁ :
     ∀ {p q} b →
-    (p ≡ M₁.ω → q ≡ M₁.ω) →
-    tr-BinderMode tr tr-Σ b p ≡ M₂.ω → tr q ≡ M₂.ω
+    (p ≡ Has-omega.ω has-ω₁ → q ≡ Has-omega.ω has-ω₁) →
+    tr-BinderMode tr tr-Σ b p ≡ Has-omega.ω has-ω₂ → tr q ≡ Has-omega.ω has-ω₂
   lemma₁ {p = p} {q = q} BMΠ hyp =
-    tr p ≡ M₂.ω  →⟨ tr-ω .proj₁ ⟩
-    p ≡ M₁.ω     →⟨ hyp ⟩
-    q ≡ M₁.ω     →⟨ tr-ω .proj₂ ⟩
-    tr q ≡ M₂.ω  □
+    tr p ≡ Has-omega.ω has-ω₂  →⟨ tr-ω .proj₁ ⟩
+    p ≡ Has-omega.ω has-ω₁    →⟨ hyp ⟩
+    q ≡ Has-omega.ω has-ω₁    →⟨ tr-ω .proj₂ ⟩
+    tr q ≡ Has-omega.ω has-ω₂ □
   lemma₁ {p = p} {q = q} (BMΣ _) hyp =
-    tr-Σ p ≡ M₂.ω  →⟨ tr-Σ-ω .proj₁ ⟩
-    p ≡ M₁.ω       →⟨ hyp ⟩
-    q ≡ M₁.ω       →⟨ tr-ω .proj₂ ⟩
-    tr q ≡ M₂.ω    □
+    tr-Σ p ≡ Has-omega.ω has-ω₂ →⟨ tr-Σ-ω .proj₁ ⟩
+    p ≡ Has-omega.ω has-ω₁      →⟨ hyp ⟩
+    q ≡ Has-omega.ω has-ω₁      →⟨ tr-ω .proj₂ ⟩
+    tr q ≡ Has-omega.ω has-ω₂   □
 
   lemma₂ :
     ∀ {p q} →
-    (p ≢ M₁.ω → q ≡ M₁.𝟘) →
-    p ≢ M₁.ω → tr q ≡ M₂.𝟘
+    (p ≢ Has-omega.ω has-ω₁ → q ≡ M₁.𝟘) →
+    p ≢ Has-omega.ω has-ω₁ → tr q ≡ M₂.𝟘
   lemma₂ {p = p} {q = q} hyp p≢ω₁ =
     case hyp p≢ω₁ of λ {
       refl →
@@ -286,32 +295,33 @@ Are-preserving-type-restrictions-second-ΠΣ-quantities-𝟘-or-ω
 
   lemma₃ :
     ∀ {p q} b →
-    (p ≢ M₁.ω → q ≡ M₁.𝟘) →
-    tr-BinderMode tr tr-Σ b p ≢ M₂.ω → tr q ≡ M₂.𝟘
+    (p ≢ Has-omega.ω has-ω₁ → q ≡ M₁.𝟘) →
+    tr-BinderMode tr tr-Σ b p ≢ Has-omega.ω has-ω₂ → tr q ≡ M₂.𝟘
   lemma₃ {p = p} {q = q} BMΠ hyp =
-    tr p ≢ M₂.ω  →⟨ _∘→ tr-ω .proj₂ ⟩
-    p ≢ M₁.ω     →⟨ lemma₂ hyp ⟩
-    tr q ≡ M₂.𝟘  □
+    tr p ≢ Has-omega.ω has-ω₂ →⟨ _∘→ tr-ω .proj₂ ⟩
+    p ≢ Has-omega.ω has-ω₁    →⟨ lemma₂ hyp ⟩
+    tr q ≡ M₂.𝟘               □
   lemma₃ {p = p} {q = q} (BMΣ _) hyp =
-    tr-Σ p ≢ M₂.ω  →⟨ _∘→ tr-Σ-ω .proj₂ ⟩
-    p ≢ M₁.ω       →⟨ lemma₂ hyp ⟩
-    tr q ≡ M₂.𝟘    □
+    tr-Σ p ≢ Has-omega.ω has-ω₂ →⟨ _∘→ tr-Σ-ω .proj₂ ⟩
+    p ≢ Has-omega.ω has-ω₁      →⟨ lemma₂ hyp ⟩
+    tr q ≡ M₂.𝟘                 □
 
 -- If the functions tr and tr-Σ reflect certain type restrictions,
 -- then they also do this for certain type restrictions obtained using
 -- second-ΠΣ-quantities-𝟘-or-ω, given that certain assumptions hold.
 
 Are-reflecting-type-restrictions-second-ΠΣ-quantities-𝟘-or-ω :
+  ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄ ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
   (∀ {p} → tr p ≡ Modality.𝟘 𝕄₂ → p ≡ Modality.𝟘 𝕄₁) →
-  (∀ {p} → tr p ≡ Modality.ω 𝕄₂ ⇔ p ≡ Modality.ω 𝕄₁) →
-  (∀ {p} → tr-Σ p ≡ Modality.ω 𝕄₂ ⇔ p ≡ Modality.ω 𝕄₁) →
+  (∀ {p} → tr p ≡ Has-omega.ω has-ω₂ ⇔ p ≡ Has-omega.ω has-ω₁) →
+  (∀ {p} → tr-Σ p ≡ Has-omega.ω has-ω₂ ⇔ p ≡ Has-omega.ω has-ω₁) →
   Are-reflecting-type-restrictions R₁ R₂ tr tr-Σ →
   Are-reflecting-type-restrictions
     (second-ΠΣ-quantities-𝟘-or-ω 𝕄₁ 𝐌₁ R₁)
     (second-ΠΣ-quantities-𝟘-or-ω 𝕄₂ 𝐌₂ R₂)
     tr tr-Σ
 Are-reflecting-type-restrictions-second-ΠΣ-quantities-𝟘-or-ω
-  {tr} {𝕄₂} {𝕄₁} {tr-Σ} tr-𝟘 tr-ω tr-Σ-ω r = record
+  {𝕄₁} {𝕄₂} {tr} {tr-Σ} ⦃ has-ω₁ ⦄ ⦃ has-ω₂ ⦄ tr-𝟘 tr-ω tr-Σ-ω r = record
   { unfolding-mode-reflected = unfolding-mode-reflected
   ; level-support-reflected  = level-support-reflected
   ; Unitʷ-η-reflected        = Unitʷ-η-reflected
@@ -330,33 +340,33 @@ Are-reflecting-type-restrictions-second-ΠΣ-quantities-𝟘-or-ω
 
   lemma₁ :
     ∀ {p q} b →
-    (tr-BinderMode tr tr-Σ b p ≡ M₂.ω → tr q ≡ M₂.ω) →
-    p ≡ M₁.ω → q ≡ M₁.ω
+    (tr-BinderMode tr tr-Σ b p ≡ Has-omega.ω has-ω₂ → tr q ≡ Has-omega.ω has-ω₂) →
+    p ≡ Has-omega.ω has-ω₁ → q ≡ Has-omega.ω has-ω₁
   lemma₁ {p = p} {q = q} BMΠ hyp =
-    p ≡ M₁.ω     →⟨ tr-ω .proj₂ ⟩
-    tr p ≡ M₂.ω  →⟨ hyp ⟩
-    tr q ≡ M₂.ω  →⟨ tr-ω .proj₁ ⟩
-    q ≡ M₁.ω     □
+    p ≡ Has-omega.ω has-ω₁    →⟨ tr-ω .proj₂ ⟩
+    tr p ≡ Has-omega.ω has-ω₂ →⟨ hyp ⟩
+    tr q ≡ Has-omega.ω has-ω₂ →⟨ tr-ω .proj₁ ⟩
+    q ≡ Has-omega.ω has-ω₁    □
   lemma₁ {p = p} {q = q} (BMΣ _) hyp =
-    p ≡ M₁.ω       →⟨ tr-Σ-ω .proj₂ ⟩
-    tr-Σ p ≡ M₂.ω  →⟨ hyp ⟩
-    tr q ≡ M₂.ω    →⟨ tr-ω .proj₁ ⟩
-    q ≡ M₁.ω       □
+    p ≡ Has-omega.ω has-ω₁      →⟨ tr-Σ-ω .proj₂ ⟩
+    tr-Σ p ≡ Has-omega.ω has-ω₂ →⟨ hyp ⟩
+    tr q ≡ Has-omega.ω has-ω₂   →⟨ tr-ω .proj₁ ⟩
+    q ≡ Has-omega.ω has-ω₁      □
 
   lemma₂ :
     ∀ {p q} b →
-    (tr-BinderMode tr tr-Σ b p ≢ M₂.ω → tr q ≡ M₂.𝟘) →
-    p ≢ M₁.ω → q ≡ M₁.𝟘
+    (tr-BinderMode tr tr-Σ b p ≢ Has-omega.ω has-ω₂ → tr q ≡ M₂.𝟘) →
+    p ≢ Has-omega.ω has-ω₁ → q ≡ M₁.𝟘
   lemma₂ {p = p} {q = q} BMΠ hyp =
-    p ≢ M₁.ω     →⟨ _∘→ tr-ω .proj₁ ⟩
-    tr p ≢ M₂.ω  →⟨ hyp ⟩
-    tr q ≡ M₂.𝟘  →⟨ tr-𝟘 ⟩
-    q ≡ M₁.𝟘     □
+    p ≢ Has-omega.ω has-ω₁    →⟨ _∘→ tr-ω .proj₁ ⟩
+    tr p ≢ Has-omega.ω has-ω₂ →⟨ hyp ⟩
+    tr q ≡ M₂.𝟘               →⟨ tr-𝟘 ⟩
+    q ≡ M₁.𝟘                  □
   lemma₂ {p = p} {q = q} (BMΣ _) hyp =
-    p ≢ M₁.ω       →⟨ _∘→ tr-Σ-ω .proj₁ ⟩
-    tr-Σ p ≢ M₂.ω  →⟨ hyp ⟩
-    tr q ≡ M₂.𝟘    →⟨ tr-𝟘 ⟩
-    q ≡ M₁.𝟘       □
+    p ≢ Has-omega.ω has-ω₁      →⟨ _∘→ tr-Σ-ω .proj₁ ⟩
+    tr-Σ p ≢ Has-omega.ω has-ω₂ →⟨ hyp ⟩
+    tr q ≡ M₂.𝟘                 →⟨ tr-𝟘 ⟩
+    q ≡ M₁.𝟘                    □
 
 opaque
 
@@ -970,7 +980,7 @@ erasure→zero-one-many-reflects-second-ΠΣ-quantities-𝟘-or-ω :
     (second-ΠΣ-quantities-𝟘-or-ω ErasureModality 𝐌₁ R₁)
     (second-ΠΣ-quantities-𝟘-or-ω (zero-one-many-modality 𝟙≤𝟘) 𝐌₂ R₂)
     erasure→zero-one-many erasure→zero-one-many
-erasure→zero-one-many-reflects-second-ΠΣ-quantities-𝟘-or-ω {𝐌₁} {𝐌₂} =
+erasure→zero-one-many-reflects-second-ΠΣ-quantities-𝟘-or-ω  {𝐌₁} {𝐌₂} =
   Are-reflecting-type-restrictions-second-ΠΣ-quantities-𝟘-or-ω
     {𝐌₁ = 𝐌₁} {𝐌₂ = 𝐌₂}
     (λ where

--- a/Graded/Modality/Morphism/Usage-restrictions.agda
+++ b/Graded/Modality/Morphism/Usage-restrictions.agda
@@ -24,6 +24,7 @@ open import Graded.Mode.Instances.Zero-one.Variant
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Restrictions
 open import Graded.Usage.Restrictions.Natrec
+open import Graded.Usage.Restrictions.JK
 open import Graded.Usage.Restrictions.Instance as RI
 
 open import Definition.Untyped.NotParametrised
@@ -363,6 +364,10 @@ record Common-properties
       m₁ ≈ᵐ m₂ →
       R₁.erased-matches-for-K m₁ ≤ᵉᵐ R₂.erased-matches-for-K m₂
 
+    -- The usage rules for J and K that use grade ω are allowed in
+    -- the target iff it is allowed in the source.
+    JK-with-omega-preserved : R₁.JK-with-omega ⇔ R₂.JK-with-omega
+
   opaque
 
     -- If Nr-available holds in the source usage restrictions then it
@@ -441,6 +446,7 @@ opaque
       .Id-erased-preserved            → id⇔
       .erased-matches-for-J-preserved → ≈ᵐ→≤ᵉᵐ₁
       .erased-matches-for-K-preserved → ≈ᵐ→≤ᵉᵐ₁
+      .JK-with-omega-preserved        → id⇔
     where
     open Common-properties
 
@@ -467,6 +473,8 @@ opaque
       .erased-matches-for-K-preserved →
         ≈ᵐ→≤ᵉᵐ₂ CP₁.𝟘ᵐ-preserved CP₁.erased-matches-for-K-preserved
           CP₂.erased-matches-for-K-preserved
+      .JK-with-omega-preserved →
+        CP₂.JK-with-omega-preserved ∘⇔ CP₁.JK-with-omega-preserved
     where
     open Common-properties
     module CP₁ = Common-properties cp₁
@@ -550,9 +558,16 @@ record Are-preserving-usage-restrictions
       R₁.[]-cong-allowed-mode s m₁ →
       R₂.[]-cong-allowed-mode s m₂
 
+    -- If the source modality supports grade ω then the morphism
+    -- must be omega preserving
+    omega-preserving :
+      ⦃ ok₁ : R₁.JK-with-omega ⦄ ⦃ ok₂ : R₂.JK-with-omega ⦄ →
+      Is-omega-preserving-morphism 𝕄₁ 𝕄₂ tr
+
   open Common-properties common-properties public
 
 opaque
+  unfolding Common-properties-reflexive
 
   -- For every value R the identity function preserves
   -- Usage-restrictions for R and R.
@@ -570,6 +585,9 @@ opaque
       .Unitrec-preserved       → ≈ᵐ→→₁
       .Emptyrec-preserved      → ≈ᵐ→→₁
       .[]-cong-mode-preserved  → ≈ᵐ→→₁
+      .omega-preserving ⦃ ok₁ ⦄ ⦃ ok₂ ⦄ →
+        case JK-with-omega-propositional ok₁ ok₂ of λ where
+          refl → Is-omega-preserving-morphism-id
     where
     open Are-preserving-usage-restrictions
     open Usage-restrictions R
@@ -577,6 +595,7 @@ opaque
     open Graded.Mode.Instances.Zero-one.QuantityTranslation.Primitive
 
 opaque
+  unfolding Common-properties-transitive
 
   -- Composition preserves Are-preserving-usage-restrictions (in a
   -- certain sense).
@@ -622,6 +641,13 @@ opaque
       .[]-cong-mode-preserved →
         ≈ᵐ→→₂ P₂.𝟘ᵐ-preserved P₂.[]-cong-mode-preserved
           P₁.[]-cong-mode-preserved
+      .omega-preserving ⦃ ok₁ ⦄ ⦃ (ok₃) ⦄ →
+        let ok₂ = P₂.JK-with-omega-preserved .proj₁ ok₁
+        in  Is-omega-preserving-morphism-∘ ⦃ _ ⦄
+              ⦃ has-ω₂ = JK-Any-erased-matches-has-omega _ ok₂ ⦄ ⦃ _ ⦄
+              m₁ (P₁.omega-preserving ⦃ ok₁ = ok₂ ⦄)
+                 (P₂.omega-preserving ⦃ ok₂ = ok₂ ⦄)
+
     where
     open Are-preserving-usage-restrictions
     open RI R₁
@@ -728,6 +754,12 @@ record Are-reflecting-usage-restrictions
       m₁ ≈ᵐ m₂ →
       R₂.erased-matches-for-K m₂ ≤ᵉᵐ R₁.erased-matches-for-K m₁
 
+    -- If the target modality supports grade ω then the morphism
+    -- must be omega reflecting.
+    omega-reflecting :
+      ⦃ ok₁ : R₁.JK-with-omega ⦄ ⦃ ok₂ : R₂.JK-with-omega ⦄ →
+      Is-omega-reflecting-morphism 𝕄₁ 𝕄₂ tr
+
   open Common-properties common-properties public
 
   opaque
@@ -762,6 +794,9 @@ opaque
       .[]-cong-mode-reflected         → ≳ᵐ→←₁
       .erased-matches-for-J-reflected → ≈ᵐ→≤ᵉᵐ₁ ∘→ ≈ᵐ-symmetric
       .erased-matches-for-K-reflected → ≈ᵐ→≤ᵉᵐ₁ ∘→ ≈ᵐ-symmetric
+      .omega-reflecting ⦃ ok₁ ⦄ ⦃ ok₂ ⦄ →
+        case JK-with-omega-propositional ok₁ ok₂ of λ where
+          refl → Is-omega-reflecting-morphism-id
     where
     open Are-reflecting-usage-restrictions
     open Graded.Modality.Properties 𝕄
@@ -825,6 +860,11 @@ opaque
       .erased-matches-for-K-reflected →
         ≈ᵐ→≥ᵉᵐ₂ R₂.𝟘ᵐ-preserved R₁.erased-matches-for-K-reflected
           R₂.erased-matches-for-K-reflected
+      .omega-reflecting ⦃ ok₁ ⦄ ⦃ (ok₃) ⦄ →
+        let ok₂ = R₂.JK-with-omega-preserved .proj₁ ok₁
+        in  Is-omega-reflecting-morphism-∘ ⦃ _ ⦄
+             ⦃ has-ω₂ = JK-Any-erased-matches-has-omega _ ok₂ ⦄
+             ⦃ _ ⦄ (R₁.omega-reflecting ⦃ ok₁ = ok₂ ⦄) (R₂.omega-reflecting ⦃ ok₂ = ok₂ ⦄)
     where
     open Are-reflecting-usage-restrictions
     module M₁ = Modality 𝕄₁

--- a/Graded/Modality/Morphism/Usage-restrictions/Examples.agda
+++ b/Graded/Modality/Morphism/Usage-restrictions/Examples.agda
@@ -38,7 +38,8 @@ open import Graded.Modality.Instances.Linearity
 open import Graded.Modality.Instances.Unit using (UnitModality)
 open import Graded.Modality.Instances.Zero-one-many
   using (Zero-one-many; 𝟘; 𝟙; ω; zero-one-many-modality;
-         zero-one-many-has-well-behaved-zero)
+         zero-one-many-has-well-behaved-zero;
+         zero-one-many-has-omega)
 open import Graded.Mode.Instances.Zero-one.Variant
 open import Graded.Mode.Instances.Zero-one
 open import Graded.Mode.Instances.Zero-one.QuantityTranslation.Primitive
@@ -47,6 +48,7 @@ open import Graded.Restrictions.Zero-one
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Restrictions
 open import Graded.Usage.Restrictions.Natrec
+open import Graded.Usage.Restrictions.JK
 
 open Usage-restrictions
 
@@ -61,6 +63,14 @@ private variable
   tr tr-Σ      : M₁ → M₂
   v₁-ok v₂-ok  : A
   nm₁ nm₂      : Natrec-mode _
+
+-- An instance used below
+
+private instance
+  zero-one-many-has-omega′ : Has-omega (Zero-one-many 𝟙≤𝟘) (zero-one-many-modality 𝟙≤𝟘)
+  zero-one-many-has-omega′ = zero-one-many-has-omega _
+
+  {-# OVERLAPPABLE zero-one-many-has-omega′ #-}
 
 ------------------------------------------------------------------------
 -- Preserving/reflecting no usage restrictions
@@ -85,6 +95,7 @@ opaque
                                       , lift ∘→ Lift.lower
       .erased-matches-for-J-preserved → _
       .erased-matches-for-K-preserved → _
+      .JK-with-omega-preserved        → (λ ()) , (λ ())
     where
     open Common-properties
 
@@ -122,6 +133,7 @@ opaque
       .Unitrec-preserved → _
       .Emptyrec-preserved → _
       .[]-cong-mode-preserved → _
+      .omega-preserving ⦃ () ⦄
     where
     open Are-preserving-usage-restrictions
 
@@ -170,10 +182,11 @@ opaque
       .[]-cong-mode-reflected         → _
       .erased-matches-for-J-reflected → _
       .erased-matches-for-K-reflected → _
+      .omega-reflecting ⦃ () ⦄
     where
     open Are-reflecting-usage-restrictions
 
-------------------------------------------------------------------------
+-- ------------------------------------------------------------------------
 -- Preserving/reflecting certain usage restrictions
 
 opaque
@@ -182,6 +195,8 @@ opaque
   -- in a certain way.
 
   Common-properties-only-some-erased-matches :
+    ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+    ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
     Common-properties R₁ R₂ →
     Common-properties
       (only-some-erased-matches 𝕄₁ v₁ R₁)
@@ -197,6 +212,7 @@ opaque
     ; erased-matches-for-K-preserved = λ where
         𝟙ᵐ → _
         𝟘ᵐ → erased-matches-for-K-preserved 𝟘ᵐ?≈𝟘ᵐ?′
+    ; JK-with-omega-preserved = (λ _ → any) , (λ _ → any)
     }
     where
     open Common-properties cp
@@ -209,17 +225,20 @@ opaque
   -- hold.
 
   Are-preserving-usage-restrictions-only-some-erased-matches :
+    ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+    ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
     (¬ Modality.Trivial 𝕄₂ →
      ¬ Modality.Trivial 𝕄₁ ×
      (∀ {p} → tr p ≡ Modality.𝟘 𝕄₂ → p ≡ Modality.𝟘 𝕄₁) ⊎
      (∀ {p} → tr p ≢ Modality.𝟘 𝕄₂)) →
+    Is-omega-preserving-morphism 𝕄₁ 𝕄₂ tr →
     Are-preserving-usage-restrictions R₁ R₂ tr tr-Σ →
     Are-preserving-usage-restrictions
       (only-some-erased-matches 𝕄₁ v₁ R₁)
       (only-some-erased-matches 𝕄₂ v₂ R₂)
       tr tr-Σ
   Are-preserving-usage-restrictions-only-some-erased-matches
-    {𝕄₂} {𝕄₁} {tr} hyp r = record
+    {𝕄₁} {𝕄₂} {tr} {R₁} {R₂} hyp hyp′ r = record
     { common-properties =
         Common-properties-only-some-erased-matches common-properties
     ; nr-preserving = nr-preserving
@@ -241,6 +260,12 @@ opaque
         Emptyrec-preserved
     ; []-cong-mode-preserved =
         []-cong-mode-preserved
+    ; omega-preserving = λ ⦃ ok₁ ⦄ ⦃ ok₂ ⦄ →
+        case JK-with-omega-propositional (only-some-erased-matches 𝕄₁ _ R₁) ok₁ any of λ {
+          refl →
+        case JK-with-omega-propositional (only-some-erased-matches 𝕄₂ _ R₂) ok₂ any of λ {
+          refl →
+        hyp′ }}
     }
     where
     module M₁ = Modality 𝕄₁
@@ -255,16 +280,19 @@ opaque
   -- holds.
 
   Are-reflecting-usage-restrictions-only-some-erased-matches :
+    ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+    ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
     (¬ Modality.Trivial 𝕄₁ →
      ¬ Modality.Trivial 𝕄₂ ×
      (∀ {p} → p ≡ Modality.𝟘 𝕄₁ → tr p ≡ Modality.𝟘 𝕄₂)) →
+    Is-omega-reflecting-morphism 𝕄₁ 𝕄₂ tr →
     Are-reflecting-usage-restrictions R₁ R₂ tr tr-Σ →
     Are-reflecting-usage-restrictions
       (only-some-erased-matches 𝕄₁ v₁ R₁)
       (only-some-erased-matches 𝕄₂ v₂ R₂)
       tr tr-Σ
   Are-reflecting-usage-restrictions-only-some-erased-matches
-    {𝕄₁} {𝕄₂} {tr} hyp r = record
+    {𝕄₁} {𝕄₂} {tr} {R₁} {R₂} hyp hyp′ r = record
     { common-properties =
         Common-properties-only-some-erased-matches common-properties
     ; 𝟘ᵐ-reflected =
@@ -294,6 +322,12 @@ opaque
     ; erased-matches-for-K-reflected = λ where
         𝟙ᵐ → _
         𝟘ᵐ → erased-matches-for-K-reflected 𝟘ᵐ?≈𝟘ᵐ?′
+    ; omega-reflecting = λ ⦃ ok₁ ⦄ ⦃ ok₂ ⦄ →
+        case JK-with-omega-propositional (only-some-erased-matches 𝕄₁ _ R₁) ok₁ any of λ {
+          refl →
+        case JK-with-omega-propositional (only-some-erased-matches 𝕄₂ _ R₂) ok₂ any of λ {
+          refl →
+        hyp′ }}
     }
     where
     module M₁ = Modality 𝕄₁
@@ -304,6 +338,8 @@ opaque
 -- a certain way.
 
 Common-properties-no-erased-matches-UR :
+  ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+  ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
   ∀ TR₁ TR₂ →
   Common-properties R₁ R₂ →
   Common-properties
@@ -316,6 +352,7 @@ Common-properties-no-erased-matches-UR _ _ cp = record
   ; Id-erased-preserved            = Id-erased-preserved
   ; erased-matches-for-J-preserved = erased-matches-for-J-preserved
   ; erased-matches-for-K-preserved = erased-matches-for-K-preserved
+  ; JK-with-omega-preserved        = (λ _ → any) , (λ _ → any)
   }
   where
   open Common-properties
@@ -326,10 +363,13 @@ Common-properties-no-erased-matches-UR _ _ cp = record
 -- using no-erased-matches-UR, given that certain assumptions hold.
 
 Are-preserving-usage-restrictions-no-erased-matches-UR :
+  ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+  ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
   (¬ Modality.Trivial 𝕄₂ →
    ¬ Modality.Trivial 𝕄₁ ×
    (∀ {p} → tr p ≡ Modality.𝟘 𝕄₂ → p ≡ Modality.𝟘 𝕄₁) ⊎
    (∀ {p} → tr p ≢ Modality.𝟘 𝕄₂)) →
+  Is-omega-preserving-morphism 𝕄₁ 𝕄₂ tr →
   Are-preserving-type-restrictions TR₁ TR₂ tr tr-Σ →
   Are-preserving-usage-restrictions R₁ R₂ tr tr-Σ →
   Are-preserving-usage-restrictions
@@ -337,7 +377,7 @@ Are-preserving-usage-restrictions-no-erased-matches-UR :
     (no-erased-matches-UR 𝕄₂ v₂ TR₂ R₂)
     tr tr-Σ
 Are-preserving-usage-restrictions-no-erased-matches-UR
-  {𝕄₂} {𝕄₁} {tr} {TR₁} {TR₂} hyp tp up = record
+  {𝕄₁} {𝕄₂} {tr} {TR₁} {TR₂} hyp hyp′ tp up = record
   { common-properties =
       Common-properties-no-erased-matches-UR TR₁ TR₂
         UP.common-properties
@@ -347,7 +387,7 @@ Are-preserving-usage-restrictions-no-erased-matches-UR
   ; Prodrec-preserved =
       Are-preserving-usage-restrictions.Prodrec-preserved
         (Are-preserving-usage-restrictions-only-some-erased-matches
-           hyp up)
+           hyp hyp′ up)
   ; Unitrec-preserved = λ {p = p} m₁≈m₂ (P , η) →
         UP.Unitrec-preserved m₁≈m₂ P
       , (λ ≡𝟙ᵐ 𝟙≢𝟘 → case hyp 𝟙≢𝟘 of λ where
@@ -364,6 +404,10 @@ Are-preserving-usage-restrictions-no-erased-matches-UR
       UP.Emptyrec-preserved
   ; []-cong-mode-preserved =
       UP.[]-cong-mode-preserved
+  ; omega-preserving =
+      Are-preserving-usage-restrictions.omega-preserving
+        (Are-preserving-usage-restrictions-only-some-erased-matches
+           hyp hyp′ up)
   }
   where
   module UP  = Are-preserving-usage-restrictions up
@@ -378,9 +422,12 @@ Are-preserving-usage-restrictions-no-erased-matches-UR
 -- using no-erased-matches-UR, given that certain assumptions hold.
 
 Are-reflecting-usage-restrictions-no-erased-matches-UR :
+  ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+  ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
   (¬ Modality.Trivial 𝕄₁ →
    ¬ Modality.Trivial 𝕄₂ ×
    (∀ {p} → p ≡ Modality.𝟘 𝕄₁ → tr p ≡ Modality.𝟘 𝕄₂)) →
+  Is-omega-reflecting-morphism 𝕄₁ 𝕄₂ tr →
   Are-reflecting-type-restrictions TR₁ TR₂ tr tr-Σ →
   Are-reflecting-usage-restrictions R₁ R₂ tr tr-Σ →
   Are-reflecting-usage-restrictions
@@ -388,7 +435,7 @@ Are-reflecting-usage-restrictions-no-erased-matches-UR :
     (no-erased-matches-UR 𝕄₂ v₂ TR₂ R₂)
     tr tr-Σ
 Are-reflecting-usage-restrictions-no-erased-matches-UR
-  {𝕄₁} {𝕄₂} {tr} {TR₁} {TR₂} hyp tp up = record
+  {𝕄₁} {𝕄₂} {tr} {TR₁} {TR₂} hyp hyp′ tp up = record
   { common-properties =
       Common-properties-no-erased-matches-UR TR₁ TR₂
         (Are-reflecting-usage-restrictions.common-properties up)
@@ -418,12 +465,14 @@ Are-reflecting-usage-restrictions-no-erased-matches-UR
       UR.erased-matches-for-K-reflected
   ; []-cong-mode-reflected =
       UR.[]-cong-mode-reflected
+  ; omega-reflecting =
+      UR.omega-reflecting
   }
   where
   module UR =
     Are-reflecting-usage-restrictions
       (Are-reflecting-usage-restrictions-only-some-erased-matches
-        hyp up)
+        hyp hyp′ up)
   module TR  = Are-reflecting-type-restrictions tp
   module M₁  = Modality 𝕄₁
   module M₂  = Modality 𝕄₂
@@ -456,6 +505,8 @@ opaque
   -- Common-properties in a certain way.
 
   Common-properties-not-all-erased-matches-JK :
+    ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+    ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
     Common-properties R₁ R₂ →
     Common-properties
       (not-all-erased-matches-JK 𝕄₁ v₁ R₁)
@@ -478,6 +529,7 @@ opaque
           not-all-for-𝟙ᵐ-≤ᵉᵐ R₁.erased-matches-for-K
             R₂.erased-matches-for-K (erased-matches-for-K-preserved 𝟙ᵐ)
             𝟙ᵐ
+    ; JK-with-omega-preserved = (λ _ → any) , (λ _ → any)
     }
     where
     module R₁ = Usage-restrictions R₁
@@ -491,13 +543,16 @@ opaque
   -- using not-all-erased-matches-JK.
 
   Are-preserving-usage-restrictions-not-all-erased-matches-JK :
+    ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+    ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
+    Is-omega-preserving-morphism 𝕄₁ 𝕄₂ tr →
     Are-preserving-usage-restrictions R₁ R₂ tr tr-Σ →
     Are-preserving-usage-restrictions
       (not-all-erased-matches-JK 𝕄₁ v₁ R₁)
       (not-all-erased-matches-JK 𝕄₂ v₂ R₂)
       tr tr-Σ
   Are-preserving-usage-restrictions-not-all-erased-matches-JK
-    r = record
+    {R₁} {R₂} hyp r = record
     { common-properties =
         Common-properties-not-all-erased-matches-JK common-properties
     ; nr-preserving = nr-preserving
@@ -511,6 +566,12 @@ opaque
         Emptyrec-preserved
     ; []-cong-mode-preserved =
         []-cong-mode-preserved
+    ; omega-preserving =  λ ⦃ ok₁ ⦄ ⦃ ok₂ ⦄ →
+        case JK-with-omega-propositional (not-all-erased-matches-JK _ _ R₁) ok₁ any of λ {
+          refl →
+        case JK-with-omega-propositional (not-all-erased-matches-JK _ _ R₂) ok₂ any of λ {
+          refl →
+        hyp }}
     }
     where
     open Are-preserving-usage-restrictions r
@@ -522,13 +583,16 @@ opaque
   -- using not-all-erased-matches-JK.
 
   Are-reflecting-usage-restrictions-not-all-erased-matches-JK :
+    ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+    ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
+    Is-omega-reflecting-morphism 𝕄₁ 𝕄₂ tr →
     Are-reflecting-usage-restrictions R₁ R₂ tr tr-Σ →
     Are-reflecting-usage-restrictions
       (not-all-erased-matches-JK 𝕄₁ v₁ R₁)
       (not-all-erased-matches-JK 𝕄₂ v₂ R₂)
       tr tr-Σ
   Are-reflecting-usage-restrictions-not-all-erased-matches-JK
-    {𝕄₁} {R₁} {𝕄₂} {R₂} r = record
+    {𝕄₁} {𝕄₂} {R₁} {R₂} hyp r = record
     { common-properties =
         Common-properties-not-all-erased-matches-JK common-properties
     ; 𝟘ᵐ-reflected =
@@ -556,6 +620,12 @@ opaque
           not-all-for-𝟙ᵐ-≤ᵉᵐ R₂.erased-matches-for-K
             R₁.erased-matches-for-K (erased-matches-for-K-reflected 𝟙ᵐ)
             𝟙ᵐ
+    ; omega-reflecting = λ ⦃ ok₁ ⦄ ⦃ ok₂ ⦄ →
+        case JK-with-omega-propositional (not-all-erased-matches-JK _ _ R₁) ok₁ any of λ {
+          refl →
+        case JK-with-omega-propositional (not-all-erased-matches-JK _ _ R₂) ok₂ any of λ {
+          refl →
+        hyp }}
     }
     where
     module M₁ = Modality 𝕄₁
@@ -570,6 +640,8 @@ opaque
   -- way.
 
   Common-properties-[]-cong-UR :
+    ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+    ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
     Common-properties R₁ R₂ →
     Common-properties
       ([]-cong-UR 𝕄₁ v₁ R₁)
@@ -581,6 +653,7 @@ opaque
     ; Id-erased-preserved            = Id-erased-preserved
     ; erased-matches-for-J-preserved = _
     ; erased-matches-for-K-preserved = erased-matches-for-K-preserved
+    ; JK-with-omega-preserved        = (λ _ → any) , (λ _ → any)
     }
     where
     open Common-properties cp
@@ -592,16 +665,19 @@ opaque
   -- using []-cong-UR, given a certain assumption.
 
   Are-preserving-usage-restrictions-[]-cong-UR :
+    ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+    ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
     let module M₁ = Modality 𝕄₁
         module M₂ = Modality 𝕄₂
     in
     (M₂.Trivial → M₁.Trivial) →
+    Is-omega-preserving-morphism 𝕄₁ 𝕄₂ tr →
     Are-preserving-usage-restrictions R₁ R₂ tr tr-Σ →
     Are-preserving-usage-restrictions
       ([]-cong-UR 𝕄₁ v₁ R₁)
       ([]-cong-UR 𝕄₂ v₂ R₂)
       tr tr-Σ
-  Are-preserving-usage-restrictions-[]-cong-UR hyp r = record
+  Are-preserving-usage-restrictions-[]-cong-UR {R₁} {R₂} hyp hyp′ r = record
     { common-properties =
         Common-properties-[]-cong-UR common-properties
     ; nr-preserving =
@@ -618,6 +694,12 @@ opaque
         Emptyrec-preserved
     ; []-cong-mode-preserved = λ m₁≈m₂ →
         ⊎.map ([]-cong-mode-preserved m₁≈m₂) (_∘→ hyp)
+    ; omega-preserving = λ ⦃ ok₁ ⦄ ⦃ ok₂ ⦄ →
+        case JK-with-omega-propositional ([]-cong-UR _ _ R₁) ok₁ any of λ {
+          refl →
+        case JK-with-omega-propositional ([]-cong-UR _ _ R₂) ok₂ any of λ {
+          refl →
+        hyp′ }}
     }
     where
     open Are-preserving-usage-restrictions r
@@ -629,16 +711,19 @@ opaque
   -- using []-cong-UR, given a certain assumption.
 
   Are-reflecting-usage-restrictions-[]-cong-UR :
+    ⦃ has-ω₁ : Has-omega _ 𝕄₁ ⦄
+    ⦃ has-ω₂ : Has-omega _ 𝕄₂ ⦄ →
     let module M₁ = Modality 𝕄₁
         module M₂ = Modality 𝕄₂
     in
     (M₁.Trivial → M₂.Trivial) →
+    Is-omega-reflecting-morphism 𝕄₁ 𝕄₂ tr →
     Are-reflecting-usage-restrictions R₁ R₂ tr tr-Σ →
     Are-reflecting-usage-restrictions
       ([]-cong-UR 𝕄₁ v₁ R₁)
       ([]-cong-UR 𝕄₂ v₂ R₂)
       tr tr-Σ
-  Are-reflecting-usage-restrictions-[]-cong-UR {𝕄₂} hyp r = record
+  Are-reflecting-usage-restrictions-[]-cong-UR {𝕄₂} {R₁} {R₂} hyp hyp′ r = record
     { common-properties =
         Common-properties-[]-cong-UR common-properties
     ; 𝟘ᵐ-reflected =
@@ -664,6 +749,12 @@ opaque
         _
     ; erased-matches-for-K-reflected =
         erased-matches-for-K-reflected
+    ; omega-reflecting = λ ⦃ ok₁ ⦄ ⦃ ok₂ ⦄ →
+        case JK-with-omega-propositional ([]-cong-UR _ _ R₁) ok₁ any of λ {
+          refl →
+        case JK-with-omega-propositional ([]-cong-UR _ _ R₂) ok₂ any of λ {
+          refl →
+        hyp′ }}
     }
     where
     module M₂ = Modality 𝕄₂
@@ -706,6 +797,7 @@ opaque
           R₂.erased-matches-for-J (erased-matches-for-J-preserved m₁≈m₂)
           m₁≈m₂
     ; erased-matches-for-K-preserved = erased-matches-for-K-preserved
+    ; JK-with-omega-preserved        = JK-with-omega-preserved
     }
     where
     module R₁ = Usage-restrictions R₁
@@ -741,6 +833,8 @@ opaque
         Emptyrec-preserved
     ; []-cong-mode-preserved =
         λ _ ()
+    ; omega-preserving =
+        omega-preserving
     }
     where
     open Are-preserving-usage-restrictions r
@@ -785,6 +879,8 @@ opaque
           (erased-matches-for-J-reflected m₁≈m₂) (≈ᵐ-symmetric m₁≈m₂)
     ; erased-matches-for-K-reflected =
         erased-matches-for-K-reflected
+    ; omega-reflecting =
+        omega-reflecting
     }
     where
     module R₁ = Usage-restrictions R₁
@@ -809,7 +905,7 @@ opaque
       unit→erasure tr
   unit→erasure-preserves-only-some-erased-matches =
     Are-preserving-usage-restrictions-only-some-erased-matches
-      (λ _ → inj₂ (λ ()))
+      (λ _ → inj₂ (λ ())) unit⇨erasure-omega-preserving
 
 opaque
 
@@ -825,7 +921,7 @@ opaque
       unit→erasure tr
   unit→erasure-reflects-only-some-erased-matches =
     Are-reflecting-usage-restrictions-only-some-erased-matches
-      (λ tt≢tt → ⊥-elim $ tt≢tt refl)
+      (λ tt≢tt → ⊥-elim $ tt≢tt refl) unit⇨erasure-omega-reflecting
 
 opaque
 
@@ -841,7 +937,7 @@ opaque
       erasure→unit tr
   erasure→unit-preserves-only-some-erased-matches =
     Are-preserving-usage-restrictions-only-some-erased-matches
-      (λ tt≢tt → ⊥-elim $ tt≢tt refl)
+      (λ tt≢tt → ⊥-elim $ tt≢tt refl) erasure⇨unit-omega-preserving
 
 opaque
 
@@ -882,6 +978,7 @@ opaque
               {p = 𝟘} _  → refl
               {p = ω} ())
          ))
+      erasure⇨zero-one-many-omega-preserving
 
 opaque
 
@@ -903,6 +1000,7 @@ opaque
          , (λ where
               {p = 𝟘} _  → refl
               {p = ω} ()))
+      erasure⇨zero-one-many-omega-reflecting
 
 opaque
 
@@ -926,6 +1024,7 @@ opaque
               {p = 𝟙} ()
               {p = ω} ())
          ))
+      zero-one-many⇨erasure-omega-preserving
 
 opaque
 
@@ -948,6 +1047,7 @@ opaque
               {p = 𝟘} _  → refl
               {p = 𝟙} ()
               {p = ω} ()))
+      zero-one-many⇨erasure-omega-reflecting
 
 opaque
 
@@ -971,6 +1071,7 @@ opaque
               {p = 𝟙} ()
               {p = ω} ())
          ))
+      linearity⇨linear-or-affine-omega-preserving
 
 opaque
 
@@ -993,6 +1094,7 @@ opaque
               {p = 𝟘} _  → refl
               {p = 𝟙} ()
               {p = ω} ()))
+      linearity⇨linear-or-affine-omega-reflecting
 
 opaque
 
@@ -1017,6 +1119,7 @@ opaque
               {p = ≤𝟙} ()
               {p = ≤ω} ())
          ))
+      linear-or-affine⇨linearity-omega-preserving
 
 opaque
 
@@ -1040,6 +1143,7 @@ opaque
               {p = 𝟙}  ()
               {p = ≤𝟙} ()
               {p = ≤ω} ()))
+      linear-or-affine⇨linearity-omega-reflecting
 
 opaque
 
@@ -1063,6 +1167,7 @@ opaque
               {p = 𝟙} ()
               {p = ω} ())
          ))
+      affine⇨linear-or-affine-omega-preserving
 
 opaque
 
@@ -1085,6 +1190,7 @@ opaque
               {p = 𝟘} _  → refl
               {p = 𝟙} ()
               {p = ω} ()))
+      affine⇨linear-or-affine-omega-reflecting
 
 opaque
 
@@ -1109,6 +1215,7 @@ opaque
               {p = ≤𝟙} ()
               {p = ≤ω} ())
          ))
+      linear-or-affine⇨affine-omega-preserving
 
 opaque
 
@@ -1132,6 +1239,7 @@ opaque
               {p = 𝟙}  ()
               {p = ≤𝟙} ()
               {p = ≤ω} ()))
+      linear-or-affine⇨affine-omega-reflecting
 
 opaque
 
@@ -1155,6 +1263,7 @@ opaque
               {p = 𝟙} ()
               {p = ω} ())
          ))
+      affine⇨linearity-omega-preserving
 
 opaque
 
@@ -1177,6 +1286,7 @@ opaque
               {p = 𝟘} _  → refl
               {p = 𝟙} ()
               {p = ω} ()))
+      affine⇨linearity-omega-reflecting
 
 opaque
 
@@ -1200,6 +1310,7 @@ opaque
               {p = 𝟙} ()
               {p = ω} ())
          ))
+      linearity⇨affine-omega-preserving
 
 opaque
 
@@ -1222,6 +1333,7 @@ opaque
               {p = 𝟘} _  → refl
               {p = 𝟙} ()
               {p = ω} ()))
+      linearity⇨affine-omega-reflecting
 
 ------------------------------------------------------------------------
 -- Some lemmas related to no-erased-matches-UR and concrete
@@ -1241,6 +1353,7 @@ unit→erasure-preserves-no-erased-matches-UR :
 unit→erasure-preserves-no-erased-matches-UR =
   Are-preserving-usage-restrictions-no-erased-matches-UR
     (λ _ → inj₂ (λ ()))
+    unit⇨erasure-omega-preserving
 
 -- If the functions unit→erasure and tr reflect certain usage
 -- restrictions, then they also do this for certain usage restrictions
@@ -1256,6 +1369,7 @@ unit→erasure-reflects-no-erased-matches-UR :
 unit→erasure-reflects-no-erased-matches-UR =
   Are-reflecting-usage-restrictions-no-erased-matches-UR
     (λ tt≢tt → ⊥-elim $ tt≢tt refl)
+    unit⇨erasure-omega-reflecting
 
 -- If the functions erasure→unit and tr preserve certain usage
 -- restrictions, then they also do this for certain usage restrictions
@@ -1271,6 +1385,7 @@ erasure→unit-preserves-no-erased-matches-UR :
 erasure→unit-preserves-no-erased-matches-UR =
   Are-preserving-usage-restrictions-no-erased-matches-UR
     (λ tt≢tt → ⊥-elim $ tt≢tt refl)
+    erasure⇨unit-omega-preserving
 
 -- The functions erasure→unit and tr do not reflect certain usage
 -- restrictions obtained using no-erased-matches-UR.
@@ -1309,6 +1424,7 @@ erasure→zero-one-many-preserves-no-erased-matches-UR =
             {p = 𝟘} _  → refl
             {p = ω} ())
        ))
+    erasure⇨zero-one-many-omega-preserving
 
 -- If the functions erasure→zero-one-many and tr reflect certain usage
 -- restrictions, then they also do this for certain usage restrictions
@@ -1329,6 +1445,7 @@ erasure→zero-one-many-reflects-no-erased-matches-UR =
        , (λ where
             {p = 𝟘} _  → refl
             {p = ω} ()))
+    erasure⇨zero-one-many-omega-reflecting
 
 -- If the functions zero-one-many→erasure and tr preserve certain
 -- usage restrictions, then they also do this for certain usage
@@ -1352,6 +1469,7 @@ zero-one-many→erasure-preserves-no-erased-matches-UR =
             {p = 𝟙} ()
             {p = ω} ())
        ))
+    zero-one-many⇨erasure-omega-preserving
 
 -- If the functions zero-one-many→erasure and tr reflect certain usage
 -- restrictions, then they also do this for certain usage restrictions
@@ -1373,6 +1491,7 @@ zero-one-many→erasure-reflects-no-erased-matches-UR =
             {p = 𝟘} _  → refl
             {p = 𝟙} ()
             {p = ω} ()))
+    zero-one-many⇨erasure-omega-reflecting
 
 -- If the functions linearity→linear-or-affine and tr preserve certain
 -- usage restrictions, then they also do this for certain usage
@@ -1397,6 +1516,7 @@ linearity→linear-or-affine-preserves-no-erased-matches-UR =
             {p = 𝟙} ()
             {p = ω} ())
        ))
+    linearity⇨linear-or-affine-omega-preserving
 
 -- If the functions linearity→linear-or-affine and tr reflect certain
 -- usage restrictions, then they also do this for certain usage
@@ -1420,6 +1540,7 @@ linearity→linear-or-affine-reflects-no-erased-matches-UR =
             {p = 𝟘} _  → refl
             {p = 𝟙} ()
             {p = ω} ()))
+    linearity⇨linear-or-affine-omega-reflecting
 
 -- If the functions linear-or-affine→linearity and tr preserve certain
 -- usage restrictions, then they also do this for certain usage
@@ -1445,6 +1566,7 @@ linear-or-affine→linearity-preserves-no-erased-matches-UR =
             {p = ≤𝟙} ()
             {p = ≤ω} ())
        ))
+    linear-or-affine⇨linearity-omega-preserving
 
 -- If the functions linear-or-affine→linearity and tr reflect certain
 -- usage restrictions, then they also do this for certain usage
@@ -1469,6 +1591,7 @@ linear-or-affine→linearity-reflects-no-erased-matches-UR =
             {p = 𝟙}  ()
             {p = ≤𝟙} ()
             {p = ≤ω} ()))
+    linear-or-affine⇨linearity-omega-reflecting
 
 -- If the functions affine→linear-or-affine and tr preserve certain
 -- usage restrictions, then they also do this for certain usage
@@ -1492,6 +1615,7 @@ affine→linear-or-affine-preserves-no-erased-matches-UR =
             {p = 𝟙} ()
             {p = ω} ())
        ))
+    affine⇨linear-or-affine-omega-preserving
 
 -- If the functions affine→linear-or-affine and tr reflect certain
 -- usage restrictions, then they also do this for certain usage
@@ -1514,6 +1638,7 @@ affine→linear-or-affine-reflects-no-erased-matches-UR =
             {p = 𝟘} _  → refl
             {p = 𝟙} ()
             {p = ω} ()))
+    affine⇨linear-or-affine-omega-reflecting
 
 -- If the functions linear-or-affine→affine and tr preserve certain
 -- usage restrictions, then they also do this for certain usage
@@ -1538,6 +1663,7 @@ linear-or-affine→affine-preserves-no-erased-matches-UR =
             {p = ≤𝟙} ()
             {p = ≤ω} ())
        ))
+    linear-or-affine⇨affine-omega-preserving
 
 -- If the functions linear-or-affine→affine and tr reflect certain
 -- usage restrictions, then they also do this for certain usage
@@ -1561,6 +1687,7 @@ linear-or-affine→affine-reflects-no-erased-matches-UR =
             {p = 𝟙}  ()
             {p = ≤𝟙} ()
             {p = ≤ω} ()))
+    linear-or-affine⇨affine-omega-reflecting
 
 -- If the functions affine→linearity and tr preserve certain usage
 -- restrictions, then they also do this for certain usage restrictions
@@ -1583,6 +1710,7 @@ affine→linearity-preserves-no-erased-matches-UR =
             {p = 𝟙} ()
             {p = ω} ())
        ))
+    affine⇨linearity-omega-preserving
 
 -- If the functions affine→linearity and tr reflect certain usage
 -- restrictions, then they also do this for certain usage restrictions
@@ -1604,6 +1732,7 @@ affine→linearity-reflects-no-erased-matches-UR =
             {p = 𝟘} _  → refl
             {p = 𝟙} ()
             {p = ω} ()))
+    affine⇨linearity-omega-reflecting
 
 -- If the functions linearity→affine and tr preserve certain usage
 -- restrictions, then they also do this for certain usage restrictions
@@ -1626,6 +1755,7 @@ linearity→affine-preserves-no-erased-matches-UR =
             {p = 𝟙} ()
             {p = ω} ())
        ))
+    linearity⇨affine-omega-preserving
 
 -- If the functions linearity→affine and tr reflect certain usage
 -- restrictions, then they also do this for certain usage restrictions
@@ -1647,7 +1777,7 @@ linearity→affine-reflects-no-erased-matches-UR =
             {p = 𝟘} _  → refl
             {p = 𝟙} ()
             {p = ω} ()))
-
+    linearity⇨affine-omega-reflecting
 
 ------------------------------------------------------------------------
 -- Some lemmas related to Is-no-nr-preserving and concrete modalities

--- a/Graded/Modality/Omega-instances.agda
+++ b/Graded/Modality/Omega-instances.agda
@@ -1,0 +1,9 @@
+------------------------------------------------------------------------
+-- Instances related to the Has-omega property
+------------------------------------------------------------------------
+
+module Graded.Modality.Omega-instances {a} {M : Set a} where
+
+open import Graded.Modality M
+
+open Has-omega ⦃ … ⦄ public

--- a/Graded/Modality/Properties/Addition.agda
+++ b/Graded/Modality/Properties/Addition.agda
@@ -9,6 +9,7 @@ module Graded.Modality.Properties.Addition
 
 open Modality 𝕄
 
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties.Meet 𝕄
 open import Graded.Modality.Properties.Multiplication 𝕄
 open import Graded.Modality.Properties.PartialOrder 𝕄
@@ -116,7 +117,7 @@ opaque
 
   -- The grade ω · (p + q) is bounded by ω · p.
 
-  ω·+≤ω·ˡ : ω · (p + q) ≤ ω · p
+  ω·+≤ω·ˡ : ⦃ ok : Has-omega _ 𝕄 ⦄ → ω · (p + q) ≤ ω · p
   ω·+≤ω·ˡ {p} {q} = begin
     ω · (p + q)  ≡⟨ ·-congˡ $ +-comm _ _ ⟩
     ω · (q + p)  ≤⟨ ω·+≤ω·ʳ ⟩
@@ -128,7 +129,7 @@ opaque
 
   -- The grade ω is bounded by 𝟘.
 
-  ω≤𝟘 : ω ≤ 𝟘
+  ω≤𝟘 : ⦃ ok : Has-omega _ 𝕄 ⦄ → ω ≤ 𝟘
   ω≤𝟘 = begin
     ω            ≡˘⟨ ·-identityʳ _ ⟩
     ω · 𝟙        ≡˘⟨ ·-congˡ $ +-identityʳ _ ⟩
@@ -142,14 +143,14 @@ opaque
 
   -- The grade ω is bounded by 𝟘 ∧ 𝟙.
 
-  ω≤𝟘∧𝟙 : ω ≤ 𝟘 ∧ 𝟙
+  ω≤𝟘∧𝟙 : ⦃ ok : Has-omega _ 𝕄 ⦄ → ω ≤ 𝟘 ∧ 𝟙
   ω≤𝟘∧𝟙 = ∧-greatest-lower-bound ω≤𝟘 ω≤𝟙
 
 opaque
 
   -- The grade ω + ω is bounded by ω.
 
-  ω+ω≤ω : ω + ω ≤ ω
+  ω+ω≤ω : ⦃ ok : Has-omega _ 𝕄 ⦄ → ω + ω ≤ ω
   ω+ω≤ω = begin
     ω + ω          ≡˘⟨ +-cong (·-identityʳ _) (·-identityʳ _) ⟩
     ω · 𝟙 + ω · 𝟙  ≡˘⟨ ·-distribˡ-+ _ _ _ ⟩

--- a/Graded/Modality/Properties/Has-well-behaved-zero.agda
+++ b/Graded/Modality/Properties/Has-well-behaved-zero.agda
@@ -16,6 +16,7 @@ module Graded.Modality.Properties.Has-well-behaved-zero
 open Has-well-behaved-zero 𝟘-well-behaved public
 
 open import Graded.Modality.Nr-instances
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties.Addition 𝕄
 open import Graded.Modality.Properties.Meet 𝕄
 open import Graded.Modality.Properties.PartialOrder 𝕄
@@ -88,12 +89,12 @@ opaque
 
   -- The grade ω is strictly less than 𝟘.
 
-  ω<𝟘 : ω < 𝟘
+  ω<𝟘 : ⦃ ok : Has-omega 𝕄 ⦄ → ω < 𝟘
   ω<𝟘 = ≤<-trans ω≤𝟘∧𝟙 𝟘∧𝟙<𝟘
 
 -- The grade ω is not equal to 𝟘.
 
-ω≢𝟘 : ω ≢ 𝟘
+ω≢𝟘 : ⦃ ok : Has-omega 𝕄 ⦄ → ω ≢ 𝟘
 ω≢𝟘 = ω<𝟘 .proj₂
 
 -- If p ⊛ q ▷ r is equal to zero, then p is equal to zero.

--- a/Graded/Modality/Properties/Multiplication.agda
+++ b/Graded/Modality/Properties/Multiplication.agda
@@ -9,6 +9,7 @@ module Graded.Modality.Properties.Multiplication
 
 open Modality 𝕄
 
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties.Meet 𝕄
 open import Graded.Modality.Properties.PartialOrder 𝕄
 
@@ -17,7 +18,6 @@ open import Tools.Function
 open import Tools.Product
 open import Tools.PropositionalEquality
 import Tools.Reasoning.PartialOrder
-
 
 private
   variable
@@ -58,7 +58,7 @@ opaque
 
 -- Multiplication by ω (from the left) is decreasing.
 
-ω·-decreasing : ω · p ≤ p
+ω·-decreasing : ⦃ ok : Has-omega _ 𝕄 ⦄ → ω · p ≤ p
 ω·-decreasing {p = p} = begin
   ω · p  ≤⟨ ·-monotoneˡ ω≤𝟙 ⟩
   𝟙 · p  ≡⟨ ·-identityˡ _ ⟩
@@ -70,7 +70,7 @@ opaque
 
   -- Multiplication by ω (from the right) is decreasing.
 
-  ·ω-decreasing : p · ω ≤ p
+  ·ω-decreasing : ⦃ ok : Has-omega _ 𝕄 ⦄ → p · ω ≤ p
   ·ω-decreasing {p = p} = begin
     p · ω  ≤⟨ ·-monotoneʳ ω≤𝟙 ⟩
     p · 𝟙  ≡⟨ ·-identityʳ _ ⟩

--- a/Graded/Mode.agda
+++ b/Graded/Mode.agda
@@ -17,6 +17,7 @@ open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
 open import Graded.Modality.Nr-instances
 open import Graded.Modality.Properties 𝕄
+open import Graded.Modality.Omega-instances
 
 open import Tools.Algebra Mode
 open import Tools.Empty
@@ -987,7 +988,7 @@ record IsMode : Set (a ⊔ b) where
 
     -- The quantity ω is a right identity for _ᵐ·_.
 
-    ᵐ·-identityʳ-ω : m ᵐ· ω ≡ m
+    ᵐ·-identityʳ-ω : ⦃ ok : Has-omega 𝕄 ⦄ → m ᵐ· ω ≡ m
     ᵐ·-identityʳ-ω = ᵐ·-identityʳ-≤𝟙 ω≤𝟙
 
   opaque

--- a/Graded/Modify-box-cong-or-J.agda
+++ b/Graded/Modify-box-cong-or-J.agda
@@ -41,6 +41,7 @@ open import Definition.Untyped.Properties M
 import Definition.Untyped.Sup
 
 open import Graded.Context 𝕄
+open import Graded.Context.Properties 𝕄
 open import Graded.Erasure.Extraction 𝕄
 import Graded.Erasure.SucRed
 import Graded.Erasure.Target as T
@@ -829,22 +830,28 @@ opaque
       Uₜ.Id₀ₘ (Id-erased-⇔ .proj₁ erased) (tr-▸ A) (tr-▸ t) (tr-▸ u)
     Uₛ.rflₘ →
       Uₜ.rflₘ
-    (Uₛ.Jₘ ok₁ ok₂ A t B u v w) →
-      ▸J′ ok₁ ok₂ (tr-▸ A) (tr-▸ t) (tr-▸ B) (tr-▸ u) (tr-▸ v) (tr-▸ w)
-    (Uₛ.J₀ₘ₁ ok PE.refl PE.refl A t B u v w) →
-      ▸J′₀₁ ok (tr-▸ A) (tr-▸ t) (tr-▸ B) (tr-▸ u) (tr-▸ v) (tr-▸ w)
-    (Uₛ.J₀ₘ₂ ok A t B u v w) →
-      ▸J′₀₂ ok (tr-▸ A) (tr-▸ t) (tr-▸ B) (tr-▸ u) (tr-▸ v) (tr-▸ w)
-    (Uₛ.Kₘ ok₁ ok₂ A t B u v) →
-      Uₜ.Kₘ (PE.subst (_≤ᵉᵐ _) erased-matches-for-K-≡ ok₁)
-        (ok₂ ∘→ PE.trans erased-matches-for-K-≡) (tr-▸ A) (tr-▸ t)
-        (tr-▸ B) (tr-▸ u) (tr-▸ v)
-    (Uₛ.K₀ₘ₁ ok₁ ok₂ A t B u v) →
-      Uₜ.K₀ₘ₁ (PE.trans (PE.sym erased-matches-for-K-≡) ok₁) ok₂
-        (tr-▸ A) (tr-▸ t) (tr-▸ B) (tr-▸ u) (tr-▸ v)
-    (Uₛ.K₀ₘ₂ ok A t B u v) →
-      Uₜ.K₀ₘ₂ (PE.trans (PE.sym erased-matches-for-K-≡) ok) (tr-▸ A)
-        (tr-▸ t) (tr-▸ B) (tr-▸ u) (tr-▸ v)
+    (Uₛ.Jₘ ok A t B u v w) →
+      ▸J′ ok (tr-▸ A) (tr-▸ t) (tr-▸ B) (tr-▸ u) (tr-▸ v) (tr-▸ w)
+    (Uₛ.J₀ₘ₁ PE.refl PE.refl A t B u v w) →
+      ▸J′₀₁ (tr-▸ A) (tr-▸ t) (tr-▸ B) (tr-▸ u) (tr-▸ v) (tr-▸ w)
+    (Uₛ.J₀ₘ₂ A t B u v w) →
+      ▸J′₀₂ (tr-▸ A) (tr-▸ t) (tr-▸ B) (tr-▸ u) (tr-▸ v) (tr-▸ w)
+    (Uₛ.Kₘ ⦃ (ok₁) ⦄ ok₂ A t B u v) →
+      Uₜ.sub-≈ᶜ
+       (Uₜ.Kₘ ⦃ PE.subst (_≤ᵉᵐ _) erased-matches-for-K-≡ ok₁ ⦄
+         (ok₂ ∘→ PE.trans erased-matches-for-K-≡)
+         (tr-▸ A) (tr-▸ t) (tr-▸ B) (tr-▸ u) (tr-▸ v))
+       (·ᶜ-congʳ (ωₛ≡ωₜ URₛ.erased-matches-JK-≤-some-JK-with-omega
+         (URₜ.erased-matches-JK-≤-some-JK-with-omega ⦃ PE.subst (_≤ᵉᵐ _) erased-matches-for-K-≡ ok₁ ⦄)))
+    (Uₛ.K₀ₘ₁ ⦃ (ok₁) ⦄ ok₂ A t B u v) →
+      Uₜ.sub-≈ᶜ
+        (Uₜ.K₀ₘ₁ ⦃ PE.trans (PE.sym erased-matches-for-K-≡) ok₁ ⦄ ok₂
+          (tr-▸ A) (tr-▸ t) (tr-▸ B) (tr-▸ u) (tr-▸ v))
+        (·ᶜ-congʳ (ωₛ≡ωₜ (URₛ.erased-matches-JK-≤-some-JK-with-omega ⦃ URₛ.erased-matches-JK-≡-some-≤-some ⦄)
+          (URₜ.erased-matches-JK-≤-some-JK-with-omega ⦃ URₜ.erased-matches-JK-≡-some-≤-some
+            ⦃ PE.trans (PE.sym erased-matches-for-K-≡) ok₁ ⦄ ⦄)))
+    (Uₛ.K₀ₘ₂ ⦃ (ok) ⦄ A t B u v) →
+      Uₜ.K₀ₘ₂ ⦃ PE.trans (PE.sym erased-matches-for-K-≡) ok ⦄ (tr-▸ A) (tr-▸ t) (tr-▸ B) (tr-▸ u) (tr-▸ v)
     (Uₛ.[]-congₘ l A t u v ok) →
       ▸[]-cong′ ok (tr-▸ l) (tr-▸ A) (tr-▸ t) (tr-▸ u) (tr-▸ v)
 

--- a/Graded/Modify-box-cong-or-J/Configuration.agda
+++ b/Graded/Modify-box-cong-or-J/Configuration.agda
@@ -42,11 +42,14 @@ import Graded.Derived.Erased.Usage
 open import Graded.Erasure.Extraction 𝕄
 open import Graded.Erasure.Extraction.Properties 𝕄
 import Graded.Erasure.Target as T
+open import Graded.Modality.Omega-instances
 open import Graded.Restrictions.Zero-one 𝕄 variant
 import Graded.Usage
 open import Graded.Usage.Erased-matches
 import Graded.Usage.Properties
 import Graded.Usage.Properties.Zero-one
+import Graded.Usage.Restrictions.Instance
+open import Graded.Usage.Restrictions.JK 𝕄
 
 open import Tools.Bool hiding (_∧_)
 open import Tools.Empty
@@ -110,6 +113,7 @@ record Configuration : Set (lsuc a) where
   module Uₜ  = Graded.Usage URₜ
   module URₛ = Usage-restrictions URₛ
   module URₜ = Usage-restrictions URₜ
+  open Graded.Usage.Restrictions.Instance URₛ
 
   field
     -- Some assumptions related to type restrictions.
@@ -149,6 +153,9 @@ record Configuration : Set (lsuc a) where
       URₛ.Id-erased ⇔ URₜ.Id-erased
     erased-matches-for-K-≡ :
       URₛ.erased-matches-for-K m PE.≡ URₜ.erased-matches-for-K m
+    omega-in-second-if-in-first :
+      URₛ.JK-with-omega →
+      URₛ.JK-supported-erased-matches PE.≡ URₜ.JK-supported-erased-matches
 
   open Tₜ
   open Uₜ
@@ -227,7 +234,7 @@ record Configuration : Set (lsuc a) where
         (w [ σ ])
 
     ▸J′ :
-      URₛ.erased-matches-for-J m ≤ᵉᵐ some →
+      ⦃ ok : URₛ.erased-matches-for-J m ≤ᵉᵐ some ⦄ →
       (URₛ.erased-matches-for-J m PE.≡ some → ¬ (p PE.≡ 𝟘 × q PE.≡ 𝟘)) →
       γ₁ ▸[ 𝟘ᵐ? ] A →
       γ₂ ▸[ m ] t →
@@ -238,7 +245,7 @@ record Configuration : Set (lsuc a) where
       ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ▸[ m ] J′ p q A t B u v w
 
     ▸J′₀₁ :
-      URₛ.erased-matches-for-J m PE.≡ some →
+      ⦃ ok : URₛ.erased-matches-for-J m PE.≡ some ⦄ →
       γ₁ ▸[ 𝟘ᵐ? ] A →
       γ₂ ▸[ 𝟘ᵐ? ] t →
       γ₃ ∙ 𝟘 ∙ 𝟘 ▸[ m ] B →
@@ -248,7 +255,7 @@ record Configuration : Set (lsuc a) where
       ω ·ᶜ (γ₃ +ᶜ γ₄) ▸[ m ] J′ 𝟘 𝟘 A t B u v w
 
     ▸J′₀₂ :
-      URₛ.erased-matches-for-J m PE.≡ all →
+      ⦃ ok : URₛ.erased-matches-for-J m PE.≡ all ⦄ →
       γ₁ ▸[ 𝟘ᵐ? ] A →
       γ₂ ▸[ 𝟘ᵐ? ] t →
       γ₃ ∙ ⌜ 𝟘ᵐ? ⌝ · p ∙ ⌜ 𝟘ᵐ? ⌝ · q ▸[ 𝟘ᵐ? ] B →
@@ -494,6 +501,25 @@ record Configuration : Set (lsuc a) where
            PE.subst (_⊢_≡_∷_ _ _ _) ≡Id-wk1-wk1-0[]₀ $
            sym′ w≡w′)
 
+  ----------------------------------------------------------------------
+  -- A property related to usage restrictions
+
+  opaque
+
+    ωₛ≡ωₜ :
+      (x : JK-Any-erased-matches URₛ.JK-supported-erased-matches)
+      (y : JK-Any-erased-matches URₜ.JK-supported-erased-matches) →
+      Has-omega.ω (JK-Any-erased-matches-has-omega x) PE.≡
+      Has-omega.ω (JK-Any-erased-matches-has-omega y)
+    ωₛ≡ωₜ x y = lemma _ _ (omega-in-second-if-in-first x) x y
+      where
+      lemma :
+        ∀ a b → a PE.≡ b →
+        (x : JK-Any-erased-matches a) (y : JK-Any-erased-matches b) →
+        Has-omega.ω (JK-Any-erased-matches-has-omega x) PE.≡
+        Has-omega.ω (JK-Any-erased-matches-has-omega y)
+      lemma a b PE.refl x y = ω≡ω x y
+
 ------------------------------------------------------------------------
 -- Some configurations
 
@@ -502,9 +528,9 @@ private opaque
   -- A lemma used below.
 
   ≡-not-none-preserved :
-    URₛ .erased-matches-for-J m PE.≡ not-none sem →
-    no-[]-cong-UR URₛ .erased-matches-for-J m PE.≡ not-none sem
-  ≡-not-none-preserved {m} hyp with URₛ .erased-matches-for-J m
+    erased-matches-for-J URₛ m PE.≡ not-none sem →
+    erased-matches-for-J (no-[]-cong-UR URₛ) m PE.≡ not-none sem
+  ≡-not-none-preserved {m} hyp with erased-matches-for-J URₛ m
   ≡-not-none-preserved     hyp | not-none _ = hyp
   ≡-not-none-preserved     ()  | none
 
@@ -518,10 +544,11 @@ opaque
   -- only used to prove that the translation is usage-preserving.
 
   remove-[]-cong :
+    ⦃ ok : JK-with-omega URₛ ⦄ →
     (∀ {s} m →
      Usage-restrictions.[]-cong-allowed-mode URₛ s m → T 𝟘ᵐ-allowed) →
     Configuration
-  remove-[]-cong 𝟘ᵐ-ok = λ where
+  remove-[]-cong ⦃ ok = jk-ok ⦄ 𝟘ᵐ-ok = λ where
       .preservation-of-reduction       → true
       .glassification                  → false
       .Configuration.TRₜ               → TRₜ
@@ -542,6 +569,7 @@ opaque
       .natrec-mode-≡                   → PE.refl
       .Id-erased-⇔                     → id⇔
       .erased-matches-for-K-≡          → PE.refl
+      .omega-in-second-if-in-first _   → PE.refl
       .[]-cong′                        → []-cong-J
       .[]-cong′-[]                     → []-cong-J-[]
       .▸[]-cong′ {m} ok ▸l ▸A ▸t ▸u ▸v →
@@ -561,10 +589,15 @@ opaque
         erase-[]-cong-J
       .J′                    → J
       .J′-[]                 → PE.refl
-      .▸J′ _ _               → Jₘ-generalised
-      .▸J′₀₁ ok              → J₀ₘ₁ (≡-not-none-preserved ok)
-                                 PE.refl PE.refl
-      .▸J′₀₂ ok              → J₀ₘ₂ (≡-not-none-preserved ok)
+      .▸J′ _ ▸A ▸t ▸B ▸u ▸v ▸w →
+        sub-≈ᶜ (Jₘ-generalised ▸A ▸t ▸B ▸u ▸v ▸w)
+          (·ᶜ-congʳ (ω≡ω (erased-matches-JK-≤-some-JK-with-omega URₛ) jk-ok))
+      .▸J′₀₁ ⦃ (ok) ⦄ ▸A ▸t ▸B ▸u ▸v ▸w →
+        sub-≈ᶜ (J₀ₘ₁ ⦃ ≡-not-none-preserved ok ⦄ PE.refl PE.refl ▸A ▸t ▸B ▸u ▸v ▸w)
+          (·ᶜ-congʳ (ω≡ω (erased-matches-JK-≤-some-JK-with-omega URₛ ⦃ erased-matches-JK-≡-some-≤-some URₛ ⦄)
+            (erased-matches-JK-≤-some-JK-with-omega URₜ {jk = J}
+              ⦃ erased-matches-JK-≡-some-≤-some URₜ {jk = J} ⦃ ≡-not-none-preserved ok ⦄ ⦄)))
+      .▸J′₀₂ ⦃ (ok) ⦄        → J₀ₘ₂ ⦃ ≡-not-none-preserved ok ⦄
       .J′-cong               → J-cong′
       .J′-subst _ ⊢B ⊢u w⇒w′ → redMany (J-subst′ ⊢B ⊢u w⇒w′)
       .J′-β-≡′ ¬⊤            → ⊥-elim (¬⊤ _)
@@ -586,8 +619,8 @@ opaque
     open Graded.Usage.Properties.Zero-one variant URₜ
 
     some-erased-matches-allowed :
-      ∃ λ sem → URₜ .erased-matches-for-J m PE.≡ not-none sem
-    some-erased-matches-allowed {m} with URₛ .erased-matches-for-J m
+      ∃ λ sem → erased-matches-for-J URₜ m PE.≡ not-none sem
+    some-erased-matches-allowed {m} with erased-matches-for-J URₛ m
     … | none       = _ , PE.refl
     … | not-none _ = _ , PE.refl
 
@@ -610,10 +643,11 @@ opaque
 
   remove-J-𝟘-𝟘 :
     ⦃ ok : T 𝟘ᵐ-allowed ⦄ →
+    JK-with-omega URₛ →
     Prodrec-allowed URₛ 𝟘ᵐ? (𝟘 ∧ 𝟙) 𝟘 𝟘 →
     Usage-restrictions.erased-matches-for-J URₛ 𝟙ᵐ ≤ᵉᵐ some →
     Configuration
-  remove-J-𝟘-𝟘 ⦃ ok = 𝟘ᵐ-ok ⦄ P-ok ≤some = λ where
+  remove-J-𝟘-𝟘 ⦃ ok = 𝟘ᵐ-ok ⦄ jk-ω P-ok ≤some = λ where
       .preservation-of-reduction            → false
       .glassification                       → false
       .Configuration.TRₜ                    → TRₜ
@@ -635,6 +669,7 @@ opaque
       .natrec-mode-≡                        → PE.refl
       .Id-erased-⇔                          → id⇔
       .erased-matches-for-K-≡               → PE.refl
+      .omega-in-second-if-in-first _        → omega-in-second _ jk-ω
       .[]-cong′                             → []-cong
       .[]-cong′-[]                          → PE.refl
       .▸[]-cong′ ok ▸l ▸A ▸t ▸u ▸v →
@@ -650,9 +685,13 @@ opaque
         PE.refl
       .J′ p q      → J″       (is-𝟘? p ×-dec is-𝟘? q)
       .J′-[]       → J″-[]    (is-𝟘? _ ×-dec _)
-      .▸J′ _ _     → ▸J″      (is-𝟘? _ ×-dec _)
-      .▸J′₀₁ _     → ▸J″₀₁    (is-𝟘? _ ×-dec _)
-      .▸J′₀₂       → ▸J″₀₂    (is-𝟘? _ ×-dec _)
+      .▸J′ _ ▸A ▸t ▸B ▸u ▸v ▸w →
+        sub-≈ᶜ (▸J″ (is-𝟘? _ ×-dec _) ▸A ▸t ▸B ▸u ▸v ▸w)
+          (·ᶜ-congʳ (ω≡ω (erased-matches-JK-≤-some-JK-with-omega URₛ) jk-ω))
+      .▸J′₀₁ ▸A ▸t ▸B ▸u ▸v ▸w →
+        sub-≈ᶜ (▸J″₀₁ (is-𝟘? _ ×-dec _) ▸A ▸t ▸B ▸u ▸v ▸w)
+          (·ᶜ-congʳ (ω≡ω (erased-matches-JK-≤-some-JK-with-omega URₛ ⦃ erased-matches-JK-≡-some-≤-some URₛ ⦄) jk-ω))
+      .▸J′₀₂ ⦃ ok ⦄ → ▸J″₀₂ (is-𝟘? _ ×-dec _) ok
       .J′-cong     → J″-cong  (is-𝟘? _ ×-dec _)
       .J′-subst ()
       .J′-β-≡′ _   → J″-β-≡′  (is-𝟘? _ ×-dec _)
@@ -663,7 +702,9 @@ opaque
     TRₜ = []-cong-TR TRₛ
 
     URₜ : Usage-restrictions
-    URₜ = []-cong-UR URₛ
+    URₜ = []-cong-UR ⦃ JK-Any-erased-matches-has-omega jk-ω ⦄ URₛ
+
+    module URₜ′ = Usage-restrictions URₜ
 
     open Configuration hiding (TRₜ; URₜ)
     open Definition.Typed TRₜ
@@ -672,7 +713,20 @@ opaque
     open Graded.Usage URₜ
     open Graded.Usage.Properties URₜ
     open Graded.Usage.Properties.Zero-one variant URₜ
+    open Graded.Usage.Restrictions.Instance URₜ
     open ≤ᶜ-reasoning
+
+    instance
+      jk-ω′ : JK-with-omega URₜ
+      jk-ω′ = any
+
+    opaque
+
+      omega-in-second :
+        ∀ x → (ok : JK-Any-erased-matches x) →
+        x PE.≡ JK-supported-erased-matches ([]-cong-UR ⦃ JK-Any-erased-matches-has-omega ok ⦄ URₛ)
+      omega-in-second any any = PE.refl
+      omega-in-second only-all ()
 
     opaque
 
@@ -752,7 +806,7 @@ opaque
 
       ▸J″₀₂ :
         (d : Dec (p PE.≡ 𝟘 × q PE.≡ 𝟘)) →
-        URₛ .erased-matches-for-J m PE.≡ all →
+        erased-matches-for-J URₛ m PE.≡ all →
         γ₁ ▸[ 𝟘ᵐ? ] A →
         γ₂ ▸[ 𝟘ᵐ? ] t →
         γ₃ ∙ ⌜ 𝟘ᵐ? ⌝ · p ∙ ⌜ 𝟘ᵐ? ⌝ · q ▸[ 𝟘ᵐ? ] B →
@@ -844,8 +898,9 @@ opaque
   -- A translation that replaces every occurrence of []-cong with rfl
   -- and turns on equality reflection.
 
-  replace-[]-cong-with-rfl : Configuration
-  replace-[]-cong-with-rfl = λ where
+  replace-[]-cong-with-rfl :
+    ⦃ ok : JK-with-omega URₛ ⦄ → Configuration
+  replace-[]-cong-with-rfl ⦃ ok = jk-ok ⦄ = λ where
       .preservation-of-reduction          → true
       .glassification                     → true
       .Configuration.TRₜ                  → TRₜ
@@ -866,6 +921,7 @@ opaque
       .natrec-mode-≡                      → PE.refl
       .Id-erased-⇔                        → id⇔
       .erased-matches-for-K-≡             → PE.refl
+      .omega-in-second-if-in-first _      → PE.refl
       .[]-cong′ _ _ _ _ _ _               → rfl
       .[]-cong′-[]                        → PE.refl
       .▸[]-cong′ _ _ _ _ _ _              → rflₘ
@@ -887,10 +943,17 @@ opaque
         PE.refl
       .J′                    → J
       .J′-[]                 → PE.refl
-      .▸J′ _ _               → Jₘ-generalised
-      .▸J′₀₁ ok              → J₀ₘ₁ (≡-not-none-preserved ok)
-                                 PE.refl PE.refl
-      .▸J′₀₂ ok              → J₀ₘ₂ (≡-not-none-preserved ok)
+      .▸J′ ⦃ ok ⦄ _ ▸A ▸t ▸B ▸u ▸v ▸w →
+        sub-≈ᶜ (Jₘ-generalised ▸A ▸t ▸B ▸u ▸v ▸w)
+          (·ᶜ-congʳ (ω≡ω (erased-matches-JK-≤-some-JK-with-omega URₛ) jk-ok))
+      .▸J′₀₁ ⦃ ok ⦄ ▸A ▸t ▸B ▸u ▸v ▸w →
+        sub-≈ᶜ
+          (J₀ₘ₁ ⦃ ≡-not-none-preserved ok ⦄ PE.refl PE.refl
+            ▸A ▸t ▸B ▸u ▸v ▸w)
+          (·ᶜ-congʳ (ω≡ω (erased-matches-JK-≤-some-JK-with-omega URₛ ⦃  erased-matches-JK-≡-some-≤-some URₛ ⦄)
+            (erased-matches-JK-≤-some-JK-with-omega URₜ {jk = J}
+              ⦃ erased-matches-JK-≡-some-≤-some URₜ {jk = J} ⦃ ≡-not-none-preserved ok ⦄ ⦄)))
+      .▸J′₀₂ ⦃ ok ⦄           → J₀ₘ₂ ⦃ ≡-not-none-preserved ok ⦄
       .J′-cong               → J-cong′
       .J′-subst _ ⊢B ⊢u w⇒w′ → redMany (J-subst′ ⊢B ⊢u w⇒w′)
       .J′-β-≡′ ¬⊤            → ⊥-elim (¬⊤ _)
@@ -937,6 +1000,7 @@ opaque
       .natrec-mode-≡               → PE.refl
       .Id-erased-⇔                 → id⇔
       .erased-matches-for-K-≡      → PE.refl
+      .omega-in-second-if-in-first → λ _ → PE.refl
       .[]-cong′                    → []-cong
       .[]-cong′-[]                 → PE.refl
       .▸[]-cong′ ok ▸l ▸A ▸t ▸u ▸v →
@@ -950,7 +1014,7 @@ opaque
       .J′                          → J
       .J′-[]                       → PE.refl
       .▸J′                         → Jₘ
-      .▸J′₀₁ ok                    → J₀ₘ₁ ok PE.refl PE.refl
+      .▸J′₀₁                       → J₀ₘ₁ PE.refl PE.refl
       .▸J′₀₂                       → J₀ₘ₂
       .J′-cong                     → J-cong′
       .J′-subst _ ⊢B ⊢u w⇒w′       → redMany (J-subst′ ⊢B ⊢u w⇒w′)

--- a/Graded/Neutral.agda
+++ b/Graded/Neutral.agda
@@ -32,6 +32,7 @@ open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
 open import Graded.Erasure.Consequences.Soundness TR UR
 open import Graded.Erasure.Target using (non-strict)
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 open import Graded.Restrictions.Zero-one 𝕄 variant
 open import Graded.Usage UR
@@ -162,7 +163,7 @@ opaque
                                 (inj₂ γ≈𝟘) → γ≈𝟘) ⟩
           γ ≈ᶜ 𝟘ᶜ →⟨ helper t-n ⊢t (▸-cong (≢𝟘→⌞⌟≡𝟙ᵐ p≢𝟘) ▸t) ⟩
           ⊥ □ }
-      (Jₙ w-n) ⊢J (Jₘ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} _ _ _ _ _ _ _ ▸w) →
+      (Jₙ w-n) ⊢J (Jₘ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} _ _ _ _ _ _ ▸w) →
         case inversion-J ⊢J of λ {
           (_ , _ , _ , _ , _ , ⊢w , _) →
         ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ≈ᶜ 𝟘ᶜ   →⟨ ·ᶜ-zero-product ⟩
@@ -175,17 +176,17 @@ opaque
                                                      proj₂ ∘→ +ᶜ-positive ⟩
         γ₆ ≈ᶜ 𝟘ᶜ                                  →⟨ helper w-n ⊢w ▸w ⟩
         ⊥                                         □ }
-      (Jₙ _) _ (J₀ₘ₁ em _ _ _ _ _ _ _ _) →
+      (Jₙ _) _ (J₀ₘ₁ ⦃ (em) ⦄ _ _ _ _ _ _ _ _) →
         case
           PE.trans (PE.sym em)
             (nem non-trivial .proj₂ .proj₂ .proj₂ .proj₁)
         of λ ()
-      (Jₙ _) _ (J₀ₘ₂ em _ _ _ _ _ _) →
+      (Jₙ _) _ (J₀ₘ₂ ⦃ (em) ⦄ _ _ _ _ _ _) →
         case
           PE.trans (PE.sym em)
             (nem non-trivial .proj₂ .proj₂ .proj₂ .proj₁)
         of λ ()
-      (Kₙ v-n) ⊢K (Kₘ {γ₂} {γ₃} {γ₄} {γ₅} _ _ _ _ _ _ ▸v) →
+      (Kₙ v-n) ⊢K (Kₘ {γ₂} {γ₃} {γ₄} {γ₅} _ _ _ _ _ ▸v) →
         case inversion-K ⊢K of λ {
           (_ , _ , _ , _ , ⊢v , _) →
         ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ≈ᶜ 𝟘ᶜ   →⟨ ·ᶜ-zero-product ⟩
@@ -197,12 +198,12 @@ opaque
                                                proj₂ ∘→ +ᶜ-positive ⟩
         γ₅ ≈ᶜ 𝟘ᶜ                            →⟨ helper v-n ⊢v ▸v ⟩
         ⊥                                   □ }
-      (Kₙ _) _ (K₀ₘ₁ em _ _ _ _ _ _) →
+      (Kₙ _) _ (K₀ₘ₁ ⦃ (em) ⦄ _ _ _ _ _ _) →
         case
           PE.trans (PE.sym em)
             (nem non-trivial .proj₂ .proj₂ .proj₂ .proj₂)
         of λ ()
-      (Kₙ _) _ (K₀ₘ₂ em _ _ _ _ _) →
+      (Kₙ _) _ (K₀ₘ₂ ⦃ (em) ⦄ _ _ _ _ _) →
         case
           PE.trans (PE.sym em)
             (nem non-trivial .proj₂ .proj₂ .proj₂ .proj₂)

--- a/Graded/Reduction.agda
+++ b/Graded/Reduction.agda
@@ -24,6 +24,7 @@ open Usage-restrictions UR
 open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
 open import Graded.Context.Weakening 𝕄
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 open import Graded.Substitution.Properties UR
 open import Graded.Usage UR
@@ -382,29 +383,29 @@ module Subject-reduction
 
   usagePresTerm ▸∇ γ▸ (J-subst _ _ _ _ v⇒v′) =
     case inv-usage-J γ▸ of λ where
-      (invUsageJ ok₁ ok₂ ▸A ▸t ▸B ▸u ▸t′ ▸v γ≤) → sub
-        (Jₘ ok₁ ok₂ ▸A ▸t ▸B ▸u ▸t′ (usagePresTerm ▸∇ ▸v v⇒v′))
+      (invUsageJ ok ▸A ▸t ▸B ▸u ▸t′ ▸v γ≤) → sub
+        (Jₘ ok ▸A ▸t ▸B ▸u ▸t′ (usagePresTerm ▸∇ ▸v v⇒v′))
         γ≤
-      (invUsageJ₀₁ ok p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸t′ ▸v γ≤) → sub
-        (J₀ₘ₁ ok p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸t′
+      (invUsageJ₀₁ p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸t′ ▸v γ≤) → sub
+        (J₀ₘ₁ p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸t′
            (usagePresTerm (ε-▸-𝟘ᵐ ∘→ ▸∇) ▸v v⇒v′))
         γ≤
-      (invUsageJ₀₂ ok ▸A ▸t ▸B ▸u ▸t′ ▸v γ≤) → sub
-        (J₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸t′
+      (invUsageJ₀₂ ▸A ▸t ▸B ▸u ▸t′ ▸v γ≤) → sub
+        (J₀ₘ₂ ▸A ▸t ▸B ▸u ▸t′
            (usagePresTerm (ε-▸-𝟘ᵐ ∘→ ▸∇) ▸v v⇒v′))
         γ≤
 
   usagePresTerm ▸∇ γ▸ (K-subst _ _ v⇒v′ _) =
     case inv-usage-K γ▸ of λ where
-      (invUsageK ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v γ≤) → sub
-        (Kₘ ok₁ ok₂ ▸A ▸t ▸B ▸u (usagePresTerm ▸∇ ▸v v⇒v′))
+      (invUsageK ok ▸A ▸t ▸B ▸u ▸v γ≤) → sub
+        (Kₘ ok ▸A ▸t ▸B ▸u (usagePresTerm ▸∇ ▸v v⇒v′))
         γ≤
-      (invUsageK₀₁ ok p≡𝟘 ▸A ▸t ▸B ▸u ▸v γ≤) → sub
-        (K₀ₘ₁ ok p≡𝟘 ▸A ▸t ▸B ▸u
+      (invUsageK₀₁ p≡𝟘 ▸A ▸t ▸B ▸u ▸v γ≤) → sub
+        (K₀ₘ₁ p≡𝟘 ▸A ▸t ▸B ▸u
            (usagePresTerm (ε-▸-𝟘ᵐ ∘→ ▸∇) ▸v v⇒v′))
         γ≤
-      (invUsageK₀₂ ok ▸A ▸t ▸B ▸u ▸v γ≤) → sub
-        (K₀ₘ₂ ok ▸A ▸t ▸B ▸u (usagePresTerm (ε-▸-𝟘ᵐ ∘→ ▸∇) ▸v v⇒v′))
+      (invUsageK₀₂ ▸A ▸t ▸B ▸u ▸v γ≤) → sub
+        (K₀ₘ₂ ▸A ▸t ▸B ▸u (usagePresTerm (ε-▸-𝟘ᵐ ∘→ ▸∇) ▸v v⇒v′))
         γ≤
 
   usagePresTerm ▸∇ γ▸ ([]-cong-subst _ v⇒v′ _) =
@@ -417,7 +418,7 @@ module Subject-reduction
   usagePresTerm {γ} _ γ▸ (J-β _ _ _ _ _ _) =
     case inv-usage-J γ▸ of λ where
       (invUsageJ {γ₂ = γ₂} {γ₃ = γ₃} {γ₄ = γ₄} {γ₅ = γ₅} {γ₆ = γ₆}
-         _ _ _ _ _ ▸u _ _ γ≤) → sub
+         _ _ _ _ ▸u _ _ γ≤) → sub
         ▸u
         (begin
            γ                                  ≤⟨ γ≤ ⟩
@@ -426,14 +427,14 @@ module Subject-reduction
                                                  ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
            ω ·ᶜ γ₄                            ≤⟨ ω·ᶜ-decreasing ⟩
            γ₄                                 ∎)
-      (invUsageJ₀₁ {γ₃} {γ₄} _ _ _ _ _ _ ▸u _ _ γ≤) → sub
+      (invUsageJ₀₁ {γ₃} {γ₄} _ _ _ _ _ ▸u _ _ γ≤) → sub
         ▸u
         (begin
            γ                ≤⟨ γ≤ ⟩
            ω ·ᶜ (γ₃ +ᶜ γ₄)  ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
            ω ·ᶜ γ₄          ≤⟨ ω·ᶜ-decreasing ⟩
            γ₄               ∎)
-      (invUsageJ₀₂ _ _ _ _ ▸u _ _ γ≤) →
+      (invUsageJ₀₂ _ _ _ ▸u _ _ γ≤) →
         sub ▸u γ≤
     where
     open import Tools.Reasoning.PartialOrder ≤ᶜ-poset
@@ -441,7 +442,7 @@ module Subject-reduction
   usagePresTerm {γ} _ γ▸ (K-β _ _ _) =
     case inv-usage-K γ▸ of λ where
       (invUsageK {γ₂ = γ₂} {γ₃ = γ₃} {γ₄ = γ₄} {γ₅ = γ₅}
-         _ _ _ _ _ ▸u _ γ≤) → sub
+         _ _ _ _ ▸u _ γ≤) → sub
         ▸u
         (begin
            γ                            ≤⟨ γ≤ ⟩
@@ -450,14 +451,14 @@ module Subject-reduction
                                            ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
            ω ·ᶜ γ₄                      ≤⟨ ω·ᶜ-decreasing ⟩
            γ₄                           ∎)
-      (invUsageK₀₁ {γ₃} {γ₄} _ _ _ _ _ ▸u _ γ≤) → sub
+      (invUsageK₀₁ {γ₃} {γ₄} _ _ _ _ ▸u _ γ≤) → sub
         ▸u
         (begin
            γ                ≤⟨ γ≤ ⟩
            ω ·ᶜ (γ₃ +ᶜ γ₄)  ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
            ω ·ᶜ γ₄          ≤⟨ ω·ᶜ-decreasing ⟩
            γ₄               ∎)
-      (invUsageK₀₂ _ _ _ _ ▸u _ γ≤) →
+      (invUsageK₀₂ _ _ _ ▸u _ γ≤) →
         sub ▸u γ≤
     where
     open import Tools.Reasoning.PartialOrder ≤ᶜ-poset

--- a/Graded/Restrictions.agda
+++ b/Graded/Restrictions.agda
@@ -26,11 +26,13 @@ open import Tools.Relation as Dec
 open import Tools.Sum
 open import Tools.Unit
 
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 import Graded.Usage.Decidable.Assumptions as UD
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Restrictions 𝕄 𝐌
 open import Graded.Usage.Restrictions.Natrec 𝕄
+open import Graded.Usage.Restrictions.JK 𝕄
 
 import Definition.Typechecking.Decidable.Assumptions as TD
 open import Definition.Typed.Restrictions 𝕄
@@ -111,6 +113,7 @@ second-ΠΣ-quantities-𝟘 R = record R
 -- quantity is not ω, then the second quantity is the 𝟘 of 𝕄.
 
 second-ΠΣ-quantities-𝟘-or-ω :
+  ⦃ ok : Has-omega 𝕄 ⦄ →
   Type-restrictions → Type-restrictions
 second-ΠΣ-quantities-𝟘-or-ω R = record R
   { ΠΣ-allowed = λ b p q →
@@ -265,10 +268,10 @@ no-usage-restrictions nm nr-ok erased sink = λ where
     .Id-erased                               → Lift _ (T erased)
     .Id-erased?                              → Dec.map lift Lift.lower $
                                                 T? erased
-    .erased-matches-for-J                    → λ _ → all
-    .erased-matches-for-J-≤ᵉᵐ                → _
-    .erased-matches-for-K                    → λ _ → all
-    .erased-matches-for-K-≤ᵉᵐ                → _
+    .JK-supported-erased-matches             → only-all
+    .erased-matches-for-JK                   → λ _ _ → all
+    .erased-matches-for-JK-≤ᵉᵐ               → _
+    .erased-matches-for-JK-supports-ω        → λ ()
     .mode-supports-nr                        → nr-ok
   where
   open Usage-restrictions
@@ -300,44 +303,24 @@ nr-not-available-glb-UR ok UR =
 -- The function enables support for []-cong (if the modality is
 -- non-trivial), but disables support for erased matches for J.
 
-[]-cong-UR : Usage-restrictions → Usage-restrictions
-[]-cong-UR UR = record UR
+[]-cong-UR : ⦃ ok : Has-omega 𝕄 ⦄ → Usage-restrictions → Usage-restrictions
+[]-cong-UR ⦃ ok ⦄ UR = record UR
   { []-cong-allowed-mode     = λ m s → []-cong-allowed-mode m s ⊎
                                      ¬ Trivial
   ; []-cong-allowed-mode-upwards-closed = λ where
       (inj₁ ok) m≤m′ → inj₁ ([]-cong-allowed-mode-upwards-closed ok m≤m′)
       (inj₂ 𝟙≢𝟘) _   → inj₂ 𝟙≢𝟘
-  ; erased-matches-for-J     = λ _ → none
-  ; erased-matches-for-J-≤ᵉᵐ = _
+  ; JK-supported-erased-matches = any ⦃ ok ⦄
+  ; erased-matches-for-JK     = λ where
+      J _ → none
+      K m → erased-matches-for-JK K m
+  ; erased-matches-for-JK-≤ᵉᵐ = λ where
+      {jk = J} m≤m′ → _
+      {jk = K} m≤m′ → erased-matches-for-JK-≤ᵉᵐ m≤m′
+  ; erased-matches-for-JK-supports-ω = λ _ → any
   }
   where
   open Usage-restrictions UR
-
-------------------------------------------------------------------------
--- No-secret-matches
-
--- The property of not allowing (certain) secret matches (matches on
--- data that is "more secret" than a given grade).
-
--- record No-secret-matches
---   (p₀ : M) (TV : Type-variant) (UR : Usage-restrictions) : Set (a ⊔ a′) where
-
---   no-eta-equality
-
---   open Usage-restrictions UR
---   open Type-variant TV
-
---   field
---     no-secret-prodrec :
---       ∀ {m p q r} → m ≤ᵐ ⌞ p₀ ⌟ → Prodrec-allowed m r p q → r ≤ p₀
---     no-secret-unitrec :
---       ∀ {m p q} → m ≤ᵐ ⌞ p₀ ⌟ → ¬ Unitʷ-η → Unitrec-allowed ⌞ m ⌟ p q → p ≤ p₀
---     no-secret-J :
---       erased-matches-for-J ⌞ p₀ ⌟ ≡ none
---     no-secret-K :
---       m ≤ᵐ ⌞ p₀ ⌟ → erased-matches-for-K m ≡ none
---     no-secret-[]-cong :
---       ∀ {s m} → m ≤ p₀ → []-cong-allowed-mode s ⌞ m ⌟ → 𝟘 ≤ p₀
 
 ------------------------------------------------------------------------
 -- No-erased-matches
@@ -447,6 +430,7 @@ opaque
   -- TD.Assumptions.
 
   Assumptions-second-ΠΣ-quantities-𝟘-or-ω :
+    ⦃ ok : Has-omega 𝕄 ⦄ →
     TD.Assumptions TR → TD.Assumptions (second-ΠΣ-quantities-𝟘-or-ω TR)
   Assumptions-second-ΠΣ-quantities-𝟘-or-ω as = λ where
       ._≟_                    → A._≟_

--- a/Graded/Restrictions/Zero-one.agda
+++ b/Graded/Restrictions/Zero-one.agda
@@ -32,6 +32,7 @@ import Graded.Usage.Decidable.Assumptions as UD
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Restrictions 𝕄 Zero-one-isMode
 open import Graded.Usage.Restrictions.Natrec 𝕄
+open import Graded.Usage.Restrictions.JK 𝕄
 
 import Definition.Typechecking.Decidable.Assumptions as TD
 open import Definition.Typed.Restrictions 𝕄
@@ -96,20 +97,17 @@ not-all-for-𝟙ᵐ f 𝟙ᵐ with f 𝟙ᵐ
 -- The function adds the restriction that, for the mode 𝟙ᵐ, "all"
 -- erased matches are not allowed for J and K.
 
-not-all-erased-matches-JK : Usage-restrictions → Usage-restrictions
+not-all-erased-matches-JK :
+  ⦃ ok : Has-omega 𝕄 ⦄ → Usage-restrictions → Usage-restrictions
 not-all-erased-matches-JK UR = record UR
-  { erased-matches-for-J =
-      not-all-for-𝟙ᵐ erased-matches-for-J
-  ; erased-matches-for-J-≤ᵉᵐ =
-     𝟙ᵐ𝟘ᵐ→≤ᵐ (λ m m′ → not-all-for-𝟙ᵐ erased-matches-for-J m ≤ᵉᵐ not-all-for-𝟙ᵐ erased-matches-for-J m′)
-       (not-all-for-𝟙ᵐ-≤ᵉᵐ erased-matches-for-J (erased-matches-for-J-≤ᵉᵐ 𝟙ᵐ≤))
-       ≤ᵉᵐ-reflexive
-  ; erased-matches-for-K =
-      not-all-for-𝟙ᵐ erased-matches-for-K
-  ; erased-matches-for-K-≤ᵉᵐ =
-    𝟙ᵐ𝟘ᵐ→≤ᵐ (λ m m′ → not-all-for-𝟙ᵐ erased-matches-for-K m ≤ᵉᵐ not-all-for-𝟙ᵐ erased-matches-for-K m′)
-      (not-all-for-𝟙ᵐ-≤ᵉᵐ erased-matches-for-K (erased-matches-for-K-≤ᵉᵐ 𝟙ᵐ≤))
-      ≤ᵉᵐ-reflexive
+  { JK-supported-erased-matches = any
+  ; erased-matches-for-JK = λ jk m → not-all-for-𝟙ᵐ (erased-matches-for-JK jk) m
+  ; erased-matches-for-JK-≤ᵉᵐ =
+      𝟙ᵐ𝟘ᵐ→≤ᵐ
+        (λ m m′ → not-all-for-𝟙ᵐ (erased-matches-for-JK _) m ≤ᵉᵐ not-all-for-𝟙ᵐ (erased-matches-for-JK _) m′)
+        (not-all-for-𝟙ᵐ-≤ᵉᵐ (erased-matches-for-JK _) (erased-matches-for-JK-≤ᵉᵐ 𝟙ᵐ≤))
+        ≤ᵉᵐ-reflexive
+  ; erased-matches-for-JK-supports-ω = λ _ → any
   }
   where
   open Usage-restrictions UR
@@ -130,21 +128,20 @@ not-all-erased-matches-JK UR = record UR
 -- or unitrec. For prodrec the added restriction only applies to
 -- non-trivial modalities.
 
-only-some-erased-matches : Usage-restrictions → Usage-restrictions
+only-some-erased-matches :
+  ⦃ ok : Has-omega 𝕄 ⦄ → Usage-restrictions → Usage-restrictions
 only-some-erased-matches UR = record UR
   { Prodrec-allowed = λ m r p q →
       Prodrec-allowed m r p q ×
       (m ≡ 𝟙ᵐ → ¬ Trivial → r ≢ 𝟘)
   ; Prodrec-allowed-upwards-closed = λ (ok , r≢𝟘) m≤m′ →
       Prodrec-allowed-upwards-closed ok m≤m′ , λ { refl → r≢𝟘 (≤ᵐ-𝟙ᵐ→ m≤m′) }
-  ; erased-matches-for-J =
-      f (erased-matches-for-J 𝟘ᵐ?)
-  ; erased-matches-for-J-≤ᵉᵐ =
+  ; JK-supported-erased-matches = any
+  ; erased-matches-for-JK =
+      λ jk → f (erased-matches-for-JK jk 𝟘ᵐ?)
+  ; erased-matches-for-JK-≤ᵉᵐ =
       𝟙ᵐ𝟘ᵐ→≤ᵐ (λ m m′ → f _ m ≤ᵉᵐ f _ m′) _ ≤ᵉᵐ-reflexive
-  ; erased-matches-for-K =
-      f (erased-matches-for-K 𝟘ᵐ?)
-  ; erased-matches-for-K-≤ᵉᵐ =
-      𝟙ᵐ𝟘ᵐ→≤ᵐ (λ m m′ → f _ m ≤ᵉᵐ f _ m′) _ ≤ᵉᵐ-reflexive
+  ; erased-matches-for-JK-supports-ω = λ _ → any
   }
   where
   open Usage-restrictions UR
@@ -159,6 +156,7 @@ only-some-erased-matches UR = record UR
 -- applies if η-equality is not allowed for weak unit types.
 
 no-erased-matches-UR :
+  ⦃ ok : Has-omega 𝕄 ⦄ →
   Type-restrictions → Usage-restrictions → Usage-restrictions
 no-erased-matches-UR TR UR = record (only-some-erased-matches UR)
   { Unitrec-allowed = λ m p q →
@@ -196,13 +194,27 @@ no-[]-cong-UR : Usage-restrictions → Usage-restrictions
 no-[]-cong-UR UR = record UR
   { []-cong-allowed-mode                = λ _ _ → Lift _ ⊥
   ; []-cong-allowed-mode-upwards-closed = λ ()
-  ; erased-matches-for-J     = at-least-some erased-matches-for-J
-  ; erased-matches-for-J-≤ᵉᵐ =
-      𝟙ᵐ𝟘ᵐ→≤ᵐ (λ m m′ → at-least-some erased-matches-for-J m ≤ᵉᵐ at-least-some erased-matches-for-J m′)
+  ; erased-matches-for-JK    = λ where
+      J → at-least-some erased-matches-for-J
+      K → erased-matches-for-K
+  ; erased-matches-for-JK-≤ᵉᵐ = λ where
+      {jk = J} → 𝟙ᵐ𝟘ᵐ→≤ᵐ (λ m m′ → at-least-some erased-matches-for-J m ≤ᵉᵐ at-least-some erased-matches-for-J m′)
         at-least-some-≤ᵉᵐ ≤ᵉᵐ-reflexive
+      {jk = K} → erased-matches-for-K-≤ᵉᵐ
+  ; erased-matches-for-JK-supports-ω = λ where
+      {jk = J} ≤some → erased-matches-for-JK-supports-ω
+        (≤ᵉᵐ-transitive (some-≤ᵉᵐ-at-least-some (erased-matches-for-JK J) _) ≤some)
+      {jk = K} ≤some → erased-matches-for-JK-supports-ω ≤some
   }
   where
   open Usage-restrictions UR
+
+  some-≤ᵉᵐ-at-least-some :
+    (f : Mode → Erased-matches) (m : Mode) →
+    f m ≤ᵉᵐ at-least-some f m
+  some-≤ᵉᵐ-at-least-some f m with f m
+  ... | none       = _
+  ... | not-none x = ≤ᵉᵐ-reflexive
 
   at-least-some-≤ᵉᵐ :
     at-least-some erased-matches-for-J 𝟙ᵐ ≤ᵉᵐ
@@ -245,6 +257,7 @@ opaque
   -- only-some-erased-matches satisfy Only-some-erased-matches.
 
   Only-some-erased-matches-only-some-erased-matches :
+    ⦃ ok : Has-omega 𝕄 ⦄ →
     ∀ TR UR →
     Only-some-erased-matches
       (no-erased-matches-TR 𝕤 (no-erased-matches-TR 𝕨 TR))
@@ -286,6 +299,7 @@ No-erased-matches TR UR =
 -- no-erased-matches-UR satisfy No-erased-matches.
 
 No-erased-matches-no-erased-matches :
+  ⦃ ok : Has-omega 𝕄 ⦄ →
   ∀ TR UR →
   let TR′ = no-erased-matches-TR 𝕤 (no-erased-matches-TR 𝕨 TR) in
   No-erased-matches TR′ (no-erased-matches-UR TR′ UR)
@@ -351,6 +365,7 @@ opaque
   -- The function not-all-erased-matches-JK preserves UD.Assumptions.
 
   Assumptions-not-all-erased-matches-JK :
+    ⦃ ok : Has-omega 𝕄 ⦄ →
     UD.Assumptions UR → UD.Assumptions (not-all-erased-matches-JK UR)
   Assumptions-not-all-erased-matches-JK as = λ where
       ._≟_                   → A._≟_
@@ -368,6 +383,7 @@ opaque
   -- The function only-some-erased-matches preserves UD.Assumptions.
 
   Assumptions-only-some-erased-matches :
+    ⦃ ok : Has-omega 𝕄 ⦄ →
     UD.Assumptions UR → UD.Assumptions (only-some-erased-matches UR)
   Assumptions-only-some-erased-matches as = λ where
       ._≟_                       → A._≟_
@@ -392,6 +408,7 @@ opaque
   -- The function no-erased-matches-UR TR preserves UD.Assumptions.
 
   Assumptions-no-erased-matches-UR :
+    ⦃ ok : Has-omega 𝕄 ⦄ →
     ∀ TR → UD.Assumptions UR →
     UD.Assumptions (no-erased-matches-UR TR UR)
   Assumptions-no-erased-matches-UR TR as = λ where

--- a/Graded/Substitution/Properties.agda
+++ b/Graded/Substitution/Properties.agda
@@ -1286,8 +1286,9 @@ opaque mutual
       (<*-zeroˡ Ψ)
   substₘ-lemma {Ψ} ▶σ rflₘ =
     sub-≈ᶜ rflₘ (<*-zeroˡ Ψ)
-  substₘ-lemma {Ψ} ▶σ (Jₘ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v ▸w) =
+  substₘ-lemma {Ψ} ▶σ (Jₘ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} ok ▸A ▸t ▸B ▸u ▸v ▸w) =
     let open ≤ᶜ-reasoning
+        open Graded.Usage.Restrictions.Instance R
         ▶σ′ = ▶-≤ Ψ (ω·ᶜ-decreasing {γ = γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆}) ▶σ
         ▶σ₂ = ▶-⌞+ᶜ⌟ˡ γ₂ ▶σ′
         ▶σ₃ = ▶-⌞+ᶜ⌟ˡ γ₃ (▶-⌞+ᶜ⌟ʳ γ₂ ▶σ′)
@@ -1295,7 +1296,7 @@ opaque mutual
         ▶σ₅ = ▶-⌞+ᶜ⌟ˡ γ₅ (▶-⌞+ᶜ⌟ʳ γ₄ (▶-⌞+ᶜ⌟ʳ γ₃ (▶-⌞+ᶜ⌟ʳ γ₂ ▶σ′)))
         ▶σ₆ = ▶-⌞+ᶜ⌟ʳ γ₅ (▶-⌞+ᶜ⌟ʳ γ₄ (▶-⌞+ᶜ⌟ʳ γ₃ (▶-⌞+ᶜ⌟ʳ γ₂ ▶σ′)))
     in  sub-≈ᶜ
-          (Jₘ ok₁ ok₂
+          (Jₘ ok
             (substₘ-lemma-𝟘ᵐ ▶σ ▸A)
             (substₘ-lemma ▶σ₂ ▸t)
             (substₘ-lemma-⇑² ▶σ₃ ▸B)
@@ -1303,12 +1304,13 @@ opaque mutual
             (substₘ-lemma ▶σ₅ ▸v)
             (substₘ-lemma ▶σ₆ ▸w))
           (·ᶜ+ᶜ⁵<* γ₂)
-  substₘ-lemma {Ψ} ▶σ (J₀ₘ₁ {γ₃} {γ₄} ok p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸v ▸w) =
-    let ▶σ′ = ▶-≤ Ψ (ω·ᶜ-decreasing {γ = γ₃ +ᶜ γ₄}) ▶σ
+  substₘ-lemma {Ψ} ▶σ (J₀ₘ₁ {γ₃} {γ₄} p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸v ▸w) =
+    let open Graded.Usage.Restrictions.Instance R
+        ▶σ′ = ▶-≤ Ψ (ω·ᶜ-decreasing {γ = γ₃ +ᶜ γ₄}) ▶σ
         ▶σ₃ = ▶-⌞+ᶜ⌟ˡ γ₃ ▶σ′
         ▶σ₄ = ▶-⌞+ᶜ⌟ʳ γ₃ ▶σ′
     in  sub-≈ᶜ
-          (J₀ₘ₁ ok p≡𝟘 q≡𝟘
+          (J₀ₘ₁ p≡𝟘 q≡𝟘
             (substₘ-lemma-𝟘ᵐ ▶σ ▸A)
             (substₘ-lemma-𝟘ᵐ ▶σ ▸t)
             (substₘ-lemma-⇑² ▶σ₃ ▸B)
@@ -1316,40 +1318,42 @@ opaque mutual
             (substₘ-lemma-𝟘ᵐ ▶σ ▸v)
             (substₘ-lemma-𝟘ᵐ ▶σ ▸w))
           (·ᶜ+ᶜ²<* γ₃)
-  substₘ-lemma ▶σ (J₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸v ▸w) =
-    J₀ₘ₂ ok
+  substₘ-lemma ▶σ (J₀ₘ₂ ▸A ▸t ▸B ▸u ▸v ▸w) =
+    J₀ₘ₂
       (substₘ-lemma-𝟘ᵐ ▶σ ▸A)
       (substₘ-lemma-𝟘ᵐ ▶σ ▸t)
       (substₘ-lemma-𝟘ᵐ-⇑² ▶σ ▸B)
       (substₘ-lemma ▶σ ▸u)
       (substₘ-lemma-𝟘ᵐ ▶σ ▸v)
       (substₘ-lemma-𝟘ᵐ ▶σ ▸w)
-  substₘ-lemma {Ψ} ▶σ (Kₘ {γ₂} {γ₃} {γ₄} {γ₅} ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v) =
-    let ▶σ′ = ▶-≤ Ψ (ω·ᶜ-decreasing {γ = γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅}) ▶σ
+  substₘ-lemma {Ψ} ▶σ (Kₘ {γ₂} {γ₃} {γ₄} {γ₅} ok ▸A ▸t ▸B ▸u ▸v) =
+    let open Graded.Usage.Restrictions.Instance R
+        ▶σ′ = ▶-≤ Ψ (ω·ᶜ-decreasing {γ = γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅}) ▶σ
         ▶σ₂ = ▶-⌞+ᶜ⌟ˡ γ₂ ▶σ′
         ▶σ₃ = ▶-⌞+ᶜ⌟ˡ γ₃ (▶-⌞+ᶜ⌟ʳ γ₂ ▶σ′)
         ▶σ₄ = ▶-⌞+ᶜ⌟ˡ γ₄ (▶-⌞+ᶜ⌟ʳ γ₃ (▶-⌞+ᶜ⌟ʳ γ₂ ▶σ′))
         ▶σ₅ = ▶-⌞+ᶜ⌟ʳ γ₄ (▶-⌞+ᶜ⌟ʳ γ₃ (▶-⌞+ᶜ⌟ʳ γ₂ ▶σ′))
     in  sub-≈ᶜ
-          (Kₘ ok₁ ok₂ (substₘ-lemma-𝟘ᵐ ▶σ ▸A)
+          (Kₘ ok (substₘ-lemma-𝟘ᵐ ▶σ ▸A)
             (substₘ-lemma ▶σ₂ ▸t)
             (substₘ-lemma-⇑ ▶σ₃ ▸B)
             (substₘ-lemma ▶σ₄ ▸u)
             (substₘ-lemma ▶σ₅ ▸v))
           (·ᶜ+ᶜ⁴<* γ₂)
-  substₘ-lemma {Ψ} ▶σ (K₀ₘ₁ {γ₃} {γ₄} ok p≡𝟘 ▸A ▸t ▸B ▸u ▸v) =
-    let ▶σ′ = ▶-≤ Ψ (ω·ᶜ-decreasing {γ = γ₃ +ᶜ γ₄}) ▶σ
+  substₘ-lemma {Ψ} ▶σ (K₀ₘ₁ {γ₃} {γ₄} p≡𝟘 ▸A ▸t ▸B ▸u ▸v) =
+    let open Graded.Usage.Restrictions.Instance R
+        ▶σ′ = ▶-≤ Ψ (ω·ᶜ-decreasing {γ = γ₃ +ᶜ γ₄}) ▶σ
         ▶σ₃ = ▶-⌞+ᶜ⌟ˡ γ₃ ▶σ′
         ▶σ₄ = ▶-⌞+ᶜ⌟ʳ γ₃ ▶σ′
     in  sub-≈ᶜ
-          (K₀ₘ₁ ok p≡𝟘 (substₘ-lemma-𝟘ᵐ ▶σ ▸A)
+          (K₀ₘ₁ p≡𝟘 (substₘ-lemma-𝟘ᵐ ▶σ ▸A)
             (substₘ-lemma-𝟘ᵐ ▶σ ▸t)
             (substₘ-lemma-⇑ ▶σ₃ ▸B)
             (substₘ-lemma ▶σ₄ ▸u)
             (substₘ-lemma-𝟘ᵐ ▶σ ▸v))
           (·ᶜ+ᶜ²<* γ₃)
-  substₘ-lemma ▶σ (K₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸v) =
-    K₀ₘ₂ ok (substₘ-lemma-𝟘ᵐ ▶σ ▸A)
+  substₘ-lemma ▶σ (K₀ₘ₂ ▸A ▸t ▸B ▸u ▸v) =
+    K₀ₘ₂ (substₘ-lemma-𝟘ᵐ ▶σ ▸A)
       (substₘ-lemma-𝟘ᵐ ▶σ ▸t)
       (substₘ-lemma-𝟘ᵐ-⇑ ▶σ ▸B)
       (substₘ-lemma ▶σ ▸u)

--- a/Graded/Usage.agda
+++ b/Graded/Usage.agda
@@ -21,6 +21,7 @@ open Usage-restrictions R
 
 open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
+open import Graded.Modality.Omega-instances
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Restrictions.Instance R
 open import Graded.Usage.Restrictions.Natrec 𝕄
@@ -55,26 +56,27 @@ private
 -- A view used in the implementation of ⌈_⌉.
 
 data ⌈⌉-view (A : Set a) (em : Erased-matches) : Set a where
-  is-all      : em ≡ all → ⌈⌉-view A em
-  is-some-yes : em ≡ some → A → ⌈⌉-view A em
-  is-other    : em ≤ᵉᵐ some → (em ≡ some → ¬ A) → ⌈⌉-view A em
+  is-all      : ⦃ ok : em ≡ all ⦄ → ⌈⌉-view A em
+  is-some-yes : ⦃ ok : em ≡ some ⦄ → A → ⌈⌉-view A em
+  is-other    : ⦃ ok : em ≤ᵉᵐ some ⦄ → (em ≡ some → ¬ A) → ⌈⌉-view A em
 
 opaque
 
   -- The view ⌈⌉-view A em is inhabited if A is decided.
 
   ⌈⌉-view-inhabited : {A : Set a} → Dec A → ∀ em → ⌈⌉-view A em
-  ⌈⌉-view-inhabited _       all  = is-all refl
-  ⌈⌉-view-inhabited (yes p) some = is-some-yes refl p
-  ⌈⌉-view-inhabited (no p)  some = is-other _ (λ _ → p)
-  ⌈⌉-view-inhabited _       none = is-other _ (λ ())
+  ⌈⌉-view-inhabited _       all  = is-all
+  ⌈⌉-view-inhabited (yes p) some = is-some-yes p
+  ⌈⌉-view-inhabited (no p)  some = is-other ⦃ _ ⦄ (λ _ → p)
+  ⌈⌉-view-inhabited _       none = is-other ⦃ _ ⦄ (λ ())
 
-opaque
+
 
   -- An instantiation of ⌈⌉-view-inhabited used for J.
 
-  J-view : ∀ p q m → ⌈⌉-view (p ≡ 𝟘 × q ≡ 𝟘) (erased-matches-for-J m)
-  J-view p q _ = ⌈⌉-view-inhabited (is-𝟘? p ×-dec is-𝟘? q) _
+J-view : ∀ p q m → ⌈⌉-view (p ≡ 𝟘 × q ≡ 𝟘) (erased-matches-for-J m)
+J-view p q _ = ⌈⌉-view-inhabited (is-𝟘? p ×-dec is-𝟘? q) _
+
 
 opaque
 
@@ -138,16 +140,16 @@ mutual
     (no _)  → ⌈ A ⌉ m +ᶜ ⌈ t ⌉ m +ᶜ ⌈ u ⌉ m
   ⌈ rfl ⌉ _ = 𝟘ᶜ
   ⌈ J p q _ t B u v w ⌉ m with J-view p q m
-  … | is-all _        = ⌈ u ⌉ m
-  … | is-some-yes _ _ = ω ·ᶜ (tailₘ (tailₘ (⌈ B ⌉ m)) +ᶜ ⌈ u ⌉ m)
-  … | is-other _ _    =
+  … | is-all        = ⌈ u ⌉ m
+  … | is-some-yes _ = ω ·ᶜ (tailₘ (tailₘ (⌈ B ⌉ m)) +ᶜ ⌈ u ⌉ m)
+  … | is-other _    =
         ω ·ᶜ
         (⌈ t ⌉ m +ᶜ tailₘ (tailₘ (⌈ B ⌉ m)) +ᶜ
          ⌈ u ⌉ m +ᶜ ⌈ v ⌉ m +ᶜ ⌈ w ⌉ m)
   ⌈ K p _ t B u v ⌉ m with K-view p m
-  … | is-all _        = ⌈ u ⌉ m
-  … | is-some-yes _ _ = ω ·ᶜ (tailₘ (⌈ B ⌉ m) +ᶜ ⌈ u ⌉ m)
-  … | is-other _ _    =
+  … | is-all        = ⌈ u ⌉ m
+  … | is-some-yes _ = ω ·ᶜ (tailₘ (⌈ B ⌉ m) +ᶜ ⌈ u ⌉ m)
+  … | is-other _    =
         ω ·ᶜ (⌈ t ⌉ m +ᶜ tailₘ (⌈ B ⌉ m) +ᶜ ⌈ u ⌉ m +ᶜ ⌈ v ⌉ m)
   ⌈ []-cong _ _ _ _ _ _ ⌉ _ = 𝟘ᶜ
 
@@ -478,7 +480,7 @@ data _▸[_]_ {n : Nat} : Conₘ n → Mode → Term[ k ] n → Set (a ⊔ a′)
 
   rflₘ      : 𝟘ᶜ ▸[ m ] rfl
 
-  Jₘ        : erased-matches-for-J m ≤ᵉᵐ some
+  Jₘ        : ⦃ ok : erased-matches-for-J m ≤ᵉᵐ some ⦄
             → (erased-matches-for-J m ≡ some → ¬ (p ≡ 𝟘 × q ≡ 𝟘))
             → γ₁ ▸[ 𝟘ᵐ ] A
             → γ₂ ▸[ m ] t
@@ -488,7 +490,7 @@ data _▸[_]_ {n : Nat} : Conₘ n → Mode → Term[ k ] n → Set (a ⊔ a′)
             → γ₆ ▸[ m ] w
             → ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ▸[ m ] J p q A t B u v w
 
-  J₀ₘ₁      : erased-matches-for-J m ≡ some
+  J₀ₘ₁      : ⦃ ok : erased-matches-for-J m ≡ some ⦄
             → p ≡ 𝟘
             → q ≡ 𝟘
             → γ₁ ▸[ 𝟘ᵐ ] A
@@ -499,7 +501,7 @@ data _▸[_]_ {n : Nat} : Conₘ n → Mode → Term[ k ] n → Set (a ⊔ a′)
             → γ₆ ▸[ 𝟘ᵐ ] w
             → ω ·ᶜ (γ₃ +ᶜ γ₄) ▸[ m ] J p q A t B u v w
 
-  J₀ₘ₂      : erased-matches-for-J m ≡ all
+  J₀ₘ₂      : ⦃ ok : erased-matches-for-J m ≡ all ⦄
             → γ₁ ▸[ 𝟘ᵐ ] A
             → γ₂ ▸[ 𝟘ᵐ ] t
             → γ₃ ∙ ⌜ 𝟘ᵐ ⌝ · p ∙ ⌜ 𝟘ᵐ ⌝ · q ▸[ 𝟘ᵐ ] B
@@ -508,7 +510,7 @@ data _▸[_]_ {n : Nat} : Conₘ n → Mode → Term[ k ] n → Set (a ⊔ a′)
             → γ₆ ▸[ 𝟘ᵐ ] w
             → γ₄ ▸[ m ] J p q A t B u v w
 
-  Kₘ        : erased-matches-for-K m ≤ᵉᵐ some
+  Kₘ        : ⦃ ok : erased-matches-for-K m ≤ᵉᵐ some ⦄
             → (erased-matches-for-K m ≡ some → p ≢ 𝟘)
             → γ₁ ▸[ 𝟘ᵐ ] A
             → γ₂ ▸[ m ] t
@@ -517,7 +519,7 @@ data _▸[_]_ {n : Nat} : Conₘ n → Mode → Term[ k ] n → Set (a ⊔ a′)
             → γ₅ ▸[ m ] v
             → ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ▸[ m ] K p A t B u v
 
-  K₀ₘ₁      : erased-matches-for-K m ≡ some
+  K₀ₘ₁      : ⦃ ok : erased-matches-for-K m ≡ some ⦄
             → p ≡ 𝟘
             → γ₁ ▸[ 𝟘ᵐ ] A
             → γ₂ ▸[ 𝟘ᵐ ] t
@@ -526,7 +528,7 @@ data _▸[_]_ {n : Nat} : Conₘ n → Mode → Term[ k ] n → Set (a ⊔ a′)
             → γ₅ ▸[ 𝟘ᵐ ] v
             → ω ·ᶜ (γ₃ +ᶜ γ₄) ▸[ m ] K p A t B u v
 
-  K₀ₘ₂      : erased-matches-for-K m ≡ all
+  K₀ₘ₂      : ⦃ ok : erased-matches-for-K m ≡ all ⦄
             → γ₁ ▸[ 𝟘ᵐ ] A
             → γ₂ ▸[ 𝟘ᵐ ] t
             → γ₃ ∙ ⌜ 𝟘ᵐ ⌝ · p ▸[ 𝟘ᵐ ] B

--- a/Graded/Usage/Decidable.agda
+++ b/Graded/Usage/Decidable.agda
@@ -321,7 +321,7 @@ infix 10 ⌈⌉▸[_]?_
   inj₁ rflₘ
 
 ⌈⌉▸[ m ]? J p q A t B u v w with J-view p q m
-… | is-all ≡all =
+… | is-all ⦃ ok = ≡all ⦄ =
   case ⌈⌉▸[ 𝟘ᵐ ]? A ×-Dec-∀ ⌈⌉▸[ 𝟘ᵐ ]? t ×-Dec-∀ ⌈⌉▸[ m ]? u ×-Dec-∀
        ⌈⌉▸[ 𝟘ᵐ ]? v ×-Dec-∀ ⌈⌉▸[ 𝟘ᵐ ]? w ×-Dec-∀ ⌈⌉▸[ 𝟘ᵐ ]? B ×-Dec-∀
        Dec→Dec-∀ (⌜ 𝟘ᵐ ⌝ · p ≤? headₘ (tailₘ (⌈ B ⌉ 𝟘ᵐ))) ×-Dec-∀
@@ -337,23 +337,23 @@ infix 10 ⌈⌉▸[_]?_
 
             ⌈ B ⌉ 𝟘ᵐ                                                ∎
       in
-      inj₁ (J₀ₘ₂ ≡all ▸A ▸t (sub ▸B lemma) ▸u ▸v ▸w)
+      inj₁ (J₀ₘ₂ ▸A ▸t (sub ▸B lemma) ▸u ▸v ▸w)
     (inj₂ problem) → inj₂ λ _ ▸J →
       case inv-usage-J ▸J of λ where
-        (invUsageJ₀₂ _ ▸A ▸t ▸B ▸u ▸v ▸w _) →
+        (invUsageJ₀₂ ▸A ▸t ▸B ▸u ▸v ▸w _) →
           let ≤⌈B⌉𝟘ᵐ = usage-upper-bound no-sink-or-≤𝟘 ▸B in
           problem _
             ( ▸A , ▸t , ▸u , ▸v , ▸w , ▸B
             , headₘ-monotone (tailₘ-monotone ≤⌈B⌉𝟘ᵐ)
             , headₘ-monotone ≤⌈B⌉𝟘ᵐ
             )
-        (invUsageJ ≤some _ _ _ _ _ _ _ _) →
+        (invUsageJ ⦃ ≤some ⦄ _ _ _ _ _ _ _ _) →
           case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
-        (invUsageJ₀₁ ≡some _ _ _ _ _ _ _ _ _) →
+        (invUsageJ₀₁ ⦃ ≡some ⦄ _ _ _ _ _ _ _ _ _) →
           case trans (sym ≡some) ≡all of λ ()
   where
   open ≤ᶜ-reasoning
-… | is-some-yes ≡some (refl , refl) =
+… | is-some-yes ⦃ ok = ≡some ⦄ (refl , refl) =
   case ⌈⌉▸[ 𝟘ᵐ ]? A ×-Dec-∀ ⌈⌉▸[ 𝟘ᵐ ]? t ×-Dec-∀ ⌈⌉▸[ m ]? u ×-Dec-∀
        ⌈⌉▸[ 𝟘ᵐ ]? v ×-Dec-∀ ⌈⌉▸[ 𝟘ᵐ ]? w ×-Dec-∀ ⌈⌉▸[ m ]? B ×-Dec-∀
        Dec→Dec-∀ (𝟘 ≤? headₘ (tailₘ (⌈ B ⌉ m))) ×-Dec-∀
@@ -369,23 +369,23 @@ infix 10 ⌈⌉▸[_]?_
 
             ⌈ B ⌉ m                                              ∎
       in
-      inj₁ (J₀ₘ₁ ≡some refl refl ▸A ▸t (sub ▸B lemma) ▸u ▸v ▸w)
+      inj₁ (J₀ₘ₁ refl refl ▸A ▸t (sub ▸B lemma) ▸u ▸v ▸w)
     (inj₂ problem) → inj₂ λ _ ▸J →
       case inv-usage-J ▸J of λ where
-        (invUsageJ₀₁ _ _ _ ▸A ▸t ▸B ▸u ▸v ▸w _) →
+        (invUsageJ₀₁ _ _ ▸A ▸t ▸B ▸u ▸v ▸w _) →
           let ≤⌈B⌉m = usage-upper-bound no-sink-or-≤𝟘 ▸B in
           problem _
             ( ▸A , ▸t , ▸u , ▸v , ▸w , ▸B
             , headₘ-monotone (tailₘ-monotone ≤⌈B⌉m)
             , headₘ-monotone ≤⌈B⌉m
             )
-        (invUsageJ _ ≢𝟘 _ _ _ _ _ _ _) →
+        (invUsageJ ≢𝟘 _ _ _ _ _ _ _) →
           ⊥-elim $ ≢𝟘 ≡some (refl , refl)
-        (invUsageJ₀₂ ≡all _ _ _ _ _ _ _) →
+        (invUsageJ₀₂ ⦃ ≡all ⦄ _ _ _ _ _ _ _) →
           case trans (sym ≡all) ≡some of λ ()
   where
   open ≤ᶜ-reasoning
-… | is-other ≤some ≢𝟘 =
+… | is-other ⦃ ok = ≤some ⦄ ≢𝟘 =
   case ⌈⌉▸[ 𝟘ᵐ ]? A ×-Dec-∀ ⌈⌉▸[ m ]? t ×-Dec-∀ ⌈⌉▸[ m ]? u ×-Dec-∀
        ⌈⌉▸[ m ]? v ×-Dec-∀ ⌈⌉▸[ m ]? w ×-Dec-∀ ⌈⌉▸[ m ]? B ×-Dec-∀
        Dec→Dec-∀ (⌜ m ⌝ · p ≤? headₘ (tailₘ (⌈ B ⌉ m))) ×-Dec-∀
@@ -401,25 +401,25 @@ infix 10 ⌈⌉▸[_]?_
 
             ⌈ B ⌉ m                                              ∎
       in
-      inj₁ (Jₘ ≤some ≢𝟘 ▸A ▸t (sub ▸B lemma) ▸u ▸v ▸w)
+      inj₁ (Jₘ ≢𝟘 ▸A ▸t (sub ▸B lemma) ▸u ▸v ▸w)
     (inj₂ problem) → inj₂ λ _ ▸J →
       case inv-usage-J ▸J of λ where
-        (invUsageJ _ _ ▸A ▸t ▸B ▸u ▸v ▸w _) →
+        (invUsageJ _ ▸A ▸t ▸B ▸u ▸v ▸w _) →
           let ≤⌈B⌉m = usage-upper-bound no-sink-or-≤𝟘 ▸B in
           problem _
             ( ▸A , ▸t , ▸u , ▸v , ▸w , ▸B
             , headₘ-monotone (tailₘ-monotone ≤⌈B⌉m)
             , headₘ-monotone ≤⌈B⌉m
             )
-        (invUsageJ₀₁ ≡some p≡𝟘 q≡𝟘 _ _ _ _ _ _ _) →
+        (invUsageJ₀₁ ⦃ ≡some ⦄ p≡𝟘 q≡𝟘 _ _ _ _ _ _ _) →
           ⊥-elim $ ≢𝟘 ≡some (p≡𝟘 , q≡𝟘)
-        (invUsageJ₀₂ ≡all _ _ _ _ _ _ _) →
+        (invUsageJ₀₂ ⦃ ≡all ⦄ _ _ _ _ _ _ _) →
           case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
   where
   open ≤ᶜ-reasoning
 
 ⌈⌉▸[ m ]? K p A t B u v with K-view p m
-… | is-all ≡all =
+… | is-all ⦃ ok = ≡all ⦄ =
   case ⌈⌉▸[ 𝟘ᵐ ]? A ×-Dec-∀ ⌈⌉▸[ 𝟘ᵐ ]? t ×-Dec-∀ ⌈⌉▸[ m ]? u ×-Dec-∀
        ⌈⌉▸[ 𝟘ᵐ ]? v ×-Dec-∀ ⌈⌉▸[ 𝟘ᵐ ]? B ×-Dec-∀
        Dec→Dec-∀ (⌜ 𝟘ᵐ ⌝ · p ≤? headₘ (⌈ B ⌉ 𝟘ᵐ)) of λ where
@@ -429,21 +429,21 @@ infix 10 ⌈⌉▸[_]?_
             tailₘ (⌈ B ⌉ 𝟘ᵐ) ∙ headₘ (⌈ B ⌉ 𝟘ᵐ)  ≡⟨ headₘ-tailₘ-correct _ ⟩
             ⌈ B ⌉ 𝟘ᵐ                              ∎
       in
-      inj₁ (K₀ₘ₂ ≡all ▸A ▸t (sub ▸B lemma) ▸u ▸v)
+      inj₁ (K₀ₘ₂ ▸A ▸t (sub ▸B lemma) ▸u ▸v)
     (inj₂ problem) → inj₂ λ _ ▸K →
       case inv-usage-K ▸K of λ where
-        (invUsageK₀₂ _ ▸A ▸t ▸B ▸u ▸v _) →
+        (invUsageK₀₂ ▸A ▸t ▸B ▸u ▸v _) →
           problem _
             ( ▸A , ▸t , ▸u , ▸v , ▸B
             , headₘ-monotone (usage-upper-bound no-sink-or-≤𝟘 ▸B)
             )
-        (invUsageK ≤some _ _ _ _ _ _ _) →
+        (invUsageK ⦃ ≤some ⦄ _ _ _ _ _ _ _) →
           case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
-        (invUsageK₀₁ ≡some _ _ _ _ _ _ _) →
+        (invUsageK₀₁ ⦃ ≡some ⦄ _ _ _ _ _ _ _) →
           case trans (sym ≡some) ≡all of λ ()
   where
   open ≤ᶜ-reasoning
-… | is-some-yes ≡some refl =
+… | is-some-yes ⦃ ok = ≡some ⦄ refl =
   case ⌈⌉▸[ 𝟘ᵐ ]? A ×-Dec-∀ ⌈⌉▸[ 𝟘ᵐ ]? t ×-Dec-∀ ⌈⌉▸[ m ]? u ×-Dec-∀
        ⌈⌉▸[ 𝟘ᵐ ]? v ×-Dec-∀ ⌈⌉▸[ m ]? B ×-Dec-∀
        Dec→Dec-∀ (𝟘 ≤? headₘ (⌈ B ⌉ m)) of λ where
@@ -453,21 +453,21 @@ infix 10 ⌈⌉▸[_]?_
             tailₘ (⌈ B ⌉ m) ∙ headₘ (⌈ B ⌉ m)  ≡⟨ headₘ-tailₘ-correct _ ⟩
             ⌈ B ⌉ m                            ∎
       in
-      inj₁ (K₀ₘ₁ ≡some refl ▸A ▸t (sub ▸B lemma) ▸u ▸v)
+      inj₁ (K₀ₘ₁ refl ▸A ▸t (sub ▸B lemma) ▸u ▸v)
     (inj₂ problem) → inj₂ λ _ ▸K →
       case inv-usage-K ▸K of λ where
-        (invUsageK₀₁ _ _ ▸A ▸t ▸B ▸u ▸v _) →
+        (invUsageK₀₁ _ ▸A ▸t ▸B ▸u ▸v _) →
           problem _
             ( ▸A , ▸t , ▸u , ▸v , ▸B
             , headₘ-monotone (usage-upper-bound no-sink-or-≤𝟘 ▸B)
             )
-        (invUsageK _ ≢𝟘 _ _ _ _ _ _) →
+        (invUsageK ≢𝟘 _ _ _ _ _ _) →
           ⊥-elim $ ≢𝟘 ≡some refl
-        (invUsageK₀₂ ≡all _ _ _ _ _ _) →
+        (invUsageK₀₂ ⦃ ≡all ⦄ _ _ _ _ _ _) →
           case trans (sym ≡all) ≡some of λ ()
   where
   open ≤ᶜ-reasoning
-… | is-other ≤some ≢𝟘 =
+… | is-other ⦃ ok = ≤some ⦄ ≢𝟘 =
   case ⌈⌉▸[ 𝟘ᵐ ]? A ×-Dec-∀ ⌈⌉▸[ m ]? t ×-Dec-∀ ⌈⌉▸[ m ]? u ×-Dec-∀
        ⌈⌉▸[ m ]? v ×-Dec-∀ ⌈⌉▸[ m ]? B ×-Dec-∀
        Dec→Dec-∀ (⌜ m ⌝ · p ≤? headₘ (⌈ B ⌉ m)) of λ where
@@ -477,17 +477,17 @@ infix 10 ⌈⌉▸[_]?_
             tailₘ (⌈ B ⌉ m) ∙ headₘ (⌈ B ⌉ m)  ≡⟨ headₘ-tailₘ-correct _ ⟩
             ⌈ B ⌉ m                            ∎
       in
-      inj₁ (Kₘ ≤some ≢𝟘 ▸A ▸t (sub ▸B lemma) ▸u ▸v)
+      inj₁ (Kₘ ≢𝟘 ▸A ▸t (sub ▸B lemma) ▸u ▸v)
     (inj₂ problem) → inj₂ λ _ ▸K →
       case inv-usage-K ▸K of λ where
-        (invUsageK _ _ ▸A ▸t ▸B ▸u ▸v ▸w) →
+        (invUsageK _ ▸A ▸t ▸B ▸u ▸v ▸w) →
           problem _
             ( ▸A , ▸t , ▸u , ▸v , ▸B
             , headₘ-monotone (usage-upper-bound no-sink-or-≤𝟘 ▸B)
             )
-        (invUsageK₀₁ ≡some p≡𝟘 _ _ _ _ _ _) →
+        (invUsageK₀₁ ⦃ ≡some ⦄ p≡𝟘 _ _ _ _ _ _) →
           ⊥-elim $ ≢𝟘 ≡some p≡𝟘
-        (invUsageK₀₂ ≡all _ _ _ _ _ _) →
+        (invUsageK₀₂ ⦃ ≡all ⦄ _ _ _ _ _ _) →
           case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
   where
   open ≤ᶜ-reasoning

--- a/Graded/Usage/Erased-matches.agda
+++ b/Graded/Usage/Erased-matches.agda
@@ -131,3 +131,29 @@ opaque
   some≤ᵉᵐ→ {(none)} ()
   some≤ᵉᵐ→ {(all)}  _ = inj₁ refl
   some≤ᵉᵐ→ {(some)} _ = inj₂ refl
+
+opaque
+
+  -- Erased-matches is a set.
+
+  Erased-matches-set :
+    (p q : em₁ ≡ em₂) → p ≡ q
+  Erased-matches-set {(none)} {(none)} refl refl = refl
+  Erased-matches-set {(all)} {not-none x₁} refl refl = refl
+  Erased-matches-set {(some)} {not-none x₁} refl refl = refl
+  Erased-matches-set {(none)} {not-none x} ()
+  Erased-matches-set {not-none x} {(none)} ()
+
+opaque
+
+  -- The order for Erased-matches is propositional
+
+  ≤ᵉᵐ-propositional :
+    (p q : em₁ ≤ᵉᵐ em₂) → p ≡ q
+  ≤ᵉᵐ-propositional {(none)} tt tt = refl
+  ≤ᵉᵐ-propositional {(all)} {(none)} ()
+  ≤ᵉᵐ-propositional {(some)} {(none)} ()
+  ≤ᵉᵐ-propositional {(all)} {(all)} tt tt = refl
+  ≤ᵉᵐ-propositional {(all)} {(some)} ()
+  ≤ᵉᵐ-propositional {(some)} {(all)} tt tt = refl
+  ≤ᵉᵐ-propositional {(some)} {(some)} tt tt = refl

--- a/Graded/Usage/Inversion.agda
+++ b/Graded/Usage/Inversion.agda
@@ -21,6 +21,7 @@ open Usage-restrictions R
 
 open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
+open import Graded.Modality.Omega-instances
 open import Graded.Usage R
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Restrictions.Instance R
@@ -639,7 +640,7 @@ data InvUsageJ
        (B : Term (2+ n)) (u t′ v : Term n) : Set (a ⊔ a′) where
   invUsageJ :
     {γ₁ γ₂ γ₃ γ₄ γ₅ γ₆ : Conₘ n} →
-    erased-matches-for-J m ≤ᵉᵐ some →
+    ⦃ ≤some : erased-matches-for-J m ≤ᵉᵐ some ⦄ →
     (erased-matches-for-J m ≡ some → ¬ (p ≡ 𝟘 × q ≡ 𝟘)) →
     γ₁ ▸[ 𝟘ᵐ ] A →
     γ₂ ▸[ m ] t →
@@ -651,7 +652,7 @@ data InvUsageJ
     InvUsageJ γ m p q A t B u t′ v
   invUsageJ₀₁ :
     {γ₁ γ₂ γ₃ γ₄ γ₅ γ₆ : Conₘ n} →
-    erased-matches-for-J m ≡ some →
+    ⦃ ≡some : erased-matches-for-J m ≡ some ⦄ →
     p ≡ 𝟘 →
     q ≡ 𝟘 →
     γ₁ ▸[ 𝟘ᵐ ] A →
@@ -664,7 +665,7 @@ data InvUsageJ
     InvUsageJ γ m p q A t B u t′ v
   invUsageJ₀₂ :
     {γ₁ γ₂ γ₃ γ₄ γ₅ γ₆ : Conₘ n} →
-    erased-matches-for-J m ≡ all →
+    ⦃ ≡all : erased-matches-for-J m ≡ all ⦄ →
     γ₁ ▸[ 𝟘ᵐ ] A →
     γ₂ ▸[ 𝟘ᵐ ] t →
     γ₃ ∙ ⌜ 𝟘ᵐ ⌝ · p ∙ ⌜ 𝟘ᵐ ⌝ · q ▸[ 𝟘ᵐ ] B →
@@ -678,19 +679,19 @@ data InvUsageJ
 
 inv-usage-J :
   γ ▸[ m ] J p q A t B u t′ v → InvUsageJ γ m p q A t B u t′ v
-inv-usage-J (Jₘ ok₁ ok₂ ▸A ▸t ▸B ▸u ▸t′ ▸v) =
-  invUsageJ ok₁ ok₂ ▸A ▸t ▸B ▸u ▸t′ ▸v ≤ᶜ-refl
-inv-usage-J (J₀ₘ₁ ok p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸t′ ▸v) =
-  invUsageJ₀₁ ok p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸t′ ▸v ≤ᶜ-refl
-inv-usage-J (J₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸t′ ▸v) =
-  invUsageJ₀₂ ok ▸A ▸t ▸B ▸u ▸t′ ▸v ≤ᶜ-refl
+inv-usage-J (Jₘ ok ▸A ▸t ▸B ▸u ▸t′ ▸v) =
+  invUsageJ ok ▸A ▸t ▸B ▸u ▸t′ ▸v ≤ᶜ-refl
+inv-usage-J (J₀ₘ₁ p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸t′ ▸v) =
+  invUsageJ₀₁ p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸t′ ▸v ≤ᶜ-refl
+inv-usage-J (J₀ₘ₂ ▸A ▸t ▸B ▸u ▸t′ ▸v) =
+  invUsageJ₀₂ ▸A ▸t ▸B ▸u ▸t′ ▸v ≤ᶜ-refl
 inv-usage-J (sub γ′▸ γ≤γ′) with inv-usage-J γ′▸
-... | invUsageJ ok₁ ok₂ ▸t ▸B ▸u ▸t′ ▸v ▸A γ′≤ =
-  invUsageJ ok₁ ok₂ ▸t ▸B ▸u ▸t′ ▸v ▸A (≤ᶜ-trans γ≤γ′ γ′≤)
-... | invUsageJ₀₁ ok p≡𝟘 q≡𝟘 ▸t ▸B ▸u ▸t′ ▸v ▸A γ′≤ =
-  invUsageJ₀₁ ok p≡𝟘 q≡𝟘 ▸t ▸B ▸u ▸t′ ▸v ▸A (≤ᶜ-trans γ≤γ′ γ′≤)
-... | invUsageJ₀₂ ok ▸t ▸B ▸u ▸t′ ▸v ▸A γ′≤ =
-  invUsageJ₀₂ ok ▸t ▸B ▸u ▸t′ ▸v ▸A (≤ᶜ-trans γ≤γ′ γ′≤)
+... | invUsageJ ok ▸t ▸B ▸u ▸t′ ▸v ▸A γ′≤ =
+  invUsageJ ok ▸t ▸B ▸u ▸t′ ▸v ▸A (≤ᶜ-trans γ≤γ′ γ′≤)
+... | invUsageJ₀₁ p≡𝟘 q≡𝟘 ▸t ▸B ▸u ▸t′ ▸v ▸A γ′≤ =
+  invUsageJ₀₁ p≡𝟘 q≡𝟘 ▸t ▸B ▸u ▸t′ ▸v ▸A (≤ᶜ-trans γ≤γ′ γ′≤)
+... | invUsageJ₀₂ ▸t ▸B ▸u ▸t′ ▸v ▸A γ′≤ =
+  invUsageJ₀₂ ▸t ▸B ▸u ▸t′ ▸v ▸A (≤ᶜ-trans γ≤γ′ γ′≤)
 
 -- A type used to state inv-usage-K.
 
@@ -699,7 +700,7 @@ data InvUsageK
        (B : Term (1+ n)) (u v : Term n) : Set (a ⊔ a′) where
   invUsageK :
     {γ₁ γ₂ γ₃ γ₄ γ₅ : Conₘ n} →
-    erased-matches-for-K m ≤ᵉᵐ some →
+    ⦃ ≤some : erased-matches-for-K m ≤ᵉᵐ some ⦄ →
     (erased-matches-for-K m ≡ some → p ≢ 𝟘) →
     γ₁ ▸[ 𝟘ᵐ ] A →
     γ₂ ▸[ m ] t →
@@ -710,7 +711,7 @@ data InvUsageK
     InvUsageK γ m p A t B u v
   invUsageK₀₁ :
     {γ₁ γ₂ γ₃ γ₄ γ₅ : Conₘ n} →
-    erased-matches-for-K m ≡ some →
+    ⦃ ≡some : erased-matches-for-K m ≡ some ⦄ →
     p ≡ 𝟘 →
     γ₁ ▸[ 𝟘ᵐ ] A →
     γ₂ ▸[ 𝟘ᵐ ] t →
@@ -721,7 +722,7 @@ data InvUsageK
     InvUsageK γ m p A t B u v
   invUsageK₀₂ :
     {γ₁ γ₂ γ₃ γ₄ γ₅ : Conₘ n} →
-    erased-matches-for-K m ≡ all →
+    ⦃ ≡all : erased-matches-for-K m ≡ all ⦄ →
     γ₁ ▸[ 𝟘ᵐ ] A →
     γ₂ ▸[ 𝟘ᵐ ] t →
     γ₃ ∙ ⌜ 𝟘ᵐ ⌝ · p ▸[ 𝟘ᵐ ] B →
@@ -733,19 +734,19 @@ data InvUsageK
 -- A usage inversion lemma for K.
 
 inv-usage-K : γ ▸[ m ] K p A t B u v → InvUsageK γ m p A t B u v
-inv-usage-K (Kₘ ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v) =
-  invUsageK ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v ≤ᶜ-refl
-inv-usage-K (K₀ₘ₁ ok p≡𝟘 ▸A ▸t ▸B ▸u ▸v) =
-  invUsageK₀₁ ok p≡𝟘 ▸A ▸t ▸B ▸u ▸v ≤ᶜ-refl
-inv-usage-K (K₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸v) =
-  invUsageK₀₂ ok ▸A ▸t ▸B ▸u ▸v ≤ᶜ-refl
+inv-usage-K (Kₘ ok ▸A ▸t ▸B ▸u ▸v) =
+  invUsageK ok ▸A ▸t ▸B ▸u ▸v ≤ᶜ-refl
+inv-usage-K (K₀ₘ₁ p≡𝟘 ▸A ▸t ▸B ▸u ▸v) =
+  invUsageK₀₁ p≡𝟘 ▸A ▸t ▸B ▸u ▸v ≤ᶜ-refl
+inv-usage-K (K₀ₘ₂ ▸A ▸t ▸B ▸u ▸v) =
+  invUsageK₀₂ ▸A ▸t ▸B ▸u ▸v ≤ᶜ-refl
 inv-usage-K (sub γ′▸ γ≤γ′) with inv-usage-K γ′▸
-... | invUsageK ok₁ ok₂ ▸t ▸B ▸u ▸v ▸A γ′≤ =
-  invUsageK ok₁ ok₂ ▸t ▸B ▸u ▸v ▸A (≤ᶜ-trans γ≤γ′ γ′≤)
-... | invUsageK₀₁ ok p≡𝟘 ▸t ▸B ▸u ▸v ▸A γ′≤ =
-  invUsageK₀₁ ok p≡𝟘 ▸t ▸B ▸u ▸v ▸A (≤ᶜ-trans γ≤γ′ γ′≤)
-... | invUsageK₀₂ ok ▸t ▸B ▸u ▸v ▸A γ′≤ =
-  invUsageK₀₂ ok ▸t ▸B ▸u ▸v ▸A (≤ᶜ-trans γ≤γ′ γ′≤)
+... | invUsageK ok ▸t ▸B ▸u ▸v ▸A γ′≤ =
+  invUsageK ok ▸t ▸B ▸u ▸v ▸A (≤ᶜ-trans γ≤γ′ γ′≤)
+... | invUsageK₀₁ p≡𝟘 ▸t ▸B ▸u ▸v ▸A γ′≤ =
+  invUsageK₀₁ p≡𝟘 ▸t ▸B ▸u ▸v ▸A (≤ᶜ-trans γ≤γ′ γ′≤)
+... | invUsageK₀₂ ▸t ▸B ▸u ▸v ▸A γ′≤ =
+  invUsageK₀₂ ▸t ▸B ▸u ▸v ▸A (≤ᶜ-trans γ≤γ′ γ′≤)
 
 -- A type used to state inv-usage-[]-cong.
 

--- a/Graded/Usage/Properties.agda
+++ b/Graded/Usage/Properties.agda
@@ -26,9 +26,11 @@ open import Graded.Usage R
 open import Graded.Usage.Inversion R
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Restrictions.Natrec 𝕄
+open import Graded.Usage.Restrictions.JK 𝕄
 import Graded.Usage.Restrictions.Instance
 open import Graded.Usage.Weakening R
 open import Graded.Modality.Nr-instances
+open import Graded.Modality.Omega-instances
 open import Graded.Modality.Properties 𝕄
 
 import Definition.Typed
@@ -255,92 +257,109 @@ opaque mutual
         sub-≈ᶜ (Id₀ₘ ok ▸A ▸t ▸u) (·ᶜ-zeroʳ _)
       rflₘ →
         sub-≈ᶜ rflₘ (·ᶜ-zeroʳ _)
-      (Jₘ {p} {q} {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} x x₁ ▸A ▸t ▸B ▸u ▸v ▸w) →
+      (Jₘ {p} {q} {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} ⦃ (ok₁) ⦄ x ▸A ▸t ▸B ▸u ▸v ▸w) →
         case J-view p q (m′ ·ᵐ m) of λ where
-          (is-all x₂) →
+          (is-all) →
             let ▸B′ = sub-≈ᶜ (▸-𝟘 ▸B) (≈ᶜ-refl ∙ lemma″ ∙ lemma″)
-            in  sub (J₀ₘ₂ x₂ ▸A (▸-𝟘 ▸t) ▸B′ (▸-· ▸u) (▸-𝟘 ▸v) (▸-𝟘 ▸w)) $ begin
+            in  sub (J₀ₘ₂ ▸A (▸-𝟘 ▸t) ▸B′ (▸-· ▸u) (▸-𝟘 ▸v) (▸-𝟘 ▸w)) $ begin
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)       ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₄ +ᶜ γ₅ +ᶜ γ₆)             ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ+ᶜ≤ω·ᶜˡ  ⟩
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ γ₄                           ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ-decreasing ⟩
               ⌜ m′ ⌝ ·ᶜ γ₄                                ∎
-          (is-some-yes x₂ (refl , refl)) →
+          (is-some-yes ⦃ (ok₂) ⦄ (refl , refl)) →
             let ▸B′ = sub-≈ᶜ (▸-· ▸B) (≈ᶜ-refl ∙ lemma′ ∙ lemma′)
-            in  sub (J₀ₘ₁ x₂ refl refl ▸A (▸-𝟘 ▸t) ▸B′ (▸-· ▸u) (▸-𝟘 ▸v) (▸-𝟘 ▸w)) $ begin
+                ok₁′ = erased-matches-JK-≤-some-JK-with-omega ⦃ ok₁ ⦄
+                ok₂′ = erased-matches-JK-≤-some-JK-with-omega
+                         ⦃ erased-matches-JK-≡-some-≤-some ⦃ ok₂ ⦄ ⦄
+            in  sub (J₀ₘ₁ refl refl ▸A (▸-𝟘 ▸t) ▸B′ (▸-· ▸u) (▸-𝟘 ▸v) (▸-𝟘 ▸w)) $ begin
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)       ≈˘⟨ ·ᶜ-congˡ (·ᶜ-congˡ (+ᶜ-assoc _ _ _)) ⟩
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ ((γ₃ +ᶜ γ₄) +ᶜ γ₅ +ᶜ γ₆)     ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄)                  ≈⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
               ω ·ᶜ ⌜ m′ ⌝ ·ᶜ (γ₃ +ᶜ γ₄)                  ≈⟨ ·ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _) ⟩
+              ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄)        ≈⟨ ·ᶜ-congʳ (ω≡ω ok₁′ ok₂′) ⟩
               ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄)        ∎
-          (is-other x₂ x₃) →
-            sub (Jₘ x₂ x₃ ▸A (▸-· ▸t) (▸-·-∙₂ ▸B) (▸-· ▸u) (▸-· ▸v) (▸-· ▸w)) $ begin
+          (is-other ⦃ (ok₂) ⦄ x) →
+            sub (Jₘ x ▸A (▸-· ▸t) (▸-·-∙₂ ▸B) (▸-· ▸u) (▸-· ▸v) (▸-· ▸w)) $ begin
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)                                         ≈⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
               ω ·ᶜ (⌜ m′ ⌝ ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆))                                       ≈⟨ ·ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _) ⟩
               ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₂ +ᶜ ⌜ m′ ⌝ ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆))                             ≈⟨ ·ᶜ-congˡ (+ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _)) ⟩
               ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₂ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ (γ₄ +ᶜ γ₅ +ᶜ γ₆))                   ≈⟨ ·ᶜ-congˡ (+ᶜ-congˡ (+ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _))) ⟩
               ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₂ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄ +ᶜ ⌜ m′ ⌝ ·ᶜ (γ₅ +ᶜ γ₆))         ≈⟨ ·ᶜ-congˡ (+ᶜ-congˡ (+ᶜ-congˡ (+ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _)))) ⟩
+              ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₂ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₅ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₆) ≈⟨ ·ᶜ-congʳ (ω≡ω erased-matches-JK-≤-some-JK-with-omega
+                                                                                                             erased-matches-JK-≤-some-JK-with-omega) ⟩
               ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₂ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₅ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₆) ∎
-      (J₀ₘ₁ {γ₃} {γ₄} x refl refl ▸A ▸t ▸B ▸u ▸v ▸w) →
-        case erased-matches-for-J-some·ᵐ {m′ = m′} x of λ where
+      (J₀ₘ₁ {γ₃} {γ₄} ⦃ (ok) ⦄ refl refl ▸A ▸t ▸B ▸u ▸v ▸w) →
+        case erased-matches-for-J-some·ᵐ {m′ = m′} ok of λ where
           (inj₁ ≡all) →
             let ▸B′ = ▸-𝟘 ▸B
-            in  sub (J₀ₘ₂ ≡all ▸A ▸t ▸B′ (▸-· ▸u) ▸v ▸w) $ begin
+            in  sub (J₀ₘ₂ ⦃ ≡all ⦄ ▸A ▸t ▸B′ (▸-· ▸u) ▸v ▸w) $ begin
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄) ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ γ₄         ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ-decreasing ⟩
               ⌜ m′ ⌝ ·ᶜ γ₄              ∎
           (inj₂ ≡some) →
             let ▸B′ = sub-≈ᶜ (▸-· ▸B) (≈ᶜ-refl ∙ sym (·-zeroʳ _) ∙ sym (·-zeroʳ _))
-            in  sub (J₀ₘ₁ ≡some refl refl ▸A ▸t ▸B′ (▸-· ▸u) ▸v ▸w) $ begin
+                instance _ = ≡some
+            in  sub (J₀ₘ₁ refl refl ▸A ▸t ▸B′ (▸-· ▸u) ▸v ▸w) $ begin
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄)           ≈⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
               ω ·ᶜ ⌜ m′ ⌝ ·ᶜ (γ₃ +ᶜ γ₄)           ≈⟨ ·ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _) ⟩
+              ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄) ≈⟨ ·ᶜ-congʳ (ω≡ω erased-matches-JK-≤-some-JK-with-omega
+                                                              erased-matches-JK-≤-some-JK-with-omega) ⟩
               ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄) ∎
-      (J₀ₘ₂ x ▸A ▸t ▸B ▸u ▸v ▸w) →
-        J₀ₘ₂ (erased-matches-for-J-all·ᵐ x) ▸A ▸t ▸B (▸-· ▸u) ▸v ▸w
-      (Kₘ {p} {γ₂} {γ₃} {γ₄} {γ₅} x x₁ ▸A ▸t ▸B ▸u ▸v) →
+      (J₀ₘ₂ ⦃ ok ⦄ ▸A ▸t ▸B ▸u ▸v ▸w) →
+        J₀ₘ₂ ⦃ erased-matches-for-J-all·ᵐ ok ⦄ ▸A ▸t ▸B (▸-· ▸u) ▸v ▸w
+      (Kₘ {p} {γ₂} {γ₃} {γ₄} {γ₅} ⦃ (ok₁) ⦄ x ▸A ▸t ▸B ▸u ▸v) →
         case K-view p (m′ ·ᵐ m) of λ where
-          (is-all x₂) →
+          (is-all) →
             let ▸B′ = sub-≈ᶜ (▸-𝟘 ▸B) (≈ᶜ-refl ∙ lemma″)
-            in  sub (K₀ₘ₂ x₂ ▸A (▸-𝟘 ▸t) ▸B′ (▸-· ▸u) (▸-𝟘 ▸v)) $ begin
+            in  sub (K₀ₘ₂ ▸A (▸-𝟘 ▸t) ▸B′ (▸-· ▸u) (▸-𝟘 ▸v)) $ begin
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅)       ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₄ +ᶜ γ₅)             ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ γ₄                     ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ-decreasing ⟩
               ⌜ m′ ⌝ ·ᶜ γ₄                          ∎
-          (is-some-yes x₂ refl) →
+          (is-some-yes ⦃ (ok₂) ⦄ refl) →
             let ▸B′ = sub-≈ᶜ (▸-· ▸B) (≈ᶜ-refl ∙ lemma′)
-            in  sub (K₀ₘ₁ x₂ refl ▸A (▸-𝟘 ▸t) ▸B′ (▸-· ▸u) (▸-𝟘 ▸v)) $ begin
+                ok₁′ = erased-matches-JK-≤-some-JK-with-omega ⦃ ok₁ ⦄
+                ok₂′ = erased-matches-JK-≤-some-JK-with-omega
+                         ⦃ erased-matches-JK-≡-some-≤-some ⦃ ok₂ ⦄ ⦄
+            in  sub (K₀ₘ₁ refl ▸A (▸-𝟘 ▸t) ▸B′ (▸-· ▸u) (▸-𝟘 ▸v)) $ begin
              ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
              ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅)       ≈˘⟨ ·ᶜ-congˡ (·ᶜ-congˡ (+ᶜ-assoc _ _ _)) ⟩
              ⌜ m′ ⌝ ·ᶜ ω ·ᶜ ((γ₃ +ᶜ γ₄) +ᶜ γ₅)     ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
              ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄)             ≈⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
              ω ·ᶜ ⌜ m′ ⌝ ·ᶜ (γ₃ +ᶜ γ₄)             ≈⟨ ·ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _) ⟩
-             ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄) ∎
-          (is-other x₂ x₃) →
-            sub (Kₘ x₂ x₃ ▸A (▸-· ▸t) (▸-·-∙ ▸B) (▸-· ▸u) (▸-· ▸v)) $ begin
+             ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄)   ≈⟨ ·ᶜ-congʳ (ω≡ω ok₁′ ok₂′) ⟩
+             ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄)   ∎
+          (is-other ⦃ (ok₂) ⦄ x) →
+            sub (Kₘ x ▸A (▸-· ▸t) (▸-·-∙ ▸B) (▸-· ▸u) (▸-· ▸v)) $ begin
             ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅)                               ≈⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
             ω ·ᶜ ⌜ m′ ⌝ ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅)                               ≈⟨ ·ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _) ⟩
             ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₂ +ᶜ ⌜ m′ ⌝ ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅))                   ≈⟨ ·ᶜ-congˡ (+ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _)) ⟩
             ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₂ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ (γ₄ +ᶜ γ₅))         ≈⟨ ·ᶜ-congˡ (+ᶜ-congˡ (+ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _))) ⟩
+            ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₂ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₅) ≈⟨ ·ᶜ-congʳ (ω≡ω erased-matches-JK-≤-some-JK-with-omega
+                                                                                              erased-matches-JK-≤-some-JK-with-omega) ⟩
             ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₂ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₅) ∎
-      (K₀ₘ₁ {γ₃} {γ₄} x refl ▸A ▸t ▸B ▸u ▸v) →
-        case erased-matches-for-K-some·ᵐ {m′ = m′} x of λ where
+      (K₀ₘ₁ {γ₃} {γ₄} ⦃ ok ⦄ refl ▸A ▸t ▸B ▸u ▸v) →
+        case erased-matches-for-K-some·ᵐ {m′ = m′} ok of λ where
           (inj₁ ≡all) →
             let ▸B′ = ▸-𝟘 ▸B
-            in  sub (K₀ₘ₂ ≡all ▸A ▸t ▸B′ (▸-· ▸u) ▸v) $ begin
+            in  sub (K₀ₘ₂ ⦃ ≡all ⦄ ▸A ▸t ▸B′ (▸-· ▸u) ▸v) $ begin
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄) ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ γ₄         ≤⟨ ·ᶜ-monotoneʳ ω·ᶜ-decreasing ⟩
               ⌜ m′ ⌝ ·ᶜ γ₄              ∎
           (inj₂ ≡some) →
             let ▸B′ = sub-≈ᶜ (▸-· ▸B) (≈ᶜ-refl ∙ sym (·-zeroʳ _))
-            in  sub (K₀ₘ₁ ≡some refl ▸A ▸t ▸B′ (▸-· ▸u) ▸v) $ begin
+                instance _ = ≡some
+            in  sub (K₀ₘ₁ refl ▸A ▸t ▸B′ (▸-· ▸u) ▸v) $ begin
               ⌜ m′ ⌝ ·ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄)           ≈⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
               ω ·ᶜ ⌜ m′ ⌝ ·ᶜ (γ₃ +ᶜ γ₄)           ≈⟨ ·ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _) ⟩
+              ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄) ≈⟨ ·ᶜ-congʳ (ω≡ω erased-matches-JK-≤-some-JK-with-omega
+                                                              erased-matches-JK-≤-some-JK-with-omega) ⟩
               ω ·ᶜ (⌜ m′ ⌝ ·ᶜ γ₃ +ᶜ ⌜ m′ ⌝ ·ᶜ γ₄) ∎
-      (K₀ₘ₂ x ▸A ▸t ▸B ▸u ▸v) →
-        K₀ₘ₂ (erased-matches-for-K-all·ᵐ x)
-          ▸A ▸t ▸B (▸-· ▸u) ▸v
+      (K₀ₘ₂ ⦃ ok ⦄ ▸A ▸t ▸B ▸u ▸v) →
+        K₀ₘ₂ ⦃ erased-matches-for-K-all·ᵐ ok ⦄ ▸A ▸t ▸B (▸-· ▸u) ▸v
       ([]-congₘ ▸l ▸A ▸t ▸u ▸v ok) →
         sub-≈ᶜ ([]-congₘ ▸l ▸A ▸t ▸u ▸v ([]-cong-allowed-mode-·ᵐ ok)) (·ᶜ-zeroʳ _)
     where
@@ -574,7 +593,7 @@ opaque mutual
         𝟘ᶜ≤ᶜm𝟘ᶜ
       rflₘ →
         𝟘ᶜ≤ᶜm𝟘ᶜ
-      (Jₘ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} _ _ _ ▸t ▸B ▸u ▸v ▸w) → begin
+      (Jₘ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} _ _ ▸t ▸B ▸u ▸v ▸w) → begin
         ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)                                              ≤⟨ ·ᶜ-monotoneʳ (+ᶜ-monotone (▸ᵐ ▸t)
                                                                                           (+ᶜ-monotone (tailₘ-monotone (tailₘ-monotone (▸ᵐ ▸B)))
                                                                                           (+ᶜ-monotone (▸ᵐ ▸u) (+ᶜ-monotone (▸ᵐ ▸v) (▸ᵐ ▸w))))) ⟩
@@ -584,14 +603,14 @@ opaque mutual
         ω ·ᶜ (⌜ m ⌝ ·ᶜ γ₂ +ᶜ ⌜ m ⌝ ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆))                          ≈˘⟨ ·ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _) ⟩
         ω ·ᶜ ⌜ m ⌝ ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)                                     ≈˘⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
         ⌜ m ⌝ ·ᶜ ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ∎
-      (J₀ₘ₁ {γ₃} {γ₄} _ _ _ _ _ ▸B ▸u _ _) → begin
+      (J₀ₘ₁ {γ₃} {γ₄} _ _ _ _ ▸B ▸u _ _) → begin
         ω ·ᶜ (γ₃ +ᶜ γ₄)                   ≤⟨ ·ᶜ-monotoneʳ (+ᶜ-monotone (tailₘ-monotone (tailₘ-monotone (▸ᵐ ▸B))) (▸ᵐ ▸u)) ⟩
         ω ·ᶜ (⌜ m ⌝ ·ᶜ γ₃ +ᶜ ⌜ m ⌝ ·ᶜ γ₄) ≈˘⟨ ·ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _) ⟩
         ω ·ᶜ ⌜ m ⌝ ·ᶜ (γ₃ +ᶜ γ₄)          ≈˘⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
         ⌜ m ⌝ ·ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄)          ∎
-      (J₀ₘ₂ _ _ _ _ ▸u _ _) →
+      (J₀ₘ₂ _ _ _ ▸u _ _) →
         ▸ᵐ ▸u
-      (Kₘ {γ₂} {γ₃} {γ₄} {γ₅} _ _ _ ▸t ▸B ▸u ▸v) → begin
+      (Kₘ {γ₂} {γ₃} {γ₄} {γ₅} _ _ ▸t ▸B ▸u ▸v) → begin
         ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅)                                     ≤⟨ ·ᶜ-monotoneʳ (+ᶜ-monotone (▸ᵐ ▸t)
                                                                            (+ᶜ-monotone (tailₘ-monotone (▸ᵐ ▸B))
                                                                            (+ᶜ-monotone (▸ᵐ ▸u) (▸ᵐ ▸v)))) ⟩
@@ -600,12 +619,12 @@ opaque mutual
         ω ·ᶜ (⌜ m ⌝ ·ᶜ γ₂ +ᶜ ⌜ m ⌝ ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅))                 ≈˘⟨ ·ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _) ⟩
         ω ·ᶜ ⌜ m ⌝ ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅)                            ≈˘⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
         ⌜ m ⌝ ·ᶜ ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ∎
-      (K₀ₘ₁ {γ₃} {γ₄} _ _ _ _ ▸B ▸u _) → begin
+      (K₀ₘ₁ {γ₃} {γ₄} _ _ _ ▸B ▸u _) → begin
         ω ·ᶜ (γ₃ +ᶜ γ₄)                   ≤⟨ ·ᶜ-monotoneʳ (+ᶜ-monotone (tailₘ-monotone (▸ᵐ ▸B)) (▸ᵐ ▸u)) ⟩
         ω ·ᶜ (⌜ m ⌝ ·ᶜ γ₃ +ᶜ ⌜ m ⌝ ·ᶜ γ₄) ≈˘⟨ ·ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _) ⟩
         ω ·ᶜ ⌜ m ⌝ ·ᶜ (γ₃ +ᶜ γ₄)          ≈˘⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
         ⌜ m ⌝ ·ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄)          ∎
-      (K₀ₘ₂ _ _ _ _ ▸u _) →
+      (K₀ₘ₂ _ _ _ ▸u _) →
         ▸ᵐ ▸u
       ([]-congₘ _ _ _ _ _ _) →
         𝟘ᶜ≤ᶜm𝟘ᶜ
@@ -781,36 +800,36 @@ private opaque
   -- Some lemmas used below.
 
   Conₘ-interchange₀₁ :
-    ∀ δ₃ δ₄ → ω ·ᶜ (γ₃ +ᶜ γ₄) , x ≔ (ω ·ᶜ (δ₃ +ᶜ δ₄)) ⟨ x ⟩ ≡
-    ω ·ᶜ ((γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ (γ₄ , x ≔ δ₄ ⟨ x ⟩))
-  Conₘ-interchange₀₁ {γ₃} {γ₄} {x} δ₃ δ₄ =
-    ω ·ᶜ (γ₃ +ᶜ γ₄) , x ≔ (ω ·ᶜ (δ₃ +ᶜ δ₄)) ⟨ x ⟩      ≡⟨ cong (_ , _ ≔_) $ lookup-distrib-·ᶜ (δ₃ +ᶜ _) _ _ ⟩
-    ω ·ᶜ (γ₃ +ᶜ γ₄) , x ≔ ω · (δ₃ +ᶜ δ₄) ⟨ x ⟩         ≡⟨ update-distrib-·ᶜ _ _ _ _ ⟩
-    ω ·ᶜ (γ₃ +ᶜ γ₄ , x ≔ (δ₃ +ᶜ δ₄) ⟨ x ⟩)             ≡⟨ cong (_ ·ᶜ_) $
+    ∀ δ₃ δ₄ → p ·ᶜ (γ₃ +ᶜ γ₄) , x ≔ (p ·ᶜ (δ₃ +ᶜ δ₄)) ⟨ x ⟩ ≡
+    p ·ᶜ ((γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ (γ₄ , x ≔ δ₄ ⟨ x ⟩))
+  Conₘ-interchange₀₁ {p} {γ₃} {γ₄} {x} δ₃ δ₄ =
+    p ·ᶜ (γ₃ +ᶜ γ₄) , x ≔ (p ·ᶜ (δ₃ +ᶜ δ₄)) ⟨ x ⟩      ≡⟨ cong (_ , _ ≔_) $ lookup-distrib-·ᶜ (δ₃ +ᶜ _) _ _ ⟩
+    p ·ᶜ (γ₃ +ᶜ γ₄) , x ≔ p · (δ₃ +ᶜ δ₄) ⟨ x ⟩         ≡⟨ update-distrib-·ᶜ _ _ _ _ ⟩
+    p ·ᶜ (γ₃ +ᶜ γ₄ , x ≔ (δ₃ +ᶜ δ₄) ⟨ x ⟩)             ≡⟨ cong (_ ·ᶜ_) $
                                                           trans (cong (_ , _ ≔_) $ lookup-distrib-+ᶜ δ₃ _ _) $
                                                           update-distrib-+ᶜ _ _ _ _ _ ⟩
-    ω ·ᶜ ((γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ (γ₄ , x ≔ δ₄ ⟨ x ⟩))  ∎
+    p ·ᶜ ((γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ (γ₄ , x ≔ δ₄ ⟨ x ⟩))  ∎
     where
     open Tools.Reasoning.PropositionalEquality
 
   Conₘ-interchange-J :
     ∀ δ₂ δ₃ δ₄ δ₅ δ₆ →
-    ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ,
-    x ≔ (ω ·ᶜ (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅ +ᶜ δ₆)) ⟨ x ⟩ ≡
-    ω ·ᶜ
+    p ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ,
+    x ≔ (p ·ᶜ (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅ +ᶜ δ₆)) ⟨ x ⟩ ≡
+    p ·ᶜ
      ((γ₂ , x ≔ δ₂ ⟨ x ⟩) +ᶜ (γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ
       (γ₄ , x ≔ δ₄ ⟨ x ⟩) +ᶜ (γ₅ , x ≔ δ₅ ⟨ x ⟩) +ᶜ
       (γ₆ , x ≔ δ₆ ⟨ x ⟩))
-  Conₘ-interchange-J {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} {x} δ₂ δ₃ δ₄ δ₅ δ₆ =
-    ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ,
-    x ≔ (ω ·ᶜ (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅ +ᶜ δ₆)) ⟨ x ⟩   ≡⟨ cong (_ , _ ≔_) $ lookup-distrib-·ᶜ (δ₂ +ᶜ _) _ _ ⟩
+  Conₘ-interchange-J {p} {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} {x} δ₂ δ₃ δ₄ δ₅ δ₆ =
+    p ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ,
+    x ≔ (p ·ᶜ (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅ +ᶜ δ₆)) ⟨ x ⟩   ≡⟨ cong (_ , _ ≔_) $ lookup-distrib-·ᶜ (δ₂ +ᶜ _) _ _ ⟩
 
-    ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ,
-    x ≔ ω · (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅ +ᶜ δ₆) ⟨ x ⟩      ≡⟨ update-distrib-·ᶜ _ _ _ _ ⟩
+    p ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ,
+    x ≔ p · (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅ +ᶜ δ₆) ⟨ x ⟩      ≡⟨ update-distrib-·ᶜ _ _ _ _ ⟩
 
-    ω ·ᶜ
+    p ·ᶜ
     (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆ ,
-     x ≔ (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅ +ᶜ δ₆) ⟨ x ⟩)        ≡⟨ cong (ω ·ᶜ_) $
+     x ≔ (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅ +ᶜ δ₆) ⟨ x ⟩)        ≡⟨ cong (p ·ᶜ_) $
                                                        trans (cong (_ , _ ≔_) $ lookup-distrib-+ᶜ δ₂ _ _) $
                                                        trans (update-distrib-+ᶜ _ _ _ _ _) $
                                                        cong (_ +ᶜ_) $
@@ -823,7 +842,7 @@ private opaque
                                                        trans (cong (_ , _ ≔_) $ lookup-distrib-+ᶜ δ₅ _ _) $
                                                        update-distrib-+ᶜ _ _ _ _ _ ⟩
 
-    ω ·ᶜ
+    p ·ᶜ
     ((γ₂ , x ≔ δ₂ ⟨ x ⟩) +ᶜ (γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ
      (γ₄ , x ≔ δ₄ ⟨ x ⟩) +ᶜ (γ₅ , x ≔ δ₅ ⟨ x ⟩) +ᶜ
      (γ₆ , x ≔ δ₆ ⟨ x ⟩))                           ∎
@@ -832,20 +851,20 @@ private opaque
 
   Conₘ-interchange-K :
     ∀ δ₂ δ₃ δ₄ δ₅ →
-    ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ,
-    x ≔ (ω ·ᶜ (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅)) ⟨ x ⟩ ≡
-    ω ·ᶜ
+    p ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ,
+    x ≔ (p ·ᶜ (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅)) ⟨ x ⟩ ≡
+    p ·ᶜ
      ((γ₂ , x ≔ δ₂ ⟨ x ⟩) +ᶜ (γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ
       (γ₄ , x ≔ δ₄ ⟨ x ⟩) +ᶜ (γ₅ , x ≔ δ₅ ⟨ x ⟩))
-  Conₘ-interchange-K {γ₂} {γ₃} {γ₄} {γ₅} {x} δ₂ δ₃ δ₄ δ₅ =
-    ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ,
-    x ≔ (ω ·ᶜ (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅)) ⟨ x ⟩                    ≡⟨ cong (_ , _ ≔_) $ lookup-distrib-·ᶜ (δ₂ +ᶜ _) _ _ ⟩
+  Conₘ-interchange-K {p} {γ₂} {γ₃} {γ₄} {γ₅} {x} δ₂ δ₃ δ₄ δ₅ =
+    p ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ,
+    x ≔ (p ·ᶜ (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅)) ⟨ x ⟩                    ≡⟨ cong (_ , _ ≔_) $ lookup-distrib-·ᶜ (δ₂ +ᶜ _) _ _ ⟩
 
-    ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ,
-    x ≔ ω · (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅) ⟨ x ⟩                       ≡⟨ update-distrib-·ᶜ _ _ _ _ ⟩
+    p ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ,
+    x ≔ p · (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅) ⟨ x ⟩                       ≡⟨ update-distrib-·ᶜ _ _ _ _ ⟩
 
-    ω ·ᶜ
-    (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ , x ≔ (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅) ⟨ x ⟩)  ≡⟨ cong (ω ·ᶜ_) $
+    p ·ᶜ
+    (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ , x ≔ (δ₂ +ᶜ δ₃ +ᶜ δ₄ +ᶜ δ₅) ⟨ x ⟩)  ≡⟨ cong (p ·ᶜ_) $
                                                                   trans (cong (_ , _ ≔_) $ lookup-distrib-+ᶜ δ₂ _ _) $
                                                                   trans (update-distrib-+ᶜ _ _ _ _ _) $
                                                                   cong (_ +ᶜ_) $
@@ -854,7 +873,7 @@ private opaque
                                                                   cong (_ +ᶜ_) $
                                                                   trans (cong (_ , _ ≔_) $ lookup-distrib-+ᶜ δ₄ _ _) $
                                                                   update-distrib-+ᶜ _ _ _ _ _ ⟩
-    ω ·ᶜ
+    p ·ᶜ
     ((γ₂ , x ≔ δ₂ ⟨ x ⟩) +ᶜ (γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ
      (γ₄ , x ≔ δ₄ ⟨ x ⟩) +ᶜ (γ₅ , x ≔ δ₅ ⟨ x ⟩))               ∎
     where
@@ -1292,15 +1311,17 @@ opaque
 
   Conₘ-interchange
     {δ = η}
-    (Jₘ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} ≤some ok ▸A ▸t ▸F ▸u ▸v ▸w) ▸J x =
+    (Jₘ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} ⦃ (≤some) ⦄ ok ▸A ▸t ▸F ▸u ▸v ▸w) ▸J x =
     case inv-usage-J ▸J of λ where
-      (invUsageJ₀₁ ≡some p≡𝟘 q≡𝟘 _ _ _ _ _ _ _) →
+      (invUsageJ₀₁ ⦃ (≡some) ⦄ p≡𝟘 q≡𝟘 _ _ _ _ _ _ _) →
         ⊥-elim $ ok ≡some (p≡𝟘 , q≡𝟘)
-      (invUsageJ₀₂ ≡all _ _ _ _ _ _ _) →
+      (invUsageJ₀₂ ⦃ (≡all) ⦄ _ _ _ _ _ _ _) →
         case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
       (invUsageJ {γ₂ = δ₂} {γ₃ = δ₃} {γ₄ = δ₄} {γ₅ = δ₅} {γ₆ = δ₆}
-         _ _ _ ▸t′ ▸F′ ▸u′ ▸v′ ▸w′ η≤ω·) → sub
-        (Jₘ ≤some ok ▸A (Conₘ-interchange ▸t ▸t′ x)
+         ⦃ (≤some′) ⦄ _ _ ▸t′ ▸F′ ▸u′ ▸v′ ▸w′ η≤ω·) →
+         case ≤ᵉᵐ-propositional ≤some ≤some′ of λ {
+           refl → sub
+        (Jₘ ⦃ ≤some ⦄ ok ▸A (Conₘ-interchange ▸t ▸t′ x)
            (Conₘ-interchange ▸F ▸F′ (x +2)) (Conₘ-interchange ▸u ▸u′ x)
            (Conₘ-interchange ▸v ▸v′ x) (Conₘ-interchange ▸w ▸w′ x))
         (begin
@@ -1312,37 +1333,42 @@ opaque
            ω ·ᶜ
            ((γ₂ , x ≔ δ₂ ⟨ x ⟩) +ᶜ (γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ
             (γ₄ , x ≔ δ₄ ⟨ x ⟩) +ᶜ (γ₅ , x ≔ δ₅ ⟨ x ⟩) +ᶜ
-            (γ₆ , x ≔ δ₆ ⟨ x ⟩))                            ∎)
+            (γ₆ , x ≔ δ₆ ⟨ x ⟩))                            ∎) }
     where
     open CR
+    open Graded.Usage.Restrictions.Instance R
 
   Conₘ-interchange
-    {δ = η} (J₀ₘ₁ {γ₃} {γ₄} ≡some p≡𝟘 q≡𝟘 ▸A ▸t ▸F ▸u ▸v ▸w) ▸J x =
+    {δ = η} (J₀ₘ₁ {γ₃} {γ₄} ⦃ (≡some) ⦄ p≡𝟘 q≡𝟘 ▸A ▸t ▸F ▸u ▸v ▸w) ▸J x =
     case inv-usage-J ▸J of λ where
-      (invUsageJ _ ok _ _ _ _ _ _ _) →
+      (invUsageJ ok _ _ _ _ _ _ _) →
         ⊥-elim $ ok ≡some (p≡𝟘 , q≡𝟘)
-      (invUsageJ₀₂ ≡all _ _ _ _ _ _ _) →
+      (invUsageJ₀₂ ⦃ (≡all) ⦄ _ _ _ _ _ _ _) →
         case trans (PE.sym ≡some) ≡all of λ ()
       (invUsageJ₀₁ {γ₃ = δ₃} {γ₄ = δ₄}
-         _ _ _ _ ▸t′ ▸F′ ▸u′ ▸v′ ▸w′ η≤ω·) → sub
-        (J₀ₘ₁ ≡some p≡𝟘 q≡𝟘 ▸A (Conₘ-interchange ▸t ▸t′ x)
+         ⦃ (≡some′) ⦄ _ _ _ ▸t′ ▸F′ ▸u′ ▸v′ ▸w′ η≤ω·) →
+         case Erased-matches-set ≡some ≡some′ of λ {
+           refl →
+         sub
+         (J₀ₘ₁ p≡𝟘 q≡𝟘 ▸A (Conₘ-interchange ▸t ▸t′ x)
            (Conₘ-interchange ▸F ▸F′ (x +2)) (Conₘ-interchange ▸u ▸u′ x)
            (Conₘ-interchange ▸v ▸v′ x) (Conₘ-interchange ▸w ▸w′ x))
-        (begin
-           ω ·ᶜ (γ₃ +ᶜ γ₄) , x ≔ η ⟨ x ⟩                      ≤⟨ update-monotoneʳ _ $ lookup-monotone _ η≤ω· ⟩
-           ω ·ᶜ (γ₃ +ᶜ γ₄) , x ≔ (ω ·ᶜ (δ₃ +ᶜ δ₄)) ⟨ x ⟩      ≡⟨ Conₘ-interchange₀₁ δ₃ δ₄ ⟩
-           ω ·ᶜ ((γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ (γ₄ , x ≔ δ₄ ⟨ x ⟩))  ∎)
+         (begin
+            ω ·ᶜ (γ₃ +ᶜ γ₄) , x ≔ η ⟨ x ⟩                      ≤⟨ update-monotoneʳ _ $ lookup-monotone _ η≤ω· ⟩
+            ω ·ᶜ (γ₃ +ᶜ γ₄) , x ≔ (ω ·ᶜ (δ₃ +ᶜ δ₄)) ⟨ x ⟩      ≡⟨ Conₘ-interchange₀₁ δ₃ δ₄ ⟩
+            ω ·ᶜ ((γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ (γ₄ , x ≔ δ₄ ⟨ x ⟩))  ∎) }
     where
     open CR
+    open Graded.Usage.Restrictions.Instance R
 
-  Conₘ-interchange {δ} (J₀ₘ₂ {γ₄} ≡all ▸A ▸t ▸F ▸u ▸v ▸w) ▸J x =
+  Conₘ-interchange {δ} (J₀ₘ₂ {γ₄} ⦃ (≡all) ⦄ ▸A ▸t ▸F ▸u ▸v ▸w) ▸J x =
     case inv-usage-J ▸J of λ where
-      (invUsageJ ≤some _ _ _ _ _ _ _ _) →
+      (invUsageJ ⦃ (≤some) ⦄ _ _ _ _ _ _ _ _) →
         case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
-      (invUsageJ₀₁ ≡some _ _ _ _ _ _ _ _ _) →
+      (invUsageJ₀₁ ⦃ (≡some) ⦄ _ _ _ _ _ _ _ _ _) →
         case trans (PE.sym ≡all) ≡some of λ ()
-      (invUsageJ₀₂ {γ₄ = γ₄′} _ _ _ _ ▸u′ _ _ δ≤γ₄′) → sub
-        (J₀ₘ₂ ≡all ▸A ▸t ▸F (Conₘ-interchange ▸u ▸u′ x) ▸v ▸w)
+      (invUsageJ₀₂ {γ₄ = γ₄′} _ _ _ ▸u′ _ _ δ≤γ₄′) → sub
+        (J₀ₘ₂ ⦃ ≡all ⦄ ▸A ▸t ▸F (Conₘ-interchange ▸u ▸u′ x) ▸v ▸w)
         (begin
            γ₄ , x ≔ δ ⟨ x ⟩    ≤⟨ update-monotoneʳ _ $ lookup-monotone _ δ≤γ₄′ ⟩
            γ₄ , x ≔ γ₄′ ⟨ x ⟩  ∎)
@@ -1350,15 +1376,17 @@ opaque
     open CR
 
   Conₘ-interchange
-    {δ = η} (Kₘ {γ₂} {γ₃} {γ₄} {γ₅} ≤some ok ▸A ▸t ▸F ▸u ▸v) ▸K x =
+    {δ = η} (Kₘ {γ₂} {γ₃} {γ₄} {γ₅} ⦃ (≤some) ⦄ ok ▸A ▸t ▸F ▸u ▸v) ▸K x =
     case inv-usage-K ▸K of λ where
-      (invUsageK₀₁ ≡some p≡𝟘 _ _ _ _ _ _) →
+      (invUsageK₀₁ ⦃ (≡some) ⦄ p≡𝟘 _ _ _ _ _ _) →
         ⊥-elim $ ok ≡some p≡𝟘
-      (invUsageK₀₂ ≡all _ _ _ _ _ _) →
+      (invUsageK₀₂ ⦃ (≡all) ⦄ _ _ _ _ _ _) →
         case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
       (invUsageK {γ₂ = δ₂} {γ₃ = δ₃} {γ₄ = δ₄} {γ₅ = δ₅}
-         _ _ _ ▸t′ ▸F′ ▸u′ ▸v′ η≤ω·) → sub
-        (Kₘ ≤some ok ▸A (Conₘ-interchange ▸t ▸t′ x)
+         ⦃ (≤some′) ⦄ _ _ ▸t′ ▸F′ ▸u′ ▸v′ η≤ω·) →
+        case ≤ᵉᵐ-propositional ≤some ≤some′ of λ {
+          refl → sub
+        (Kₘ ok ▸A (Conₘ-interchange ▸t ▸t′ x)
            (Conₘ-interchange ▸F ▸F′ (x +1)) (Conₘ-interchange ▸u ▸u′ x)
            (Conₘ-interchange ▸v ▸v′ x))
         (begin
@@ -1369,36 +1397,40 @@ opaque
 
            ω ·ᶜ
            ((γ₂ , x ≔ δ₂ ⟨ x ⟩) +ᶜ (γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ
-            (γ₄ , x ≔ δ₄ ⟨ x ⟩) +ᶜ (γ₅ , x ≔ δ₅ ⟨ x ⟩))    ∎)
+            (γ₄ , x ≔ δ₄ ⟨ x ⟩) +ᶜ (γ₅ , x ≔ δ₅ ⟨ x ⟩))    ∎) }
     where
     open CR
+    open Graded.Usage.Restrictions.Instance R
 
   Conₘ-interchange
-    {δ = η} (K₀ₘ₁ {γ₃} {γ₄} ≡some p≡𝟘 ▸A ▸t ▸F ▸u ▸v) ▸K x =
+    {δ = η} (K₀ₘ₁ {γ₃} {γ₄} ⦃ (≡some) ⦄ p≡𝟘 ▸A ▸t ▸F ▸u ▸v) ▸K x =
     case inv-usage-K ▸K of λ where
-      (invUsageK _ ok _ _ _ _ _ _) →
+      (invUsageK ok _ _ _ _ _ _) →
         ⊥-elim $ ok ≡some p≡𝟘
-      (invUsageK₀₂ ≡all _ _ _ _ _ _) →
+      (invUsageK₀₂ ⦃ (≡all) ⦄ _ _ _ _ _ _) →
         case trans (PE.sym ≡some) ≡all of λ ()
-      (invUsageK₀₁ {γ₃ = δ₃} {γ₄ = δ₄} _ _ _ ▸t′ ▸F′ ▸u′ ▸v′ η≤ω·) → sub
-        (K₀ₘ₁ ≡some p≡𝟘 ▸A (Conₘ-interchange ▸t ▸t′ x)
+      (invUsageK₀₁ {γ₃ = δ₃} {γ₄ = δ₄} ⦃ (≡some′) ⦄ _ _ ▸t′ ▸F′ ▸u′ ▸v′ η≤ω·) →
+        case Erased-matches-set ≡some ≡some′ of λ {
+          refl → sub
+        (K₀ₘ₁ p≡𝟘 ▸A (Conₘ-interchange ▸t ▸t′ x)
            (Conₘ-interchange ▸F ▸F′ (x +1)) (Conₘ-interchange ▸u ▸u′ x)
            (Conₘ-interchange ▸v ▸v′ x))
         (begin
            ω ·ᶜ (γ₃ +ᶜ γ₄) , x ≔ η ⟨ x ⟩                      ≤⟨ update-monotoneʳ _ $ lookup-monotone _ η≤ω· ⟩
            ω ·ᶜ (γ₃ +ᶜ γ₄) , x ≔ (ω ·ᶜ (δ₃ +ᶜ δ₄)) ⟨ x ⟩      ≡⟨ Conₘ-interchange₀₁ δ₃ δ₄ ⟩
-           ω ·ᶜ ((γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ (γ₄ , x ≔ δ₄ ⟨ x ⟩))  ∎)
+           ω ·ᶜ ((γ₃ , x ≔ δ₃ ⟨ x ⟩) +ᶜ (γ₄ , x ≔ δ₄ ⟨ x ⟩))  ∎) }
     where
     open CR
+    open Graded.Usage.Restrictions.Instance R
 
-  Conₘ-interchange {δ} (K₀ₘ₂ {γ₄} ≡all ▸A ▸t ▸F ▸u ▸v) ▸K x =
+  Conₘ-interchange {δ} (K₀ₘ₂ {γ₄} ⦃ (≡all) ⦄ ▸A ▸t ▸F ▸u ▸v) ▸K x =
     case inv-usage-K ▸K of λ where
-      (invUsageK ≤some _ _ _ _ _ _ _) →
+      (invUsageK ⦃ (≤some) ⦄ _ _ _ _ _ _ _) →
         case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
-      (invUsageK₀₁ ≡some _ _ _ _ _ _ _) →
+      (invUsageK₀₁ ⦃ (≡some) ⦄ _ _ _ _ _ _ _) →
         case trans (PE.sym ≡all) ≡some of λ ()
-      (invUsageK₀₂ {γ₄ = γ₄′} _ _ _ _ ▸u′ _ δ≤γ₄′) → sub
-        (K₀ₘ₂ ≡all ▸A ▸t ▸F (Conₘ-interchange ▸u ▸u′ x) ▸v)
+      (invUsageK₀₂ {γ₄ = γ₄′} _ _ _ ▸u′ _ δ≤γ₄′) → sub
+        (K₀ₘ₂ ⦃ ≡all ⦄ ▸A ▸t ▸F (Conₘ-interchange ▸u ▸u′ x) ▸v)
         (begin
            γ₄ , x ≔ δ ⟨ x ⟩    ≤⟨ update-monotoneʳ _ $ lookup-monotone _ δ≤γ₄′ ⟩
            γ₄ , x ≔ γ₄′ ⟨ x ⟩  ∎)
@@ -1445,9 +1477,27 @@ Conₘ-interchange₂ {γ = γ} {m} {t} {δ} γ▸t δ▸t =
 ------------------------------------------------------------------------
 -- Variants of some usage rules
 
+opaque
+
+  -- A variant of Idₘ and Id₀ₘ.
+
+  Idₘ-generalised :
+    γ₁ ▸[ m ] A →
+    γ₂ ▸[ m ] t →
+    γ₃ ▸[ m ] u →
+    (Id-erased → δ ≤ᶜ 𝟘ᶜ) →
+    (¬ Id-erased → δ ≤ᶜ γ₁ +ᶜ γ₂ +ᶜ γ₃) →
+    δ ▸[ m ] Id A t u
+  Idₘ-generalised ▸A ▸t ▸u δ≤𝟘ᶜ δ≤γ₁+γ₂+γ₃ =
+    case Id-erased? of λ where
+      (no not-erased) →
+        sub (Idₘ not-erased ▸A ▸t ▸u) (δ≤γ₁+γ₂+γ₃ not-erased)
+      (yes erased) →
+        sub (Id₀ₘ erased (▸-𝟘 ▸A) (▸-𝟘 ▸t) (▸-𝟘 ▸u)) (δ≤𝟘ᶜ erased)
+
 module _ where
 
-  open import Graded.Usage.Restrictions.Instance R
+  open Graded.Usage.Restrictions.Instance R
 
   -- A variant of natrecₘ, natrec-no-nrₘ and natrec-no-nr-glbₘ.
 
@@ -1482,195 +1532,278 @@ module _ where
         let _ , _ , x-glb , θ-glb , χ≤ = hyp₃
         in  sub (natrec-no-nr-glbₘ ▸t ▸u ▸v ▸A x-glb θ-glb) χ≤
 
-opaque
+  opaque
 
-  -- A variant of Idₘ and Id₀ₘ.
+    -- A generalisation of the usage rule Jₘ:
+    -- erased-matches-for-J m ≡ none and
+    -- erased-matches-for-J m ≡ some → ¬ (p ≡ 𝟘 × q ≡ 𝟘) have been
+    -- removed.
 
-  Idₘ-generalised :
-    γ₁ ▸[ m ] A →
-    γ₂ ▸[ m ] t →
-    γ₃ ▸[ m ] u →
-    (Id-erased → δ ≤ᶜ 𝟘ᶜ) →
-    (¬ Id-erased → δ ≤ᶜ γ₁ +ᶜ γ₂ +ᶜ γ₃) →
-    δ ▸[ m ] Id A t u
-  Idₘ-generalised ▸A ▸t ▸u δ≤𝟘ᶜ δ≤γ₁+γ₂+γ₃ =
-    case Id-erased? of λ where
-      (no not-erased) →
-        sub (Idₘ not-erased ▸A ▸t ▸u) (δ≤γ₁+γ₂+γ₃ not-erased)
-      (yes erased) →
-        sub (Id₀ₘ erased (▸-𝟘 ▸A) (▸-𝟘 ▸t) (▸-𝟘 ▸u)) (δ≤𝟘ᶜ erased)
-
-opaque
-
-  -- A generalisation of the usage rule Jₘ:
-  -- erased-matches-for-J m ≡ none and
-  -- erased-matches-for-J m ≡ some → ¬ (p ≡ 𝟘 × q ≡ 𝟘) have been
-  -- removed.
-
-  Jₘ-generalised :
-    γ₁ ▸[ 𝟘ᵐ ] A →
-    γ₂ ▸[ m ] t →
-    γ₃ ∙ ⌜ m ⌝ · p ∙ ⌜ m ⌝ · q ▸[ m ] B →
-    γ₄ ▸[ m ] u →
-    γ₅ ▸[ m ] v →
-    γ₆ ▸[ m ] w →
-    ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ▸[ m ] J p q A t B u v w
-  Jₘ-generalised
-    {γ₂} {m} {γ₃} {p} {q} {B} {γ₄} {γ₅} {γ₆} ▸A ▸t ▸B ▸u ▸v ▸w
-    with J-view p q m
-  … | is-other ≤some ≢𝟘 =
-    Jₘ ≤some ≢𝟘 ▸A ▸t ▸B ▸u ▸v ▸w
-  … | is-some-yes ≡some (refl , refl) = sub
-    (J₀ₘ₁ ≡some refl refl ▸A (▸-𝟘 ▸t)
-       (sub ▸B $ begin
-          γ₃ ∙ 𝟘 ∙ 𝟘                  ≈˘⟨ ≈ᶜ-refl ∙ ·-zeroʳ _ ∙ ·-zeroʳ _ ⟩
-          γ₃ ∙ ⌜ m ⌝ · 𝟘 ∙ ⌜ m ⌝ · 𝟘  ∎)
-       ▸u (▸-𝟘 ▸v) (▸-𝟘 ▸w))
-    (begin
-       ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)  ≤⟨ ≤ᶜ-trans ω·ᶜ+ᶜ≤ω·ᶜʳ $
-                                             ≤ᶜ-trans (≤ᶜ-reflexive $ ≈ᶜ-sym $ ·ᶜ-congˡ $ +ᶜ-assoc _ _ _)
-                                             ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
-       ω ·ᶜ (γ₃ +ᶜ γ₄)                    ∎)
-    where
-    open CR
-  Jₘ-generalised
-    {γ₂} {m} {γ₃} {p} {q} {B} {γ₄} {γ₅} {γ₆} ▸A ▸t ▸B ▸u ▸v ▸w
-    | is-all ≡all = sub
-    (J₀ₘ₂ ≡all ▸A (▸-𝟘 ▸t)
-      (sub (▸-𝟘 ▸B) (begin
-        ⌜ 𝟘ᵐ ⌝ ·ᶜ γ₃ ∙ ⌜ 𝟘ᵐ ⌝ · p ∙ ⌜ 𝟘ᵐ ⌝ · q                 ≈⟨ ≈ᶜ-refl ∙ lemma ∙ lemma ⟩
-        ⌜ 𝟘ᵐ ⌝ ·ᶜ γ₃ ∙ ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · p ∙ ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · q ∎))
-       ▸u (▸-𝟘 ▸v) (▸-𝟘 ▸w))
-    (begin
-       ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)  ≤⟨ ≤ᶜ-trans ω·ᶜ+ᶜ≤ω·ᶜʳ $
-                                             ≤ᶜ-trans ω·ᶜ+ᶜ≤ω·ᶜʳ
-                                             ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
-       ω ·ᶜ γ₄                            ≤⟨ ω·ᶜ-decreasing ⟩
-       γ₄                                 ∎)
-    where
-    lemma : ∀ {p} → ⌜ 𝟘ᵐ ⌝ · p ≡ ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · p
-    lemma {p} = begin
-      ⌜ 𝟘ᵐ ⌝ · p           ≡˘⟨ ·-congʳ (⌜⌝-cong (·ᵐ-zeroˡ _)) ⟩
-      ⌜ 𝟘ᵐ ·ᵐ m ⌝ · p      ≡⟨ ·-congʳ (⌜·ᵐ⌝ 𝟘ᵐ) ⟩
-      (⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝) · p ≡⟨ ·-assoc _ _ _ ⟩
-      ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · p   ∎
+    Jₘ-generalised′  :
+      γ₁ ▸[ 𝟘ᵐ ] A →
+      γ₂ ▸[ m ] t →
+      γ₃ ∙ ⌜ m ⌝ · p ∙ ⌜ m ⌝ · q ▸[ m ] B →
+      γ₄ ▸[ m ] u →
+      γ₅ ▸[ m ] v →
+      γ₆ ▸[ m ] w →
+      (⦃ ok : erased-matches-for-J m ≤ᵉᵐ some ⦄ → δ ≤ᶜ ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)) →
+      (erased-matches-for-J m ≡ all → δ ≤ᶜ γ₄) →
+      δ ▸[ m ] J p q A t B u v w
+    Jₘ-generalised′ {γ₂} {m} {γ₃} {p} {q} {γ₄} {γ₅} {γ₆} {δ} ▸A ▸t ▸B ▸u ▸v ▸w δ≤₁ δ≤₂
+      with J-view p q m
+    … | is-other ≢𝟘 =
+      sub (Jₘ ≢𝟘 ▸A ▸t ▸B ▸u ▸v ▸w) δ≤₁
+    … | is-some-yes (refl , refl) = sub
+      (J₀ₘ₁ refl refl ▸A (▸-𝟘 ▸t)
+        (sub ▸B $ begin
+            γ₃ ∙ 𝟘 ∙ 𝟘                  ≈˘⟨ ≈ᶜ-refl ∙ ·-zeroʳ _ ∙ ·-zeroʳ _ ⟩
+            γ₃ ∙ ⌜ m ⌝ · 𝟘 ∙ ⌜ m ⌝ · 𝟘  ∎)
+         ▸u (▸-𝟘 ▸v) (▸-𝟘 ▸w)) $ begin
+      δ ≤⟨ δ≤₁ ⟩
+      ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
+      ω ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)       ≈˘⟨ ·ᶜ-congˡ (+ᶜ-assoc _ _ _) ⟩
+      ω ·ᶜ ((γ₃ +ᶜ γ₄) +ᶜ γ₅ +ᶜ γ₆)     ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
+      ω ·ᶜ (γ₃ +ᶜ γ₄)                   ∎
       where
-      open Tools.Reasoning.PropositionalEquality
-    open ≤ᶜ-reasoning
-
-opaque
-
-  -- A generalisation of the usage rule J₀ₘ₁:
-  -- erased-matches-for-J m ≡ some has been replaced by
-  -- erased-matches-for-J m ≡ not-none sem.
-
-  J₀ₘ₁-generalised :
-    erased-matches-for-J m ≡ not-none sem →
-    p ≡ 𝟘 →
-    q ≡ 𝟘 →
-    γ₁ ▸[ m₁ ] A →
-    γ₂ ▸[ m₂ ] t →
-    γ₃ ∙ 𝟘 ∙ 𝟘 ▸[ m ] B →
-    γ₄ ▸[ m ] u →
-    γ₅ ▸[ m₃ ] v →
-    γ₆ ▸[ m₄ ] w →
-    ω ·ᶜ (γ₃ +ᶜ γ₄) ▸[ m ] J p q A t B u v w
-  J₀ₘ₁-generalised {m} {γ₃} {B} {γ₄} hyp refl refl ▸A ▸t ▸B ▸u ▸v ▸w
-    with erased-matches-for-J m in ok
-  … | none = case hyp of λ ()
-  … | some = J₀ₘ₁ ok refl refl (▸-𝟘 ▸A) (▸-𝟘 ▸t) ▸B ▸u (▸-𝟘 ▸v) (▸-𝟘 ▸w)
-  … | all  = sub
-    (J₀ₘ₂ ok (▸-𝟘 ▸A) (▸-𝟘 ▸t)
-       (▸-𝟘 ▸B) ▸u (▸-𝟘 ▸v) (▸-𝟘 ▸w))
-    (begin
-       ω ·ᶜ (γ₃ +ᶜ γ₄)  ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
-       ω ·ᶜ γ₄          ≤⟨ ω·ᶜ-decreasing ⟩
-       γ₄               ∎)
-    where
-    open CR
-
-opaque
-
-  -- A generalisation of the usage rule Kₘ:
-  -- erased-matches-for-K m ≤ᵉᵐ some and
-  -- erased-matches-for-K m ≡ some → p ≢ 𝟘 have been removed.
-
-  Kₘ-generalised :
-    γ₁ ▸[ 𝟘ᵐ ] A →
-    γ₂ ▸[ m ] t →
-    γ₃ ∙ ⌜ m ⌝ · p ▸[ m ] B →
-    γ₄ ▸[ m ] u →
-    γ₅ ▸[ m ] v →
-    ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ▸[ m ] K p A t B u v
-  Kₘ-generalised {γ₂} {m} {γ₃} {p} {B} {γ₄} {γ₅} ▸A ▸t ▸B ▸u ▸v
-    with K-view p m
-  … | is-other ≤some ≢𝟘 =
-    Kₘ ≤some ≢𝟘 ▸A ▸t ▸B ▸u ▸v
-  … | is-some-yes ≡some refl = sub
-    (K₀ₘ₁ ≡some refl ▸A (▸-𝟘 ▸t)
-       (sub ▸B $ begin
-          γ₃ ∙ 𝟘          ≈˘⟨ ≈ᶜ-refl ∙ ·-zeroʳ _ ⟩
-          γ₃ ∙ ⌜ m ⌝ · 𝟘  ∎)
-       ▸u (▸-𝟘 ▸v))
-    (begin
-       ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅)  ≤⟨ ≤ᶜ-trans ω·ᶜ+ᶜ≤ω·ᶜʳ $
-                                       ≤ᶜ-trans (≤ᶜ-reflexive $ ≈ᶜ-sym $ ·ᶜ-congˡ $ +ᶜ-assoc _ _ _)
-                                       ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
-       ω ·ᶜ (γ₃ +ᶜ γ₄)              ∎)
-    where
-    open CR
-  … | is-all ≡all = sub
-    (K₀ₘ₂ ≡all ▸A (▸-𝟘 ▸t)
-       (sub (▸-𝟘 ▸B) (begin
-         ⌜ 𝟘ᵐ ⌝ ·ᶜ γ₃ ∙ ⌜ 𝟘ᵐ ⌝ · p          ≈⟨ ≈ᶜ-refl ∙ lemma ⟩
-         ⌜ 𝟘ᵐ ⌝ ·ᶜ γ₃ ∙ ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · p  ∎))
-       ▸u (▸-𝟘 ▸v))
-    (begin
-       ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅)  ≤⟨ ≤ᶜ-trans ω·ᶜ+ᶜ≤ω·ᶜʳ $
-                                       ≤ᶜ-trans ω·ᶜ+ᶜ≤ω·ᶜʳ
-                                       ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
-       ω ·ᶜ γ₄                      ≤⟨ ω·ᶜ-decreasing ⟩
-       γ₄                           ∎)
-    where
-    lemma : ∀ {p} → ⌜ 𝟘ᵐ ⌝ · p ≡ ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · p
-    lemma {p} = begin
-      ⌜ 𝟘ᵐ ⌝ · p           ≡˘⟨ ·-congʳ (⌜⌝-cong (·ᵐ-zeroˡ _)) ⟩
-      ⌜ 𝟘ᵐ ·ᵐ m ⌝ · p      ≡⟨ ·-congʳ (⌜·ᵐ⌝ 𝟘ᵐ) ⟩
-      (⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝) · p ≡⟨ ·-assoc _ _ _ ⟩
-      ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · p   ∎
+      open ≤ᶜ-reasoning
+    … | is-all ⦃ (≡all) ⦄ = sub
+      (J₀ₘ₂ ▸A (▸-𝟘 ▸t)
+        (sub (▸-𝟘 ▸B) (begin
+          ⌜ 𝟘ᵐ ⌝ ·ᶜ γ₃ ∙ ⌜ 𝟘ᵐ ⌝ · p ∙ ⌜ 𝟘ᵐ ⌝ · q                 ≈⟨ ≈ᶜ-refl ∙ lemma ∙ lemma ⟩
+          ⌜ 𝟘ᵐ ⌝ ·ᶜ γ₃ ∙ ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · p ∙ ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · q ∎))
+        ▸u (▸-𝟘 ▸v) (▸-𝟘 ▸w)) (δ≤₂ ≡all)
       where
-      open Tools.Reasoning.PropositionalEquality
-    open CR
+      lemma : ∀ {p} → ⌜ 𝟘ᵐ ⌝ · p ≡ ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · p
+      lemma {p} = begin
+        ⌜ 𝟘ᵐ ⌝ · p           ≡˘⟨ ·-congʳ (⌜⌝-cong (·ᵐ-zeroˡ _)) ⟩
+        ⌜ 𝟘ᵐ ·ᵐ m ⌝ · p      ≡⟨ ·-congʳ (⌜·ᵐ⌝ 𝟘ᵐ) ⟩
+        (⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝) · p ≡⟨ ·-assoc _ _ _ ⟩
+        ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · p   ∎
+        where
+        open Tools.Reasoning.PropositionalEquality
+      open ≤ᶜ-reasoning
 
-opaque
+  opaque
 
-  -- A generalisation of the usage rule K₀ₘ₁:
-  -- erased-matches-for-K m ≡ some has been replaced by
-  -- erased-matches-for-K m ≡ not-none sem.
+    -- A generalisation of the usage rule Jₘ:
+    -- erased-matches-for-J m ≡ none and
+    -- erased-matches-for-J m ≡ some → ¬ (p ≡ 𝟘 × q ≡ 𝟘) have been
+    -- removed.
 
-  K₀ₘ₁-generalised :
-    erased-matches-for-K m ≡ not-none sem →
-    p ≡ 𝟘 →
-    γ₁ ▸[ m₁ ] A →
-    γ₂ ▸[ m₂ ] t →
-    γ₃ ∙ 𝟘 ▸[ m ] B →
-    γ₄ ▸[ m ] u →
-    γ₅ ▸[ m₃ ] v →
-    ω ·ᶜ (γ₃ +ᶜ γ₄) ▸[ m ] K p A t B u v
-  K₀ₘ₁-generalised {m} {γ₃} {B} {γ₄} hyp refl ▸A ▸t ▸B ▸u ▸v
-    with erased-matches-for-K m in ok
-  … | none = case hyp of λ ()
-  … | some = K₀ₘ₁ ok refl (▸-𝟘 ▸A) (▸-𝟘 ▸t) ▸B ▸u (▸-𝟘 ▸v)
-  … | all  = sub
-    (K₀ₘ₂ ok (▸-𝟘 ▸A) (▸-𝟘 ▸t)
-       (▸-𝟘 ▸B)
-       ▸u (▸-𝟘 ▸v))
-    (begin
-       ω ·ᶜ (γ₃ +ᶜ γ₄)  ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
-       ω ·ᶜ γ₄          ≤⟨ ω·ᶜ-decreasing ⟩
-       γ₄               ∎)
-    where
-    open CR
+    Jₘ-generalised :
+      ⦃ ok : JK-with-omega ⦄ →
+      γ₁ ▸[ 𝟘ᵐ ] A →
+      γ₂ ▸[ m ] t →
+      γ₃ ∙ ⌜ m ⌝ · p ∙ ⌜ m ⌝ · q ▸[ m ] B →
+      γ₄ ▸[ m ] u →
+      γ₅ ▸[ m ] v →
+      γ₆ ▸[ m ] w →
+      ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ▸[ m ] J p q A t B u v w
+    Jₘ-generalised {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} ⦃ ok ⦄ ▸A ▸t ▸B ▸u ▸v ▸w =
+      Jₘ-generalised′ ▸A ▸t ▸B ▸u ▸v ▸w
+        (≤ᶜ-reflexive (·ᶜ-congʳ (ω≡ω ok erased-matches-JK-≤-some-JK-with-omega)))
+        λ _ → begin
+          ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆) ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
+          ω ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)       ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
+          ω ·ᶜ (γ₄ +ᶜ γ₅ +ᶜ γ₆)             ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
+          ω ·ᶜ γ₄                           ≤⟨ ω·ᶜ-decreasing ⟩
+          γ₄                                ∎
+      where
+      open ≤ᶜ-reasoning
+
+  opaque
+
+    -- A generalisation of the usage rule J₀ₘ₁:
+    -- erased-matches-for-J m ≡ some has been replaced by
+    -- erased-matches-for-J m ≡ not-none sem.
+
+    J₀ₘ₁-generalised′ :
+      erased-matches-for-J m ≡ not-none sem →
+      p ≡ 𝟘 →
+      q ≡ 𝟘 →
+      γ₁ ▸[ m₁ ] A →
+      γ₂ ▸[ m₂ ] t →
+      γ₃ ∙ 𝟘 ∙ 𝟘 ▸[ m ] B →
+      γ₄ ▸[ m ] u →
+      γ₅ ▸[ m₃ ] v →
+      γ₆ ▸[ m₄ ] w →
+      (⦃ ok : erased-matches-for-J m ≡ some ⦄ → δ ≤ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄)) →
+      (erased-matches-for-J m ≡ all → δ ≤ᶜ γ₄) →
+      δ ▸[ m ] J p q A t B u v w
+    J₀ₘ₁-generalised′ {m} hyp refl refl ▸A ▸t ▸B ▸u ▸v ▸w δ≤₁ δ≤₂
+      with J-view 𝟘 𝟘 m
+    … | is-all ⦃ (ok) ⦄ =
+        sub (J₀ₘ₂ (▸-𝟘 ▸A) (▸-𝟘 ▸t) (▸-𝟘 ▸B) ▸u (▸-𝟘 ▸v) (▸-𝟘 ▸w)) (δ≤₂ ok)
+    … | is-some-yes _   =
+        sub (J₀ₘ₁ refl refl (▸-𝟘 ▸A) (▸-𝟘 ▸t) ▸B ▸u (▸-𝟘 ▸v) (▸-𝟘 ▸w)) δ≤₁
+    … | is-other ⦃ (≤some) ⦄ 𝟘≢𝟘 =
+        ⊥-elim (lemma _ hyp ≤some (λ ≡some → 𝟘≢𝟘 ≡some (refl , refl)))
+      where
+      lemma : ∀ em → em ≡ not-none sem → em ≤ᵉᵐ some → em ≢ some → ⊥
+      lemma none () _ _
+      lemma all _ () _
+      lemma some _ em≤ em≢some = em≢some refl
+
+  opaque
+
+    -- A generalisation of the usage rule J₀ₘ₁:
+    -- erased-matches-for-J m ≡ some has been replaced by
+    -- erased-matches-for-J m ≡ not-none sem.
+
+    J₀ₘ₁-generalised :
+      ⦃ ok : JK-with-omega ⦄ →
+      erased-matches-for-J m ≡ not-none sem →
+      p ≡ 𝟘 →
+      q ≡ 𝟘 →
+      γ₁ ▸[ m₁ ] A →
+      γ₂ ▸[ m₂ ] t →
+      γ₃ ∙ 𝟘 ∙ 𝟘 ▸[ m ] B →
+      γ₄ ▸[ m ] u →
+      γ₅ ▸[ m₃ ] v →
+      γ₆ ▸[ m₄ ] w →
+      ω ·ᶜ (γ₃ +ᶜ γ₄) ▸[ m ] J p q A t B u v w
+    J₀ₘ₁-generalised {m} {γ₃} {γ₄} ⦃ ok = has-omega ⦄ hyp refl refl ▸A ▸t ▸B ▸u ▸v ▸w =
+      J₀ₘ₁-generalised′ hyp refl refl ▸A ▸t ▸B ▸u ▸v ▸w
+        (≤ᶜ-reflexive (·ᶜ-congʳ (ω≡ω has-omega erased-matches-JK-≤-some-JK-with-omega)))
+        λ _ → begin
+          ω ·ᶜ (γ₃ +ᶜ γ₄) ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
+          ω ·ᶜ γ₄         ≤⟨ ω·ᶜ-decreasing ⟩
+          γ₄              ∎
+      where
+      open ≤ᶜ-reasoning
+
+  opaque
+
+    -- A generalisation of the usage rule Kₘ:
+    -- erased-matches-for-K m ≤ᵉᵐ some and
+    -- erased-matches-for-K m ≡ some → p ≢ 𝟘 have been removed.
+
+    Kₘ-generalised′ :
+      γ₁ ▸[ 𝟘ᵐ ] A →
+      γ₂ ▸[ m ] t →
+      γ₃ ∙ ⌜ m ⌝ · p ▸[ m ] B →
+      γ₄ ▸[ m ] u →
+      γ₅ ▸[ m ] v →
+      (⦃ ok : erased-matches-for-K m ≤ᵉᵐ some ⦄ → δ ≤ᶜ ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅)) →
+      (erased-matches-for-K m ≡ all → δ ≤ᶜ γ₄) →
+      δ ▸[ m ] K p A t B u v
+    Kₘ-generalised′ {γ₂} {m} {γ₃} {p} {γ₄} {γ₅} {δ} ▸A ▸t ▸B ▸u ▸v δ≤₁ δ≤₂
+      with K-view p m
+    … | is-other ≢𝟘 =
+      sub (Kₘ ≢𝟘 ▸A ▸t ▸B ▸u ▸v) δ≤₁
+    … | is-some-yes refl = sub
+      (K₀ₘ₁ refl ▸A (▸-𝟘 ▸t)
+        (sub ▸B $ begin
+          γ₃ ∙ 𝟘         ≈˘⟨ ≈ᶜ-refl ∙ ·-zeroʳ _ ⟩
+          γ₃ ∙ ⌜ m ⌝ · 𝟘 ∎)
+        ▸u (▸-𝟘 ▸v)) $ begin
+        δ                           ≤⟨ δ≤₁ ⟩
+        ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
+        ω ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅)       ≈˘⟨ ·ᶜ-congˡ (+ᶜ-assoc _ _ _) ⟩
+        ω ·ᶜ ((γ₃ +ᶜ γ₄) +ᶜ γ₅)     ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
+        ω ·ᶜ (γ₃ +ᶜ γ₄)             ∎
+      where
+      open ≤ᶜ-reasoning
+    … | is-all ⦃ (≡all) ⦄ = sub
+      (K₀ₘ₂ ▸A (▸-𝟘 ▸t)
+        (sub (▸-𝟘 ▸B) $ begin
+          ⌜ 𝟘ᵐ ⌝ ·ᶜ γ₃ ∙ ⌜ 𝟘ᵐ ⌝ · p         ≈⟨ ≈ᶜ-refl ∙ lemma ⟩
+          ⌜ 𝟘ᵐ ⌝ ·ᶜ γ₃ ∙ ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · p ∎)
+        ▸u (▸-𝟘 ▸v))
+      (δ≤₂ ≡all)
+      where
+      lemma : ∀ {p} → ⌜ 𝟘ᵐ ⌝ · p ≡ ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · p
+      lemma {p} = begin
+        ⌜ 𝟘ᵐ ⌝ · p           ≡˘⟨ ·-congʳ (⌜⌝-cong (·ᵐ-zeroˡ _)) ⟩
+        ⌜ 𝟘ᵐ ·ᵐ m ⌝ · p      ≡⟨ ·-congʳ (⌜·ᵐ⌝ 𝟘ᵐ) ⟩
+        (⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝) · p ≡⟨ ·-assoc _ _ _ ⟩
+        ⌜ 𝟘ᵐ ⌝ · ⌜ m ⌝ · p   ∎
+        where
+        open Tools.Reasoning.PropositionalEquality
+      open ≤ᶜ-reasoning
+
+  opaque
+
+    -- A generalisation of the usage rule Kₘ:
+    -- erased-matches-for-K m ≤ᵉᵐ some and
+    -- erased-matches-for-K m ≡ some → p ≢ 𝟘 have been removed.
+
+    Kₘ-generalised :
+      ⦃ ok : JK-with-omega ⦄ →
+      γ₁ ▸[ 𝟘ᵐ ] A →
+      γ₂ ▸[ m ] t →
+      γ₃ ∙ ⌜ m ⌝ · p ▸[ m ] B →
+      γ₄ ▸[ m ] u →
+      γ₅ ▸[ m ] v →
+      ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ▸[ m ] K p A t B u v
+    Kₘ-generalised  {γ₂} {γ₃} {γ₄} {γ₅} ⦃ ok ⦄ ▸A ▸t ▸B ▸u ▸v =
+      Kₘ-generalised′ ▸A ▸t ▸B ▸u ▸v
+        (≤ᶜ-reflexive (·ᶜ-congʳ (ω≡ω ok erased-matches-JK-≤-some-JK-with-omega)))
+        (λ _ → begin
+          ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅) ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
+          ω ·ᶜ (γ₃ +ᶜ γ₄ +ᶜ γ₅)       ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
+          ω ·ᶜ (γ₄ +ᶜ γ₅)             ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜˡ ⟩
+          ω ·ᶜ γ₄                     ≤⟨ ω·ᶜ-decreasing ⟩
+          γ₄                          ∎)
+      where
+      open ≤ᶜ-reasoning
+
+  opaque
+
+    -- A generalisation of the usage rule K₀ₘ₁:
+    -- erased-matches-for-K m ≡ some has been replaced by
+    -- erased-matches-for-K m ≡ not-none sem.
+
+    K₀ₘ₁-generalised′ :
+      erased-matches-for-K m ≡ not-none sem →
+      p ≡ 𝟘 →
+      γ₁ ▸[ m₁ ] A →
+      γ₂ ▸[ m₂ ] t →
+      γ₃ ∙ 𝟘 ▸[ m ] B →
+      γ₄ ▸[ m ] u →
+      γ₅ ▸[ m₃ ] v →
+      (⦃ ok : erased-matches-for-K m ≡ some ⦄ → δ ≤ᶜ ω ·ᶜ (γ₃ +ᶜ γ₄)) →
+      (erased-matches-for-K m ≡ all → δ ≤ᶜ γ₄) →
+      δ ▸[ m ] K p A t B u v
+    K₀ₘ₁-generalised′ {m} hyp refl ▸A ▸t ▸B ▸u ▸v δ≤₁ δ≤₂
+      with K-view 𝟘 m
+    … | is-all ⦃ (ok) ⦄ =
+        sub (K₀ₘ₂ (▸-𝟘 ▸A) (▸-𝟘 ▸t) (▸-𝟘 ▸B) ▸u (▸-𝟘 ▸v)) (δ≤₂ ok)
+    … | is-some-yes _   =
+        sub (K₀ₘ₁ refl (▸-𝟘 ▸A) (▸-𝟘 ▸t) ▸B ▸u (▸-𝟘 ▸v)) δ≤₁
+    … | is-other ⦃ (≤some) ⦄ 𝟘≢𝟘 =
+        ⊥-elim (lemma _ hyp ≤some (λ ≡some → 𝟘≢𝟘 ≡some refl))
+      where
+      lemma : ∀ em → em ≡ not-none sem → em ≤ᵉᵐ some → em ≢ some → ⊥
+      lemma none () _ _
+      lemma all _ () _
+      lemma some _ em≤ em≢some = em≢some refl
+
+  opaque
+
+    -- A generalisation of the usage rule K₀ₘ₁:
+    -- erased-matches-for-K m ≡ some has been replaced by
+    -- erased-matches-for-K m ≡ not-none sem.
+
+    K₀ₘ₁-generalised :
+      ⦃ ok : JK-with-omega ⦄ →
+      erased-matches-for-K m ≡ not-none sem →
+      p ≡ 𝟘 →
+      γ₁ ▸[ m₁ ] A →
+      γ₂ ▸[ m₂ ] t →
+      γ₃ ∙ 𝟘 ▸[ m ] B →
+      γ₄ ▸[ m ] u →
+      γ₅ ▸[ m₃ ] v →
+      ω ·ᶜ (γ₃ +ᶜ γ₄) ▸[ m ] K p A t B u v
+    K₀ₘ₁-generalised {m} {γ₃} {γ₄} ⦃ ok = has-omega ⦄ hyp refl ▸A ▸t ▸B ▸u ▸v =
+      K₀ₘ₁-generalised′ hyp refl ▸A ▸t ▸B ▸u ▸v
+        (≤ᶜ-reflexive (·ᶜ-congʳ (ω≡ω has-omega erased-matches-JK-≤-some-JK-with-omega)))
+        λ _ → begin
+          ω ·ᶜ (γ₃ +ᶜ γ₄) ≤⟨ ω·ᶜ+ᶜ≤ω·ᶜʳ ⟩
+          ω ·ᶜ γ₄         ≤⟨ ω·ᶜ-decreasing ⟩
+          γ₄              ∎
+      where
+      open ≤ᶜ-reasoning
 
 ------------------------------------------------------------------------
 -- A lemma related to level literals
@@ -1877,15 +2010,15 @@ opaque
 
     ·-⌈⌉-J : ⌜ m ⌝ ·ᶜ ⌈ J p q A t B u v w ⌉ m ≈ᶜ ⌈ J p q A t B u v w ⌉ m
     ·-⌈⌉-J {p} {q} {t} {B} {u} {v} {w} with J-view p q m
-    … | is-all _ = ·-⌈⌉ u
-    … | is-some-yes _ _ = begin
+    … | is-all = ·-⌈⌉ u
+    … | is-some-yes _ = begin
       ⌜ m ⌝ ·ᶜ ω ·ᶜ (tailₘ (tailₘ (⌈ B ⌉ m)) +ᶜ ⌈ u ⌉ m)          ≈⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
       ω ·ᶜ ⌜ m ⌝ ·ᶜ (tailₘ (tailₘ (⌈ B ⌉ m)) +ᶜ ⌈ u ⌉ m)          ≈⟨ ·ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _) ⟩
       ω ·ᶜ (⌜ m ⌝ ·ᶜ tailₘ (tailₘ (⌈ B ⌉ m)) +ᶜ ⌜ m ⌝ ·ᶜ ⌈ u ⌉ m) ≈˘⟨ ·ᶜ-congˡ (+ᶜ-congʳ (tailₘ-distrib-·ᶜ _ (tailₘ (⌈ B ⌉ m)))) ⟩
       ω ·ᶜ (tailₘ (⌜ m ⌝ ·ᶜ tailₘ (⌈ B ⌉ m)) +ᶜ ⌜ m ⌝ ·ᶜ ⌈ u ⌉ m) ≈˘⟨ ·ᶜ-congˡ (+ᶜ-congʳ (tailₘ-cong (tailₘ-distrib-·ᶜ _ (⌈ B ⌉ m)))) ⟩
       ω ·ᶜ (tailₘ (tailₘ (⌜ m ⌝ ·ᶜ ⌈ B ⌉ m)) +ᶜ ⌜ m ⌝ ·ᶜ ⌈ u ⌉ m) ≈⟨ ·ᶜ-congˡ (+ᶜ-cong (tailₘ-cong (tailₘ-cong (·-⌈⌉ B))) (·-⌈⌉ u)) ⟩
       ω ·ᶜ (tailₘ (tailₘ (⌈ B ⌉ m)) +ᶜ ⌈ u ⌉ m)                   ∎
-    … | is-other _ _ = begin
+    … | is-other _ = begin
       ⌜ m ⌝ ·ᶜ ω ·ᶜ (⌈ t ⌉ m +ᶜ tailₘ (tailₘ (⌈ B ⌉ m)) +ᶜ ⌈ u ⌉ m +ᶜ ⌈ v ⌉ m +ᶜ ⌈ w ⌉ m)
         ≈⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
       ω ·ᶜ ⌜ m ⌝ ·ᶜ (⌈ t ⌉ m +ᶜ tailₘ (tailₘ (⌈ B ⌉ m)) +ᶜ ⌈ u ⌉ m +ᶜ ⌈ v ⌉ m +ᶜ ⌈ w ⌉ m)
@@ -1902,14 +2035,14 @@ opaque
 
     ·-⌈⌉-K : ⌜ m ⌝ ·ᶜ ⌈ K p A t B u v ⌉ m ≈ᶜ ⌈ K p A t B u v ⌉ m
     ·-⌈⌉-K {p} {t} {B} {u} {v} with K-view p m
-    … | is-all _ = ·-⌈⌉ u
-    … | is-some-yes _ _ = begin
+    … | is-all = ·-⌈⌉ u
+    … | is-some-yes _ = begin
       ⌜ m ⌝ ·ᶜ ω ·ᶜ (tailₘ (⌈ B ⌉ m) +ᶜ ⌈ u ⌉ m)          ≈⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
       ω ·ᶜ ⌜ m ⌝ ·ᶜ (tailₘ (⌈ B ⌉ m) +ᶜ ⌈ u ⌉ m)          ≈⟨ ·ᶜ-congˡ (·ᶜ-distribˡ-+ᶜ _ _ _) ⟩
       ω ·ᶜ (⌜ m ⌝ ·ᶜ tailₘ (⌈ B ⌉ m) +ᶜ ⌜ m ⌝ ·ᶜ ⌈ u ⌉ m) ≈˘⟨ ·ᶜ-congˡ (+ᶜ-congʳ (tailₘ-distrib-·ᶜ _ (⌈ B ⌉ m))) ⟩
       ω ·ᶜ (tailₘ (⌜ m ⌝ ·ᶜ ⌈ B ⌉ m) +ᶜ ⌜ m ⌝ ·ᶜ ⌈ u ⌉ m) ≈⟨ ·ᶜ-congˡ (+ᶜ-cong (tailₘ-cong (·-⌈⌉ B)) (·-⌈⌉ u)) ⟩
       ω ·ᶜ (tailₘ (⌈ B ⌉ m) +ᶜ ⌈ u ⌉ m)                   ∎
-    … | is-other _ _ = begin
+    … | is-other _ = begin
       ⌜ m ⌝ ·ᶜ ω ·ᶜ (⌈ t ⌉ m +ᶜ tailₘ (⌈ B ⌉ m) +ᶜ ⌈ u ⌉ m +ᶜ ⌈ v ⌉ m)
         ≈⟨ ⌜⌝·ᶜ-comm _ _ _ ⟩
       ω ·ᶜ ⌜ m ⌝ ·ᶜ (⌈ t ⌉ m +ᶜ tailₘ (⌈ B ⌉ m) +ᶜ ⌈ u ⌉ m +ᶜ ⌈ v ⌉ m)
@@ -2093,75 +2226,75 @@ usage-upper-bound ⦃ ok ⦄ ok′ = usage-upper-bound′
   usage-upper-bound′
     {m}
     (Jₘ {p} {q} {γ₂} {t} {γ₃} {B} {γ₄} {u} {γ₅} {v} {γ₆} {w}
-       ≤some ok _ ▸t ▸B ▸u ▸v ▸w)
+       ⦃ (≤some) ⦄ ok _ ▸t ▸B ▸u ▸v ▸w)
     with J-view p q m
-  … | is-all ≡all               = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
-  … | is-some-yes ≡some p≡𝟘×q≡𝟘 = ⊥-elim $ ok ≡some p≡𝟘×q≡𝟘
-  … | is-other _ _              = begin
-    ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆)                           ≤⟨ ·ᶜ-monotoneʳ $
-                                                                   +ᶜ-monotone (usage-upper-bound′ ▸t) $
-                                                                   +ᶜ-monotone (tailₘ-monotone (tailₘ-monotone (usage-upper-bound′ ▸B))) $
-                                                                   +ᶜ-monotone (usage-upper-bound′ ▸u) $
-                                                                   +ᶜ-monotone (usage-upper-bound′ ▸v) $
-                                                                   usage-upper-bound′ ▸w ⟩
-    ω ·ᶜ
-    (⌈ t ⌉ m +ᶜ
-     tailₘ (tailₘ (⌈ B ⌉ m)) +ᶜ ⌈ u ⌉ m +ᶜ ⌈ v ⌉ m +ᶜ ⌈ w ⌉ m)  ∎
-    where
-    open ≤ᶜ-reasoning
+  … | is-all ⦃ (≡all) ⦄               = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
+  … | is-some-yes ⦃ (≡some) ⦄ p≡𝟘×q≡𝟘 = ⊥-elim $ ok ≡some p≡𝟘×q≡𝟘
+  … | is-other ⦃ ok ⦄ _               =
+    ≤ᶜ-trans (·ᶜ-monotoneʳ $
+             +ᶜ-monotone (usage-upper-bound′ ▸t) $
+             +ᶜ-monotone (tailₘ-monotone (tailₘ-monotone (usage-upper-bound′ ▸B))) $
+             +ᶜ-monotone (usage-upper-bound′ ▸u) $
+             +ᶜ-monotone (usage-upper-bound′ ▸v) $
+             usage-upper-bound′ ▸w)
+      (≤ᶜ-reflexive (·ᶜ-congʳ (ω≡ω (erased-matches-for-JK-supports-ω _)
+        (erased-matches-JK-≤-some-JK-with-omega ⦃ ok ⦄))))
 
   usage-upper-bound′
-    {m} (J₀ₘ₁ {p} {q} {γ₃} {B} {γ₄} {u} ≡some p≡𝟘 q≡𝟘 _ ▸t ▸B ▸u ▸v ▸w)
+    {m} (J₀ₘ₁ {p} {q} {γ₃} {B} {γ₄} {u} ⦃ (≡some) ⦄ p≡𝟘 q≡𝟘 _ ▸t ▸B ▸u ▸v ▸w)
     with J-view p q m
-  … | is-all ≡all     = case trans (PE.sym ≡some) ≡all of λ ()
-  … | is-other _ 𝟘≢𝟘  = ⊥-elim $ 𝟘≢𝟘 ≡some (p≡𝟘 , q≡𝟘)
-  … | is-some-yes _ _ = begin
-    ω ·ᶜ (γ₃ +ᶜ γ₄)                            ≤⟨ ·ᶜ-monotoneʳ $
-                                                  +ᶜ-monotone (tailₘ-monotone (tailₘ-monotone (usage-upper-bound′ ▸B))) $
-                                                  usage-upper-bound′ ▸u ⟩
-    ω ·ᶜ (tailₘ (tailₘ (⌈ B ⌉ m)) +ᶜ ⌈ u ⌉ m)  ∎
+  … | is-all ⦃ (≡all) ⦄     = case trans (PE.sym ≡some) ≡all of λ ()
+  … | is-other 𝟘≢𝟘  = ⊥-elim $ 𝟘≢𝟘 ≡some (p≡𝟘 , q≡𝟘)
+  … | is-some-yes ⦃ ok ⦄ _ =
+    ≤ᶜ-trans (·ᶜ-monotoneʳ $
+             +ᶜ-monotone (tailₘ-monotone (tailₘ-monotone (usage-upper-bound′ ▸B))) $
+             usage-upper-bound′ ▸u)
+      (≤ᶜ-reflexive (·ᶜ-congʳ (ω≡ω (erased-matches-for-JK-supports-ω _)
+        (erased-matches-JK-≤-some-JK-with-omega ⦃ erased-matches-JK-≡-some-≤-some ⦃ ok ⦄ ⦄))))
     where
     open ≤ᶜ-reasoning
 
-  usage-upper-bound′ {m} (J₀ₘ₂ {p} {q} ≡all _ _ _ ▸u _ _)
+  usage-upper-bound′ {m} (J₀ₘ₂ {p} {q} ⦃ (≡all) ⦄ _ _ _ ▸u _ _)
     with J-view p q m
-  … | is-other ≤some _    = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
-  … | is-some-yes ≡some _ = case trans (PE.sym ≡some) ≡all of λ ()
-  … | is-all _            = usage-upper-bound′ ▸u
+  … | is-other ⦃ (≤some) ⦄ _    = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
+  … | is-some-yes ⦃ (≡some) ⦄ _ = case trans (PE.sym ≡some) ≡all of λ ()
+  … | is-all                    = usage-upper-bound′ ▸u
 
   usage-upper-bound′
     {m}
-    (Kₘ {p} {γ₂} {t} {γ₃} {B} {γ₄} {u} {γ₅} {v} ≤some ok _ ▸t ▸B ▸u ▸v)
+    (Kₘ {p} {γ₂} {t} {γ₃} {B} {γ₄} {u} {γ₅} {v} ⦃ (≤some) ⦄ ok _ ▸t ▸B ▸u ▸v)
     with K-view p m
-  … | is-all ≡all           = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
-  … | is-some-yes ≡some p≡𝟘 = ⊥-elim $ ok ≡some p≡𝟘
-  … | is-other _ _          = begin
-    ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅)                              ≤⟨ ·ᶜ-monotoneʳ $
-                                                                +ᶜ-monotone (usage-upper-bound′ ▸t) $
-                                                                +ᶜ-monotone (tailₘ-monotone (usage-upper-bound′ ▸B)) $
-                                                                +ᶜ-monotone (usage-upper-bound′ ▸u) $
-                                                                usage-upper-bound′ ▸v ⟩
-    ω ·ᶜ (⌈ t ⌉ m +ᶜ tailₘ (⌈ B ⌉ m) +ᶜ ⌈ u ⌉ m +ᶜ ⌈ v ⌉ m)  ∎
+  … | is-all ⦃ (≡all) ⦄           = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
+  … | is-some-yes ⦃ (≡some) ⦄ p≡𝟘 = ⊥-elim $ ok ≡some p≡𝟘
+  … | is-other ⦃ ok ⦄ _           =
+    ≤ᶜ-trans (·ᶜ-monotoneʳ $
+             +ᶜ-monotone (usage-upper-bound′ ▸t) $
+             +ᶜ-monotone (tailₘ-monotone (usage-upper-bound′ ▸B)) $
+             +ᶜ-monotone (usage-upper-bound′ ▸u) $
+             usage-upper-bound′ ▸v)
+      (≤ᶜ-reflexive (·ᶜ-congʳ (ω≡ω (erased-matches-for-JK-supports-ω _)
+          (erased-matches-JK-≤-some-JK-with-omega ⦃ ok ⦄))))
     where
     open ≤ᶜ-reasoning
 
   usage-upper-bound′
-    {m} (K₀ₘ₁ {p} {γ₃} {B} {γ₄} {u} ≡some p≡𝟘 _ ▸t ▸B ▸u ▸v)
+    {m} (K₀ₘ₁ {p} {γ₃} {B} {γ₄} {u} ⦃ (≡some) ⦄ p≡𝟘 _ ▸t ▸B ▸u ▸v)
     with K-view p m
-  … | is-all ≡all     = case trans (PE.sym ≡some) ≡all of λ ()
-  … | is-other _ 𝟘≢𝟘  = ⊥-elim $ 𝟘≢𝟘 ≡some p≡𝟘
-  … | is-some-yes _ _ = begin
-    ω ·ᶜ (γ₃ +ᶜ γ₄)                    ≤⟨ ·ᶜ-monotoneʳ $
-                                          +ᶜ-monotone (tailₘ-monotone (usage-upper-bound′ ▸B)) $
-                                          usage-upper-bound′ ▸u ⟩
-    ω ·ᶜ (tailₘ (⌈ B ⌉ m) +ᶜ ⌈ u ⌉ m)  ∎
+  … | is-all ⦃ (≡all) ⦄ = case trans (PE.sym ≡some) ≡all of λ ()
+  … | is-other 𝟘≢𝟘  = ⊥-elim $ 𝟘≢𝟘 ≡some p≡𝟘
+  … | is-some-yes ⦃ ok ⦄ _ =
+    ≤ᶜ-trans (·ᶜ-monotoneʳ $
+             +ᶜ-monotone (tailₘ-monotone (usage-upper-bound′ ▸B)) $
+             usage-upper-bound′ ▸u)
+      (≤ᶜ-reflexive (·ᶜ-congʳ (ω≡ω (erased-matches-for-JK-supports-ω _)
+          (erased-matches-JK-≤-some-JK-with-omega ⦃ erased-matches-JK-≡-some-≤-some ⦃ ok ⦄ ⦄) )))
     where
     open ≤ᶜ-reasoning
 
-  usage-upper-bound′ {m} (K₀ₘ₂ {p} ≡all _ _ _ ▸u _) with K-view p m
-  … | is-other ≤some _    = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
-  … | is-some-yes ≡some _ = case trans (PE.sym ≡some) ≡all of λ ()
-  … | is-all _            = usage-upper-bound′ ▸u
+  usage-upper-bound′ {m} (K₀ₘ₂ {p} ⦃ (≡all) ⦄ _ _ _ ▸u _) with K-view p m
+  … | is-other ⦃ (≤some) ⦄ _    = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
+  … | is-some-yes ⦃ (≡some) ⦄ _ = case trans (PE.sym ≡some) ≡all of λ ()
+  … | is-all                    = usage-upper-bound′ ▸u
 
   usage-upper-bound′ ([]-congₘ _ _ _ _ _ _) =
     ≤ᶜ-refl
@@ -2240,40 +2373,40 @@ opaque
   … | yes _     = Id₀ₘ ok ▸A ▸t ▸u
   usage-inf rflₘ =
     rflₘ
-  usage-inf {m} (Jₘ {p} {q} ≤some ok ▸A ▸t ▸B ▸u ▸v ▸w) with J-view p q m
-  … | is-all ≡all               = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
-  … | is-some-yes ≡some p≡𝟘×q≡𝟘 = ⊥-elim $ ok ≡some p≡𝟘×q≡𝟘
-  … | is-other _ _              =
-    Jₘ ≤some ok ▸A (usage-inf ▸t) (Conₘ-interchange₂ (usage-inf ▸B) ▸B)
+  usage-inf {m} (Jₘ {p} {q} ⦃ (≤some) ⦄ ok ▸A ▸t ▸B ▸u ▸v ▸w) with J-view p q m
+  … | is-all ⦃ (≡all) ⦄               = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
+  … | is-some-yes ⦃ (≡some) ⦄ p≡𝟘×q≡𝟘 = ⊥-elim $ ok ≡some p≡𝟘×q≡𝟘
+  … | is-other ⦃ (≤some′) ⦄ _         =
+    Jₘ ⦃ ≤some′ ⦄ ok ▸A (usage-inf ▸t) (Conₘ-interchange₂ (usage-inf ▸B) ▸B)
       (usage-inf ▸u) (usage-inf ▸v) (usage-inf ▸w)
-  usage-inf {m} (J₀ₘ₁ {p} {q} ≡some p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸v ▸w)
+  usage-inf {m} (J₀ₘ₁ {p} {q} ⦃ (≡some) ⦄ p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸v ▸w)
     with J-view p q m
-  … | is-all ≡all     = case trans (PE.sym ≡some) ≡all of λ ()
-  … | is-other _ 𝟘≢𝟘  = ⊥-elim $ 𝟘≢𝟘 ≡some (p≡𝟘 , q≡𝟘)
-  … | is-some-yes _ _ =
-    J₀ₘ₁ ≡some p≡𝟘 q≡𝟘 ▸A (usage-inf ▸t)
+  … | is-all ⦃ (≡all) ⦄          = case trans (PE.sym ≡some) ≡all of λ ()
+  … | is-other 𝟘≢𝟘               = ⊥-elim $ 𝟘≢𝟘 ≡some (p≡𝟘 , q≡𝟘)
+  … | is-some-yes ⦃ (≡some′) ⦄ _ =
+    J₀ₘ₁ ⦃ ≡some′ ⦄ p≡𝟘 q≡𝟘 ▸A (usage-inf ▸t)
       (Conₘ-interchange₂ (usage-inf ▸B) ▸B) (usage-inf ▸u) (usage-inf ▸v)
       (usage-inf ▸w)
-  usage-inf {m} (J₀ₘ₂ {p} {q} ≡all ▸A ▸t ▸B ▸u ▸v ▸w) with J-view p q m
-  … | is-other ≤some _    = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
-  … | is-some-yes ≡some _ = case trans (PE.sym ≡some) ≡all of λ ()
-  … | is-all _            = J₀ₘ₂ ≡all ▸A ▸t ▸B (usage-inf ▸u) ▸v ▸w
-  usage-inf {m} (Kₘ {p} ≤some ok ▸A ▸t ▸B ▸u ▸v) with K-view p m
-  … | is-all ≡all           = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
-  … | is-some-yes ≡some p≡𝟘 = ⊥-elim $ ok ≡some p≡𝟘
-  … | is-other _ _          =
-    Kₘ ≤some ok ▸A (usage-inf ▸t) (Conₘ-interchange₁ (usage-inf ▸B) ▸B)
+  usage-inf {m} (J₀ₘ₂ {p} {q} ⦃ (≡all) ⦄ ▸A ▸t ▸B ▸u ▸v ▸w) with J-view p q m
+  … | is-other ⦃ (≤some) ⦄ _    = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
+  … | is-some-yes ⦃ (≡some) ⦄ _ = case trans (PE.sym ≡some) ≡all of λ ()
+  … | is-all                    = J₀ₘ₂ ⦃ ≡all ⦄ ▸A ▸t ▸B (usage-inf ▸u) ▸v ▸w
+  usage-inf {m} (Kₘ {p} ⦃ (≤some) ⦄ ok ▸A ▸t ▸B ▸u ▸v) with K-view p m
+  … | is-all ⦃ (≡all) ⦄           = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
+  … | is-some-yes ⦃ (≡some) ⦄ p≡𝟘 = ⊥-elim $ ok ≡some p≡𝟘
+  … | is-other ⦃ (≤some′) ⦄ _     =
+    Kₘ ⦃ ≤some′ ⦄ ok ▸A (usage-inf ▸t) (Conₘ-interchange₁ (usage-inf ▸B) ▸B)
       (usage-inf ▸u) (usage-inf ▸v)
-  usage-inf {m} (K₀ₘ₁ {p} ≡some p≡𝟘 ▸A ▸t ▸B ▸u ▸v) with K-view p m
-  … | is-all ≡all     = case trans (PE.sym ≡some) ≡all of λ ()
-  … | is-other _ 𝟘≢𝟘  = ⊥-elim $ 𝟘≢𝟘 ≡some p≡𝟘
-  … | is-some-yes _ _ =
-    K₀ₘ₁ ≡some p≡𝟘 ▸A (usage-inf ▸t) (Conₘ-interchange₁ (usage-inf ▸B) ▸B)
+  usage-inf {m} (K₀ₘ₁ {p} ⦃ (≡some) ⦄ p≡𝟘 ▸A ▸t ▸B ▸u ▸v) with K-view p m
+  … | is-all ⦃ (≡all) ⦄          = case trans (PE.sym ≡some) ≡all of λ ()
+  … | is-other 𝟘≢𝟘               = ⊥-elim $ 𝟘≢𝟘 ≡some p≡𝟘
+  … | is-some-yes ⦃ (≡some′) ⦄ _ =
+    K₀ₘ₁ ⦃ ≡some′ ⦄ p≡𝟘 ▸A (usage-inf ▸t) (Conₘ-interchange₁ (usage-inf ▸B) ▸B)
       (usage-inf ▸u) (usage-inf ▸v)
-  usage-inf {m} (K₀ₘ₂ {p} ≡all ▸A ▸t ▸B ▸u ▸v) with K-view p m
-  … | is-other ≤some _    = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
-  … | is-some-yes ≡some _ = case trans (PE.sym ≡some) ≡all of λ ()
-  … | is-all _            = K₀ₘ₂ ≡all ▸A ▸t ▸B (usage-inf ▸u) ▸v
+  usage-inf {m} (K₀ₘ₂ {p} ⦃ (≡all) ⦄ ▸A ▸t ▸B ▸u ▸v) with K-view p m
+  … | is-other ⦃ (≤some) ⦄ _    = case ≤ᵉᵐ→≡all→≡all ≤some ≡all of λ ()
+  … | is-some-yes ⦃ (≡some) ⦄ _ = case trans (PE.sym ≡some) ≡all of λ ()
+  … | is-all                    = K₀ₘ₂ ⦃ ≡all ⦄ ▸A ▸t ▸B (usage-inf ▸u) ▸v
   usage-inf ([]-congₘ ▸l ▸A ▸t ▸u ▸v ok) =
     []-congₘ ▸l ▸A ▸t ▸u ▸v ok
   usage-inf (sub γ▸t x) = usage-inf γ▸t
@@ -2394,26 +2527,26 @@ opaque
       (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸t) (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸u)
   ▸inline _ rflₘ =
     rflₘ
-  ▸inline ▸ξ (Jₘ ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v ▸w) =
-    Jₘ ok₁ ok₂ (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸A) (▸inline ▸ξ ▸t)
+  ▸inline ▸ξ (Jₘ ok ▸A ▸t ▸B ▸u ▸v ▸w) =
+    Jₘ ok (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸A) (▸inline ▸ξ ▸t)
       (▸inline ▸ξ ▸B) (▸inline ▸ξ ▸u) (▸inline ▸ξ ▸v) (▸inline ▸ξ ▸w)
-  ▸inline ▸ξ (J₀ₘ₁ ok₁ ok₂ ok₃ ▸A ▸t ▸B ▸u ▸v ▸w) =
-    J₀ₘ₁ ok₁ ok₂ ok₃ (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸A)
+  ▸inline ▸ξ (J₀ₘ₁ ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v ▸w) =
+    J₀ₘ₁ ok₁ ok₂ (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸A)
       (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸t) (▸inline ▸ξ ▸B) (▸inline ▸ξ ▸u)
       (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸v) (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸w)
-  ▸inline ▸ξ (J₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸v ▸w) =
-    J₀ₘ₂ ok (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸A) (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸t)
+  ▸inline ▸ξ (J₀ₘ₂ ▸A ▸t ▸B ▸u ▸v ▸w) =
+    J₀ₘ₂ (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸A) (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸t)
       (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸B) (▸inline ▸ξ ▸u)
       (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸v) (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸w)
-  ▸inline ▸ξ (Kₘ ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v) =
-    Kₘ ok₁ ok₂ (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸A) (▸inline ▸ξ ▸t)
+  ▸inline ▸ξ (Kₘ ok ▸A ▸t ▸B ▸u ▸v) =
+    Kₘ ok (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸A) (▸inline ▸ξ ▸t)
       (▸inline ▸ξ ▸B) (▸inline ▸ξ ▸u) (▸inline ▸ξ ▸v)
-  ▸inline ▸ξ (K₀ₘ₁ ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v) =
-    K₀ₘ₁ ok₁ ok₂ (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸A)
+  ▸inline ▸ξ (K₀ₘ₁ ok ▸A ▸t ▸B ▸u ▸v) =
+    K₀ₘ₁ ok (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸A)
       (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸t) (▸inline ▸ξ ▸B) (▸inline ▸ξ ▸u)
       (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸v)
-  ▸inline ▸ξ (K₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸v) =
-    K₀ₘ₂ ok (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸A) (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸t)
+  ▸inline ▸ξ (K₀ₘ₂ ▸A ▸t ▸B ▸u ▸v) =
+    K₀ₘ₂ (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸A) (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸t)
       (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸B) (▸inline ▸ξ ▸u)
       (▸inline (▸-𝟘ᵐ-DCon ▸ξ) ▸v)
   ▸inline ▸ξ ([]-congₘ ▸l ▸A ▸t ▸u ▸v ok) =

--- a/Graded/Usage/QuantityTranslation.agda
+++ b/Graded/Usage/QuantityTranslation.agda
@@ -28,11 +28,13 @@ open import Graded.Context
 import Graded.Context.Properties
 open import Graded.Context.QuantityTranslation 𝕄₁ 𝕄₂ tr
   as CQ using (tr-Conₘ)
+open import Graded.Modality.Omega-instances
 import Graded.Modality.Properties
 open import Graded.Usage
 open import Graded.Usage.Erased-matches
 import Graded.Usage.Properties
 import Graded.Usage.Properties.Zero-one
+import Graded.Usage.Restrictions.Instance
 import Graded.Usage.Restrictions.Satisfied
 open import Graded.Modality.Morphism.Usage-restrictions
 import Graded.Modality.Morphism.Backward-instances
@@ -265,8 +267,8 @@ module Is-morphism
       tr-Conₘ-nrᶜ
       where
       open Graded.Modality.Morphism.Forward-instances common-properties
-      open import Graded.Usage.Restrictions.Instance R₁
-      open import Graded.Usage.Restrictions.Instance R₂
+      open Graded.Usage.Restrictions.Instance R₁
+      open Graded.Usage.Restrictions.Instance R₂
       open CQ.Is-nr-preserving-morphism nr-preserving
       open CR₂
     tr-▸
@@ -391,7 +393,7 @@ module Is-morphism
       sub rflₘ tr-Conₘ-𝟘ᶜ-≤ᶜ
     tr-▸
       (Jₘ {m} {p} {q} {γ₂} {γ₃} {γ₄} {γ₅} {γ₆}
-         _ _ ▸A ▸t ▸B ▸u ▸v ▸w) = sub
+         _ ▸A ▸t ▸B ▸u ▸v ▸w) = sub
       (Jₘ-generalised (tr-▸[𝟘ᵐ?] ▸A) (tr-▸ ▸t)
          (sub (tr-▸ ▸B) $ begin
             tr-Conₘ γ₃ ∙ Mo₂.⌜ tr-Mode m ⌝ M₂.· tr p ∙
@@ -400,22 +402,27 @@ module Is-morphism
             tr-Conₘ γ₃ ∙ tr (Mo₁.⌜ m ⌝ M₁.· p) ∙ tr (Mo₁.⌜ m ⌝ M₁.· q)  ∎)
          (tr-▸ ▸u) (tr-▸ ▸v) (tr-▸ ▸w))
       (begin
-         tr-Conₘ (M₁.ω C₁.·ᶜ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅ C₁.+ᶜ γ₆))   ≈⟨ tr-Conₘ-·ᶜ ⟩
+         tr-Conₘ (ω C₁.·ᶜ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅ C₁.+ᶜ γ₆))   ≈⟨ tr-Conₘ-·ᶜ ⟩
 
-         tr M₁.ω C₂.·ᶜ tr-Conₘ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅ C₁.+ᶜ γ₆)  ≤⟨ flip ·ᶜ-monotone tr-ω $
+         tr ω C₂.·ᶜ tr-Conₘ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅ C₁.+ᶜ γ₆)  ≤⟨ flip ·ᶜ-monotone
+                                                                            (M.Is-omega-preserving-morphism.tr-ω omega-preserving) $
                                                                             ≤ᶜ-reflexive $
                                                                             ≈ᶜ-trans tr-Conₘ-+ᶜ $ +ᶜ-congˡ $
                                                                             ≈ᶜ-trans tr-Conₘ-+ᶜ $ +ᶜ-congˡ $
                                                                             ≈ᶜ-trans tr-Conₘ-+ᶜ $ +ᶜ-congˡ
                                                                             tr-Conₘ-+ᶜ ⟩
-         M₂.ω C₂.·ᶜ
+         ω C₂.·ᶜ
          (tr-Conₘ γ₂ C₂.+ᶜ tr-Conₘ γ₃ C₂.+ᶜ tr-Conₘ γ₄ C₂.+ᶜ
-          tr-Conₘ γ₅ C₂.+ᶜ tr-Conₘ γ₆)                                   ∎)
+          tr-Conₘ γ₅ C₂.+ᶜ tr-Conₘ γ₆)                                ∎)
       where
       open CR₂
+      open Graded.Modality.Morphism.Forward-instances common-properties
+      open Graded.Usage.Restrictions.Instance R₁
+      open Graded.Usage.Restrictions.Instance R₂
+
     tr-▸
       (J₀ₘ₁ {m} {γ₂} {γ₃} {γ₄} {γ₅} {γ₆}
-         ≡some refl refl ▸A ▸t ▸B ▸u ▸v ▸w) =
+         ⦃ (≡some) ⦄ refl refl ▸A ▸t ▸B ▸u ▸v ▸w) =
       case trivial-⊎-tr-𝟘 of λ where
         (inj₁ trivial₁) → sub
           (Jₘ-generalised (tr-▸[𝟘ᵐ?] ▸A) (tr-▸-trivial trivial₁ ▸t)
@@ -433,21 +440,22 @@ module Is-morphism
              (tr-▸ ▸u) (tr-▸-trivial trivial₁ ▸v)
              (tr-▸-trivial trivial₁ ▸w))
           (begin
-             tr-Conₘ (M₁.ω C₁.·ᶜ (γ₃ C₁.+ᶜ γ₄))                       ≡⟨ cong tr-Conₘ $ CP₁.≈ᶜ→≡ $ CP₁.≈ᶜ-trivial trivial₁ ⟩
+             tr-Conₘ (ω C₁.·ᶜ (γ₃ C₁.+ᶜ γ₄))                       ≡⟨ cong tr-Conₘ $ CP₁.≈ᶜ→≡ $ CP₁.≈ᶜ-trivial trivial₁ ⟩
 
              tr-Conₘ
-               (M₁.ω C₁.·ᶜ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅ C₁.+ᶜ γ₆))  ≈⟨ tr-Conₘ-·ᶜ ⟩
+               (ω C₁.·ᶜ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅ C₁.+ᶜ γ₆))  ≈⟨ tr-Conₘ-·ᶜ ⟩
 
-             tr M₁.ω C₂.·ᶜ
-             tr-Conₘ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅ C₁.+ᶜ γ₆)         ≤⟨ flip ·ᶜ-monotone tr-ω $
+             tr ω C₂.·ᶜ
+             tr-Conₘ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅ C₁.+ᶜ γ₆)      ≤⟨ flip ·ᶜ-monotone
+                                                                         (M.Is-omega-preserving-morphism.tr-ω omega-preserving) $
                                                                          ≤ᶜ-reflexive $
                                                                          ≈ᶜ-trans tr-Conₘ-+ᶜ $ +ᶜ-congˡ $
                                                                          ≈ᶜ-trans tr-Conₘ-+ᶜ $ +ᶜ-congˡ $
                                                                          ≈ᶜ-trans tr-Conₘ-+ᶜ $ +ᶜ-congˡ
                                                                          tr-Conₘ-+ᶜ ⟩
-             M₂.ω C₂.·ᶜ
+             ω C₂.·ᶜ
              (tr-Conₘ γ₂ C₂.+ᶜ tr-Conₘ γ₃ C₂.+ᶜ tr-Conₘ γ₄ C₂.+ᶜ
-              tr-Conₘ γ₅ C₂.+ᶜ tr-Conₘ γ₆)                            ∎)
+              tr-Conₘ γ₅ C₂.+ᶜ tr-Conₘ γ₆)                         ∎)
         (inj₂ tr-𝟘) → sub
           (J₀ₘ₁-generalised
              (≤ᵉᵐ→≡some→≡not-none
@@ -459,35 +467,44 @@ module Is-morphism
                 tr-Conₘ γ₃ ∙ tr M₁.𝟘 ∙ tr M₁.𝟘  ∎)
              (tr-▸ ▸u) (tr-▸[𝟘ᵐ?] ▸v) (tr-▸[𝟘ᵐ?] ▸w))
           (begin
-             tr-Conₘ (M₁.ω C₁.·ᶜ (γ₃ C₁.+ᶜ γ₄))        ≈⟨ tr-Conₘ-·ᶜ ⟩
-             tr M₁.ω C₂.·ᶜ tr-Conₘ (γ₃ C₁.+ᶜ γ₄)       ≤⟨ ·ᶜ-monotone (≤ᶜ-reflexive tr-Conₘ-+ᶜ) tr-ω ⟩
-             M₂.ω C₂.·ᶜ (tr-Conₘ γ₃ C₂.+ᶜ tr-Conₘ γ₄)  ∎)
+             tr-Conₘ (ω C₁.·ᶜ (γ₃ C₁.+ᶜ γ₄))        ≈⟨ tr-Conₘ-·ᶜ ⟩
+             tr ω C₂.·ᶜ tr-Conₘ (γ₃ C₁.+ᶜ γ₄)       ≤⟨ ·ᶜ-monotone (≤ᶜ-reflexive tr-Conₘ-+ᶜ)
+                                                       (M.Is-omega-preserving-morphism.tr-ω
+                                                          omega-preserving) ⟩
+             ω C₂.·ᶜ (tr-Conₘ γ₃ C₂.+ᶜ tr-Conₘ γ₄)  ∎)
       where
       open CR₂
-    tr-▸ (J₀ₘ₂ ≡all ▸A ▸t ▸B ▸u ▸v ▸w) = J₀ₘ₂
-      (≤ᵉᵐ→≡all→≡all (erased-matches-for-J-preserved ≈ᵐ-tr-Mode) ≡all)
+      open Graded.Modality.Morphism.Forward-instances common-properties
+      open Graded.Usage.Restrictions.Instance R₁
+      open Graded.Usage.Restrictions.Instance R₂
+    tr-▸ (J₀ₘ₂ ⦃ (≡all) ⦄ ▸A ▸t ▸B ▸u ▸v ▸w) = J₀ₘ₂
+      ⦃ ≤ᵉᵐ→≡all→≡all (erased-matches-for-J-preserved ≈ᵐ-tr-Mode) ≡all ⦄
       (tr-▸[𝟘ᵐ?] ▸A) (tr-▸[𝟘ᵐ?] ▸t) (tr-∙∙▸[𝟘ᵐ?] ▸B) (tr-▸ ▸u)
       (tr-▸[𝟘ᵐ?] ▸v) (tr-▸[𝟘ᵐ?] ▸w)
-    tr-▸ (Kₘ {m} {p} {γ₂} {γ₃} {γ₄} {γ₅} _ _ ▸A ▸t ▸B ▸u ▸v) = sub
+    tr-▸ (Kₘ {m} {p} {γ₂} {γ₃} {γ₄} {γ₅} _ ▸A ▸t ▸B ▸u ▸v) = sub
       (Kₘ-generalised (tr-▸[𝟘ᵐ?] ▸A) (tr-▸ ▸t)
          (sub (tr-▸ ▸B) $ begin
             tr-Conₘ γ₃ ∙ Mo₂.⌜ tr-Mode m ⌝ M₂.· tr p  ≈⟨ ≈ᶜ-refl ∙ tr-⌜⌝-· m ⟩
             tr-Conₘ γ₃ ∙ tr (Mo₁.⌜ m ⌝ M₁.· p)        ∎)
          (tr-▸ ▸u) (tr-▸ ▸v))
       (begin
-         tr-Conₘ (M₁.ω C₁.·ᶜ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅))   ≈⟨ tr-Conₘ-·ᶜ ⟩
+         tr-Conₘ (ω C₁.·ᶜ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅))   ≈⟨ tr-Conₘ-·ᶜ ⟩
 
-         tr M₁.ω C₂.·ᶜ tr-Conₘ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅)  ≤⟨ flip ·ᶜ-monotone tr-ω $
+         tr ω C₂.·ᶜ tr-Conₘ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅)  ≤⟨ flip ·ᶜ-monotone
+                                                                   (M.Is-omega-preserving-morphism.tr-ω omega-preserving) $
                                                                    ≤ᶜ-reflexive $
                                                                    ≈ᶜ-trans tr-Conₘ-+ᶜ $ +ᶜ-congˡ $
                                                                    ≈ᶜ-trans tr-Conₘ-+ᶜ $ +ᶜ-congˡ
                                                                    tr-Conₘ-+ᶜ ⟩
-         M₂.ω C₂.·ᶜ
+         ω C₂.·ᶜ
          (tr-Conₘ γ₂ C₂.+ᶜ tr-Conₘ γ₃ C₂.+ᶜ tr-Conₘ γ₄ C₂.+ᶜ
-          tr-Conₘ γ₅)                                           ∎)
+          tr-Conₘ γ₅)                                        ∎)
       where
       open CR₂
-    tr-▸ (K₀ₘ₁ {m} {γ₂} {γ₃} {γ₄} {γ₅} ≡some refl ▸A ▸t ▸B ▸u ▸v) =
+      open Graded.Modality.Morphism.Forward-instances common-properties
+      open Graded.Usage.Restrictions.Instance R₁
+      open Graded.Usage.Restrictions.Instance R₂
+    tr-▸ (K₀ₘ₁ {m} {γ₂} {γ₃} {γ₄} {γ₅} ⦃ (≡some) ⦄ refl ▸A ▸t ▸B ▸u ▸v) =
       case trivial-⊎-tr-𝟘 of λ where
         (inj₁ trivial₁) → sub
           (Kₘ-generalised (tr-▸[𝟘ᵐ?] ▸A) (tr-▸-trivial trivial₁ ▸t)
@@ -498,16 +515,16 @@ module Is-morphism
                 tr-Conₘ γ₃ ∙ tr M₁.𝟘                         ∎)
              (tr-▸ ▸u) (tr-▸-trivial trivial₁ ▸v))
           (begin
-             tr-Conₘ (M₁.ω C₁.·ᶜ (γ₃ C₁.+ᶜ γ₄))                     ≡⟨ cong tr-Conₘ $ CP₁.≈ᶜ→≡ $ CP₁.≈ᶜ-trivial trivial₁ ⟩
+             tr-Conₘ (ω C₁.·ᶜ (γ₃ C₁.+ᶜ γ₄))                     ≡⟨ cong tr-Conₘ $ CP₁.≈ᶜ→≡ $ CP₁.≈ᶜ-trivial trivial₁ ⟩
 
-             tr-Conₘ (M₁.ω C₁.·ᶜ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅))   ≈⟨ tr-Conₘ-·ᶜ ⟩
+             tr-Conₘ (ω C₁.·ᶜ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅))   ≈⟨ tr-Conₘ-·ᶜ ⟩
 
-             tr M₁.ω C₂.·ᶜ tr-Conₘ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅)  ≤⟨ flip ·ᶜ-monotone tr-ω $
+             tr ω C₂.·ᶜ tr-Conₘ (γ₂ C₁.+ᶜ γ₃ C₁.+ᶜ γ₄ C₁.+ᶜ γ₅)  ≤⟨ flip ·ᶜ-monotone (M.Is-omega-preserving-morphism.tr-ω omega-preserving) $
                                                                        ≤ᶜ-reflexive $
                                                                        ≈ᶜ-trans tr-Conₘ-+ᶜ $ +ᶜ-congˡ $
                                                                        ≈ᶜ-trans tr-Conₘ-+ᶜ $ +ᶜ-congˡ
                                                                        tr-Conₘ-+ᶜ ⟩
-             M₂.ω C₂.·ᶜ
+             ω C₂.·ᶜ
              (tr-Conₘ γ₂ C₂.+ᶜ tr-Conₘ γ₃ C₂.+ᶜ tr-Conₘ γ₄ C₂.+ᶜ
               tr-Conₘ γ₅)                                           ∎)
         (inj₂ tr-𝟘) → sub
@@ -521,13 +538,18 @@ module Is-morphism
                 tr-Conₘ γ₃ ∙ tr M₁.𝟘  ∎)
              (tr-▸ ▸u) (tr-▸[𝟘ᵐ?] ▸v))
           (begin
-             tr-Conₘ (M₁.ω C₁.·ᶜ (γ₃ C₁.+ᶜ γ₄))        ≈⟨ tr-Conₘ-·ᶜ ⟩
-             tr M₁.ω C₂.·ᶜ tr-Conₘ (γ₃ C₁.+ᶜ γ₄)       ≤⟨ ·ᶜ-monotone (≤ᶜ-reflexive tr-Conₘ-+ᶜ) tr-ω ⟩
-             M₂.ω C₂.·ᶜ (tr-Conₘ γ₃ C₂.+ᶜ tr-Conₘ γ₄)  ∎)
+             tr-Conₘ (ω C₁.·ᶜ (γ₃ C₁.+ᶜ γ₄))        ≈⟨ tr-Conₘ-·ᶜ ⟩
+             tr ω C₂.·ᶜ tr-Conₘ (γ₃ C₁.+ᶜ γ₄)       ≤⟨ ·ᶜ-monotone (≤ᶜ-reflexive tr-Conₘ-+ᶜ)
+                                                        (M.Is-omega-preserving-morphism.tr-ω
+                                                          omega-preserving) ⟩
+             ω C₂.·ᶜ (tr-Conₘ γ₃ C₂.+ᶜ tr-Conₘ γ₄)  ∎)
       where
       open CR₂
-    tr-▸ (K₀ₘ₂ ≡none ▸A ▸t ▸B ▸u ▸v) = K₀ₘ₂
-      (≤ᵉᵐ→≡all→≡all (erased-matches-for-K-preserved ≈ᵐ-tr-Mode) ≡none)
+      open Graded.Modality.Morphism.Forward-instances common-properties
+      open Graded.Usage.Restrictions.Instance R₁
+      open Graded.Usage.Restrictions.Instance R₂
+    tr-▸ (K₀ₘ₂ ⦃ (≡none) ⦄ ▸A ▸t ▸B ▸u ▸v) = K₀ₘ₂
+      ⦃ ≤ᵉᵐ→≡all→≡all (erased-matches-for-K-preserved ≈ᵐ-tr-Mode) ≡none ⦄
       (tr-▸[𝟘ᵐ?] ▸A) (tr-▸[𝟘ᵐ?] ▸t) (tr-∙▸[𝟘ᵐ?] ▸B) (tr-▸ ▸u)
       (tr-▸[𝟘ᵐ?] ▸v)
     tr-▸ ([]-congₘ {m} ▸l ▸A ▸t ▸u ▸v ok) = sub
@@ -746,7 +768,7 @@ module Is-order-embedding
 
   opaque
 
-    -- A variant of ? and tr-Conₘ-≤ᶜ-tr-Σ-·ᶜ for tr-BinderMode
+    -- A variant of tr-Conₘ-≤ᶜ-·ᶜ and tr-Conₘ-≤ᶜ-tr-Σ-·ᶜ for tr-BinderMode
 
     tr-Conₘ-≤ᶜ-tr-BinderMode-·ᶜ :
       ∀ {b} → tr-Conₘ γ C₂.≤ᶜ tr-BinderMode b p C₂.·ᶜ δ →
@@ -886,11 +908,11 @@ module Is-order-embedding
             (lemma-𝟘ᵐ?-𝟘ᵐ? t) (lemma-𝟘ᵐ?-𝟘ᵐ? u)
         rfl rflᵤ →
           RS₁.rflᵤ
-        (J _ _ _ _ _ _ _ _) (Jᵤ _ _ A t B u v w) →
+        (J _ _ _ _ _ _ _ _) (Jᵤ _ A t B u v w) →
           RS₁.Jᵤ-generalised (lemma-𝟘ᵐ?-𝟘ᵐ? A) (lemma m₁≳m₂ _ t)
             (lemma m₁≳m₂ _ B) (lemma m₁≳m₂ _ u) (lemma m₁≳m₂ _ v)
             (lemma m₁≳m₂ _ w)
-        (J _ _ _ _ _ _ _ _) (J₀ᵤ₁ ≡some tr-p≡𝟘 tr-q≡𝟘 A t B u v w) →
+        (J _ _ _ _ _ _ _ _) (J₀ᵤ₁ ⦃ (≡some) ⦄ tr-p≡𝟘 tr-q≡𝟘 A t B u v w) →
           subst (RS₁.Usage-restrictions-satisfied _)
             (sym $
              case trivial-⊎-tr-≡-𝟘-⇔ of λ where
@@ -920,22 +942,22 @@ module Is-order-embedding
               RS₁.Jᵤ-generalised (lemma-𝟘ᵐ?-𝟘ᵐ? A) (lemma-𝟘ᵐ? m₁≳m₂ t)
                 (lemma m₁≳m₂ _ B) (lemma m₁≳m₂ _ u) (lemma-𝟘ᵐ? m₁≳m₂ v)
                 (lemma-𝟘ᵐ? m₁≳m₂ w)
-        (J _ _ _ _ _ _ _ _) (J₀ᵤ₂ ≡all A t B u v w) →
+        (J _ _ _ _ _ _ _ _) (J₀ᵤ₂ ⦃ (≡all) ⦄ A t B u v w) →
           case m₁≳m₂ of λ where
             [ m₁≈m₂ ] →
               RS₁.J₀ᵤ₂
-                (≤ᵉᵐ→≡all→≡all (erased-matches-for-J-reflected m₁≈m₂)
-                   ≡all)
+                ⦃ ≤ᵉᵐ→≡all→≡all (erased-matches-for-J-reflected m₁≈m₂)
+                   ≡all ⦄
                 (lemma-𝟘ᵐ?-𝟘ᵐ? A) (lemma-𝟘ᵐ?-𝟘ᵐ? t) (lemma-𝟘ᵐ?-𝟘ᵐ? B)
                 (lemma m₁≳m₂ _ u) (lemma-𝟘ᵐ?-𝟘ᵐ? v) (lemma-𝟘ᵐ?-𝟘ᵐ? w)
             (𝟙ᵐ≳𝟘ᵐ _) →
               RS₁.Jᵤ-generalised (lemma-𝟘ᵐ?-𝟘ᵐ? A) (lemma-𝟘ᵐ? m₁≳m₂ t)
                 (lemma-𝟘ᵐ? m₁≳m₂ B) (lemma m₁≳m₂ _ u)
                 (lemma-𝟘ᵐ? m₁≳m₂ v) (lemma-𝟘ᵐ? m₁≳m₂ w)
-        (K _ _ _ _ _ _) (Kᵤ _ _ A t B u v) →
+        (K _ _ _ _ _ _) (Kᵤ _ A t B u v) →
           RS₁.Kᵤ-generalised (lemma-𝟘ᵐ?-𝟘ᵐ? A) (lemma m₁≳m₂ _ t)
             (lemma m₁≳m₂ _ B) (lemma m₁≳m₂ _ u) (lemma m₁≳m₂ _ v)
-        (K _ _ _ _ _ _) (K₀ᵤ₁ ≡some tr-p≡𝟘 A t B u v) →
+        (K _ _ _ _ _ _) (K₀ᵤ₁ ⦃ (≡some) ⦄ tr-p≡𝟘 A t B u v) →
           case m₁≳m₂ of λ where
             [ m₁≈m₂ ] →
               case singleton $ UR₁.erased-matches-for-K m₁ of λ where
@@ -956,12 +978,12 @@ module Is-order-embedding
             (𝟙ᵐ≳𝟘ᵐ _) →
               RS₁.Kᵤ-generalised (lemma-𝟘ᵐ?-𝟘ᵐ? A) (lemma-𝟘ᵐ? m₁≳m₂ t)
                 (lemma m₁≳m₂ _ B) (lemma m₁≳m₂ _ u) (lemma-𝟘ᵐ? m₁≳m₂ v)
-        (K _ _ _ _ _ _) (K₀ᵤ₂ ≡all A t B u v) →
+        (K _ _ _ _ _ _) (K₀ᵤ₂ ⦃ (≡all) ⦄ A t B u v) →
           case m₁≳m₂ of λ where
             [ m₁≈m₂ ] →
               RS₁.K₀ᵤ₂
-                (≤ᵉᵐ→≡all→≡all (erased-matches-for-K-reflected m₁≈m₂)
-                   ≡all)
+                ⦃ ≤ᵉᵐ→≡all→≡all (erased-matches-for-K-reflected m₁≈m₂)
+                   ≡all ⦄
                 (lemma-𝟘ᵐ?-𝟘ᵐ? A) (lemma-𝟘ᵐ?-𝟘ᵐ? t) (lemma-𝟘ᵐ?-𝟘ᵐ? B)
                 (lemma m₁≳m₂ _ u) (lemma-𝟘ᵐ?-𝟘ᵐ? v)
             (𝟙ᵐ≳𝟘ᵐ _) →
@@ -1243,8 +1265,8 @@ module Is-order-embedding
         γ≤nr-prθ′δ′η′
       where
       open Graded.Modality.Morphism.Backward-instances common-properties
-      open import Graded.Usage.Restrictions.Instance R₁
-      open import Graded.Usage.Restrictions.Instance R₂
+      open Graded.Usage.Restrictions.Instance R₁
+      open Graded.Usage.Restrictions.Instance R₂
       open CQ.Is-nr-reflecting-morphism nr-reflected
 
     tr-▸⁻¹′
@@ -1345,7 +1367,7 @@ module Is-order-embedding
       sub rflₘ (tr-Conₘ-≤ᶜ-𝟘ᶜ-→-≤ᶜ-𝟘ᶜ ≤𝟘)
 
     tr-▸⁻¹′
-      {m} (J p q _ _ _ _ _ _) (Jₘ {γ₃} _ _ ▸A ▸t ▸B ▸u ▸v ▸w) refl
+      {m} (J p q _ _ _ _ _ _) (Jₘ {γ₃} _ ▸A ▸t ▸B ▸u ▸v ▸w) refl
       γ≤ω[γ₂+γ₃+γ₄+γ₅+γ₆] =
       case tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ⁴ γ≤ω[γ₂+γ₃+γ₄+γ₅+γ₆] of λ
         (_ , γ₃′ , _ , _ , _ ,
@@ -1362,10 +1384,15 @@ module Is-order-embedding
          (tr-▸⁻¹′ _ ▸u refl γ₄′≤γ₄) (tr-▸⁻¹′ _ ▸v refl γ₅′≤γ₅)
          (tr-▸⁻¹′ _ ▸w refl γ₆′≤γ₆))
       γ≤ω[γ₂′+γ₃′+γ₄′+γ₅′+γ₆′]
+      where
+      open Graded.Usage.Restrictions.Instance R₁
+      open Graded.Usage.Restrictions.Instance R₂
+      open Graded.Modality.Morphism.Backward-instances common-properties
+      open CQ.Is-omega-reflecting tr-emb omega-reflecting
 
     tr-▸⁻¹′
       {m} {γ} (J p q _ _ _ _ _ _)
-      (J₀ₘ₁ {γ₃} {γ₄} ≡some tr-p≡𝟘 tr-q≡𝟘 ▸A ▸t ▸B ▸u ▸v ▸w) refl
+      (J₀ₘ₁ {γ₃} {γ₄} ⦃ (≡some) ⦄ tr-p≡𝟘 tr-q≡𝟘 ▸A ▸t ▸B ▸u ▸v ▸w) refl
       γ≤ω[γ₃+γ₄] =
       case
         (case trivial-⊎-tr-≡-𝟘-⇔ of λ where
@@ -1390,16 +1417,21 @@ module Is-order-embedding
          (tr-▸⁻¹′ _ ▸u refl γ₄′≤γ₄) (tr-▸[𝟘ᵐ?]⁻¹ ▸v .proj₂)
          (tr-▸[𝟘ᵐ?]⁻¹ ▸w .proj₂))
       γ≤ω[γ₃′+γ₄′]
+      where
+      open Graded.Usage.Restrictions.Instance R₁
+      open Graded.Usage.Restrictions.Instance R₂
+      open Graded.Modality.Morphism.Backward-instances common-properties
+      open CQ.Is-omega-reflecting tr-emb omega-reflecting
 
     tr-▸⁻¹′
-      (J _ _ _ _ _ _ _ _) (J₀ₘ₂ ≡all ▸A ▸t ▸B ▸u ▸v ▸w) refl ≤γ′ = J₀ₘ₂
-      (≤ᵉᵐ→≡all→≡all (erased-matches-for-J-reflected ≈ᵐ-tr-Mode) ≡all)
+      (J _ _ _ _ _ _ _ _) (J₀ₘ₂ ⦃ (≡all) ⦄ ▸A ▸t ▸B ▸u ▸v ▸w) refl ≤γ′ = J₀ₘ₂
+      ⦃ ≤ᵉᵐ→≡all→≡all (erased-matches-for-J-reflected ≈ᵐ-tr-Mode) ≡all ⦄
       (tr-▸[𝟘ᵐ?]⁻¹ ▸A .proj₂) (tr-▸[𝟘ᵐ?]⁻¹ ▸t .proj₂)
       (tr-∙∙▸[𝟘ᵐ?]⁻¹ ▸B .proj₂) (tr-▸⁻¹′ _ ▸u refl ≤γ′)
       (tr-▸[𝟘ᵐ?]⁻¹ ▸v .proj₂) (tr-▸[𝟘ᵐ?]⁻¹ ▸w .proj₂)
 
     tr-▸⁻¹′
-      {m} (K p _ _ _ _ _) (Kₘ {γ₃} _ _ ▸A ▸t ▸B ▸u ▸v) refl
+      {m} (K p _ _ _ _ _) (Kₘ {γ₃} _ ▸A ▸t ▸B ▸u ▸v) refl
       γ≤ω[γ₂+γ₃+γ₄+γ₅] =
       case tr-Conₘ-≤ᶜ-ωᶜ·ᶜ+ᶜ³ γ≤ω[γ₂+γ₃+γ₄+γ₅] of λ
         (_ , γ₃′ , _ , _ , γ₂′≤γ₂ , γ₃′≤γ₃ , γ₄′≤γ₄ , γ₅′≤γ₅ ,
@@ -1412,10 +1444,15 @@ module Is-order-embedding
             γ₃ ∙ Mo₂.⌜ tr-Mode m ⌝ M₂.· tr p     ∎)
          (tr-▸⁻¹′ _ ▸u refl γ₄′≤γ₄) (tr-▸⁻¹′ _ ▸v refl γ₅′≤γ₅))
       γ≤ω[γ₂′+γ₃′+γ₄′+γ₅′]
+      where
+      open Graded.Usage.Restrictions.Instance R₁
+      open Graded.Usage.Restrictions.Instance R₂
+      open Graded.Modality.Morphism.Backward-instances common-properties
+      open CQ.Is-omega-reflecting tr-emb omega-reflecting
 
     tr-▸⁻¹′
       (K _ _ _ _ _ _)
-      (K₀ₘ₁ {γ₃} ≡some tr-p≡𝟘 ▸A ▸t ▸B ▸u ▸v) refl γ≤ω[γ₃+γ₄] =
+      (K₀ₘ₁ {γ₃} ⦃ (≡some) ⦄ tr-p≡𝟘 ▸A ▸t ▸B ▸u ▸v) refl γ≤ω[γ₃+γ₄] =
       case
         (case trivial-⊎-tr-≡-𝟘-⇔ of λ where
            (inj₁ trivial₁) → MP₁.≡-trivial trivial₁
@@ -1435,9 +1472,14 @@ module Is-order-embedding
             γ₃ ∙ M₂.𝟘              ∎)
          (tr-▸⁻¹′ _ ▸u refl γ₄′≤γ₄) (tr-▸[𝟘ᵐ?]⁻¹ ▸v .proj₂))
       γ≤ω[γ₃′+γ₄′]
+      where
+      open Graded.Usage.Restrictions.Instance R₁
+      open Graded.Usage.Restrictions.Instance R₂
+      open Graded.Modality.Morphism.Backward-instances common-properties
+      open CQ.Is-omega-reflecting tr-emb omega-reflecting
 
-    tr-▸⁻¹′ (K _ _ _ _ _ _) (K₀ₘ₂ ≡all ▸A ▸t ▸B ▸u ▸v) refl ≤γ′ = K₀ₘ₂
-      (≤ᵉᵐ→≡all→≡all (erased-matches-for-K-reflected ≈ᵐ-tr-Mode) ≡all)
+    tr-▸⁻¹′ (K _ _ _ _ _ _) (K₀ₘ₂ ⦃ (≡all) ⦄ ▸A ▸t ▸B ▸u ▸v) refl ≤γ′ = K₀ₘ₂
+      ⦃ ≤ᵉᵐ→≡all→≡all (erased-matches-for-K-reflected ≈ᵐ-tr-Mode) ≡all ⦄
       (tr-▸[𝟘ᵐ?]⁻¹ ▸A .proj₂) (tr-▸[𝟘ᵐ?]⁻¹ ▸t .proj₂)
       (tr-∙▸[𝟘ᵐ?]⁻¹ ▸B .proj₂) (tr-▸⁻¹′ _ ▸u refl ≤γ′)
       (tr-▸[𝟘ᵐ?]⁻¹ ▸v .proj₂)

--- a/Graded/Usage/Restrictions.agda
+++ b/Graded/Usage/Restrictions.agda
@@ -16,6 +16,7 @@ module Graded.Usage.Restrictions
 open import Graded.Context 𝕄
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Restrictions.Natrec 𝕄
+open import Graded.Usage.Restrictions.JK 𝕄
 open import Definition.Untyped.NotParametrised
 
 open import Tools.Bool
@@ -37,6 +38,9 @@ private variable
   s : Strength
   ⦃ ok ⦄ : T _
   γ δ η : Conₘ _
+
+private variable
+  jk : JK
 
 -- Restrictions on/choices for usage derivations.
 
@@ -86,25 +90,26 @@ record Usage-restrictions : Set (lsuc a ⊔ b) where
     -- Id-erased is decided.
     Id-erased? : Dec Id-erased
 
-    -- What kinds of erased matches are allowed for the J rule (for
-    -- the current mode)?
-    erased-matches-for-J : Mode → Erased-matches
+    -- Should the erased matches for J and K that require the grade ω be
+    -- allowed?
+    JK-supported-erased-matches : JK-Supported-erased-matches
 
-    -- The usage rules for J are at least as permissive for m′
+    -- What kinds of erased matches are allowed for the J and K rules (for
+    -- the current mode)?
+    erased-matches-for-JK : JK → Mode → Erased-matches
+
+    -- The usage rules for J and K are at least as permissive for m′
     -- as for m when m ≤ᵐ m′. (See Graded.Usage.Properties.Jₘ-generalised and
-    -- Graded.Usage.Properties.J₀ₘ₁-generalised.)
-    erased-matches-for-J-≤ᵉᵐ :
-      m ≤ᵐ m′ → erased-matches-for-J m ≤ᵉᵐ erased-matches-for-J m′
+    -- Graded.Usage.Properties.J₀ₘ₁-generalised and similar for K)
+    erased-matches-for-JK-≤ᵉᵐ :
+      m ≤ᵐ m′ → erased-matches-for-JK jk m ≤ᵉᵐ erased-matches-for-JK jk m′
 
-    -- What kinds of erased matches are allowed for the K rule (for
-    -- the current mode)?
-    erased-matches-for-K : Mode → Erased-matches
-
-    -- The usage rules for K are at least as permissive for m′
-    -- as for m when m ≤ᵐ m′. (See Graded.Usage.Properties.Kₘ-generalised and
-    -- Graded.Usage.Properties.K₀ₘ₁-generalised.)
-    erased-matches-for-K-≤ᵉᵐ :
-      m ≤ᵐ m′ → erased-matches-for-K m ≤ᵉᵐ erased-matches-for-K m′
+    -- If the erased matches for J or K is at most "some" for any mode
+    -- then such erased modes must be supported by the modality. I.e.
+    -- the modality must have grade ω.
+    erased-matches-for-JK-supports-ω :
+      erased-matches-for-JK jk m ≤ᵉᵐ some →
+      JK-Any-erased-matches JK-supported-erased-matches
 
   -- Three mutually exclusive types which correspond to each of the
   -- three possibilities for natrec-mode
@@ -118,7 +123,16 @@ record Usage-restrictions : Set (lsuc a ⊔ b) where
   Nr-not-available-GLB : Set a
   Nr-not-available-GLB = Natrec-mode-no-nr-glb natrec-mode
 
+  -- A type that is inhabited iff the usage rules for J and K that
+  -- require grade ω are allowed.
+
+  JK-with-omega : Set a
+  JK-with-omega = JK-Any-erased-matches JK-supported-erased-matches
+
   field
+
+    -- If nr functions are used, they must be compatible with
+    -- the modes.
 
     mode-supports-nr :
       ⦃ ok : Nr-available ⦄ →
@@ -144,11 +158,45 @@ record Usage-restrictions : Set (lsuc a ⊔ b) where
   … | false = inj₂ idᶠ
   … | true = inj₁ _
 
+  -- The erased matches for J for a given mode.
+
+  erased-matches-for-J : Mode → Erased-matches
+  erased-matches-for-J = erased-matches-for-JK J
+
+  -- The erased matches for K for a given mode.
+
+  erased-matches-for-K : Mode → Erased-matches
+  erased-matches-for-K = erased-matches-for-JK K
+
+  opaque
+
+    -- JK-with-omega is propositional
+
+    JK-with-omega-propositional : (p q : JK-with-omega) → p ≡ q
+    JK-with-omega-propositional = JK-Any-erased-matches-propositional
+
+  opaque
+
+    -- The usage rules for J are at least as permissive for m′
+    -- as for m when m ≤ᵐ m′. (See Graded.Usage.Properties.Jₘ-generalised and
+    -- Graded.Usage.Properties.J₀ₘ₁-generalised.)
+    erased-matches-for-J-≤ᵉᵐ :
+      m ≤ᵐ m′ → erased-matches-for-J m ≤ᵉᵐ erased-matches-for-J m′
+    erased-matches-for-J-≤ᵉᵐ = erased-matches-for-JK-≤ᵉᵐ
+
+  opaque
+
+    -- The usage rules for K are at least as permissive for m′
+    -- as for m when m ≤ᵐ m′. (See Graded.Usage.Properties.Kₘ-generalised and
+    -- Graded.Usage.Properties.K₀ₘ₁-generalised.)
+    erased-matches-for-K-≤ᵉᵐ :
+      m ≤ᵐ m′ → erased-matches-for-K m ≤ᵉᵐ erased-matches-for-K m′
+    erased-matches-for-K-≤ᵉᵐ = erased-matches-for-JK-≤ᵉᵐ
+
   opaque
 
     -- If prodrec is allowed at mode m (for some grade) then it is
     -- also allowed at mode m′ ·ᵐ m.
-
 
     Prodrec-allowed-·ᵐ :
       Prodrec-allowed m r p q →
@@ -186,114 +234,102 @@ record Usage-restrictions : Set (lsuc a ⊔ b) where
     []-cong-allowed-mode-·ᵐ ok =
       []-cong-allowed-mode-upwards-closed ok ·ᵐ-increasingˡ
 
-  opaque
+  -- The following two instances give connections from the
+  -- choice of erased matches for J or K, as given in the
+  -- corresponding usage rules, to the property JK-with-omega.
 
-    -- The usage rules for J are at least as permissive for m′ ·ᵐ m as
-    -- for m. (See Graded.Usage.Properties.Jₘ-generalised and
-    -- Graded.Usage.Properties.J₀ₘ₁-generalised.)
+  instance
 
-    erased-matches-for-J-≤ᵉᵐ·ᵐ :
-      erased-matches-for-J m ≤ᵉᵐ erased-matches-for-J (m′ ·ᵐ m)
-    erased-matches-for-J-≤ᵉᵐ·ᵐ =
-      erased-matches-for-J-≤ᵉᵐ ·ᵐ-increasingˡ
+    -- If the erased matches for J or K are at most "some" then
+    -- erased matches that require ω are supported.
 
-  opaque
+    erased-matches-JK-≤-some-JK-with-omega :
+      ⦃ ok : erased-matches-for-JK jk m ≤ᵉᵐ some ⦄ →
+      JK-with-omega
+    erased-matches-JK-≤-some-JK-with-omega ⦃ ok ⦄ =
+      erased-matches-for-JK-supports-ω
+        (≤ᵉᵐ-transitive (erased-matches-for-JK-≤ᵉᵐ 𝟙ᵐ≤) ok)
 
-    -- If J has some erased matches for m then it has all
-    -- erased matches for m′ ·ᵐ m.
+    {-# INCOHERENT erased-matches-JK-≤-some-JK-with-omega #-}
 
-    erased-matches-for-J-all·ᵐ :
-      erased-matches-for-J m ≡ all →
-      erased-matches-for-J (m′ ·ᵐ m) ≡ all
-    erased-matches-for-J-all·ᵐ ≡all =
-      ≤ᵉᵐ→≡all→≡all erased-matches-for-J-≤ᵉᵐ·ᵐ ≡all
+  instance
 
-  opaque
+    -- If erased matches for J or K are some then they are at
+    -- most some.
 
-    -- If J has some erased matches for m then it has either all or
-    -- some erased matches for m′ ·ᵐ m.
+    erased-matches-JK-≡-some-≤-some :
+      ⦃ ok : erased-matches-for-JK jk m ≡ some ⦄ →
+      erased-matches-for-JK jk m ≤ᵉᵐ some
+    erased-matches-JK-≡-some-≤-some ⦃ ok ⦄ =
+      subst (_≤ᵉᵐ some) (sym ok) _
 
-    erased-matches-for-J-some·ᵐ :
-      erased-matches-for-J m ≡ some →
-      erased-matches-for-J (m′ ·ᵐ m) ≡ all ⊎
-      erased-matches-for-J (m′ ·ᵐ m) ≡ some
-    erased-matches-for-J-some·ᵐ {m} {m′} ≡some =
-      some≤ᵉᵐ→ (subst (_≤ᵉᵐ erased-matches-for-J (m′ ·ᵐ m))
-                 ≡some erased-matches-for-J-≤ᵉᵐ·ᵐ)
+    {-# INCOHERENT erased-matches-JK-≡-some-≤-some #-}
 
-  private opaque
+  -- The usage rules for J are at least as permissive for m′ ·ᵐ m as
+  -- for m. (See Graded.Usage.Properties.Jₘ-generalised and
+  -- Graded.Usage.Properties.J₀ₘ₁-generalised.)
 
-    -- A lemma used below
+  erased-matches-for-JK-≤ᵉᵐ·ᵐ :
+    erased-matches-for-JK jk m ≤ᵉᵐ erased-matches-for-JK jk (m′ ·ᵐ m)
+  erased-matches-for-JK-≤ᵉᵐ·ᵐ =
+    erased-matches-for-JK-≤ᵉᵐ ·ᵐ-increasingˡ
 
-    erased-matches-for-JK-not-none·ᵐ :
-      ∀ sem em → not-none sem ≤ᵉᵐ em →
-      ∃ λ sem′ → em ≡ not-none sem′
-    erased-matches-for-JK-not-none·ᵐ all′ none ()
-    erased-matches-for-JK-not-none·ᵐ all′ (not-none x) _ = x , refl
-    erased-matches-for-JK-not-none·ᵐ some′ none ()
-    erased-matches-for-JK-not-none·ᵐ some′ (not-none x) le = x , refl
+  -- If J or K has all erased matches for m then it has all
+  -- erased matches for m′ ·ᵐ m.
 
-  opaque
-
-    -- If J has not-none erased matches for m then it has
-    -- not-none erased matches for m′ ·ᵐ m.
-
-    erased-matches-for-J-not-none·ᵐ :
-      ∀ {sem} →
-      erased-matches-for-J m ≡ not-none sem →
-      ∃ λ sem′ → erased-matches-for-J (m′ ·ᵐ m) ≡ not-none sem′
-    erased-matches-for-J-not-none·ᵐ {m} {m′} ok =
-      erased-matches-for-JK-not-none·ᵐ _ _
-        (subst (_≤ᵉᵐ erased-matches-for-J (m′ ·ᵐ m)) ok erased-matches-for-J-≤ᵉᵐ·ᵐ)
-
-  opaque
-
-    -- The usage rules for K are at least as permissive for m′ ·ᵐ m as
-    -- for m. (See Graded.Usage.Properties.Kₘ-generalised and
-    -- Graded.Usage.Properties.K₀ₘ₁-generalised.)
-
-    erased-matches-for-K-≤ᵉᵐ·ᵐ :
-      erased-matches-for-K m ≤ᵉᵐ erased-matches-for-K (m′ ·ᵐ m)
-    erased-matches-for-K-≤ᵉᵐ·ᵐ =
-      erased-matches-for-K-≤ᵉᵐ ·ᵐ-increasingˡ
-
-  opaque
+  erased-matches-for-JK-all·ᵐ :
+    erased-matches-for-JK jk m ≡ all →
+    erased-matches-for-JK jk (m′ ·ᵐ m) ≡ all
+  erased-matches-for-JK-all·ᵐ ≡all =
+    ≤ᵉᵐ→≡all→≡all erased-matches-for-JK-≤ᵉᵐ·ᵐ ≡all
 
 
-    -- If K has some erased matches for m then it has all
-    -- erased matches for m′ ·ᵐ m.
+  -- If J has all erased matches for m then it has all
+  -- erased matches for m′ ·ᵐ m.
 
-    erased-matches-for-K-all·ᵐ :
-      erased-matches-for-K m ≡ all →
-      erased-matches-for-K (m′ ·ᵐ m) ≡ all
-    erased-matches-for-K-all·ᵐ ≡all =
-      ≤ᵉᵐ→≡all→≡all erased-matches-for-K-≤ᵉᵐ·ᵐ ≡all
+  erased-matches-for-J-all·ᵐ :
+    erased-matches-for-J m ≡ all →
+    erased-matches-for-J (m′ ·ᵐ m) ≡ all
+  erased-matches-for-J-all·ᵐ = erased-matches-for-JK-all·ᵐ
 
-  opaque
 
-    -- If K has some erased matches for m then it has either all or
-    -- some erased matches for m′ ·ᵐ m.
+  -- If K has all erased matches for m then it has all
+  -- erased matches for m′ ·ᵐ m.
 
-    erased-matches-for-K-some·ᵐ :
-      erased-matches-for-K m ≡ some →
-      erased-matches-for-K (m′ ·ᵐ m) ≡ all ⊎
-      erased-matches-for-K (m′ ·ᵐ m) ≡ some
-    erased-matches-for-K-some·ᵐ {m} {m′} ≡some =
-      some≤ᵉᵐ→ (subst (_≤ᵉᵐ erased-matches-for-K (m′ ·ᵐ m))
-                 ≡some erased-matches-for-K-≤ᵉᵐ·ᵐ)
+  erased-matches-for-K-all·ᵐ :
+    erased-matches-for-K m ≡ all →
+    erased-matches-for-K (m′ ·ᵐ m) ≡ all
+  erased-matches-for-K-all·ᵐ = erased-matches-for-JK-all·ᵐ
 
-  opaque
 
-    -- If K has not-none erased matches for m then it has
-    -- not-none erased matches for m′ ·ᵐ m.
+  -- If J or K has some erased matches for m then it has either all or
+  -- some erased matches for m′ ·ᵐ m.
 
-    erased-matches-for-K-not-none·ᵐ :
-      ∀ {sem} →
-      erased-matches-for-K m ≡ not-none sem →
-      ∃ λ sem′ → erased-matches-for-K (m′ ·ᵐ m) ≡ not-none sem′
-    erased-matches-for-K-not-none·ᵐ {m} {m′} ok =
-      erased-matches-for-JK-not-none·ᵐ _ _
-        (subst (_≤ᵉᵐ erased-matches-for-K (m′ ·ᵐ m)) ok erased-matches-for-K-≤ᵉᵐ·ᵐ)
+  erased-matches-for-JK-some·ᵐ :
+    erased-matches-for-JK jk m ≡ some →
+    erased-matches-for-JK jk (m′ ·ᵐ m) ≡ all ⊎
+    erased-matches-for-JK jk (m′ ·ᵐ m) ≡ some
+  erased-matches-for-JK-some·ᵐ {m} {m′} ≡-some =
+    some≤ᵉᵐ→ (subst (_≤ᵉᵐ erased-matches-for-JK _ (m′ ·ᵐ m))
+               ≡-some erased-matches-for-JK-≤ᵉᵐ·ᵐ)
+
+  -- If J has some erased matches for m then it has either all or
+  -- some erased matches for m′ ·ᵐ m.
+
+  erased-matches-for-J-some·ᵐ :
+    erased-matches-for-J m ≡ some →
+    erased-matches-for-J (m′ ·ᵐ m) ≡ all ⊎
+    erased-matches-for-J (m′ ·ᵐ m) ≡ some
+  erased-matches-for-J-some·ᵐ = erased-matches-for-JK-some·ᵐ
+
+  -- If K has some erased matches for m then it has either all or
+  -- some erased matches for m′ ·ᵐ m.
+
+  erased-matches-for-K-some·ᵐ :
+    erased-matches-for-K m ≡ some →
+    erased-matches-for-K (m′ ·ᵐ m) ≡ all ⊎
+    erased-matches-for-K (m′ ·ᵐ m) ≡ some
+  erased-matches-for-K-some·ᵐ = erased-matches-for-JK-some·ᵐ
 
   opaque
 

--- a/Graded/Usage/Restrictions/Instance.agda
+++ b/Graded/Usage/Restrictions/Instance.agda
@@ -14,6 +14,7 @@ module Graded.Usage.Restrictions.Instance
   where
 
 open import Graded.Usage.Restrictions.Natrec 𝕄
+open import Graded.Usage.Restrictions.JK 𝕄
 
 open Usage-restrictions R
 open Modality 𝕄
@@ -33,3 +34,11 @@ instance
     Has-well-behaved-GLBs M 𝕄
   Nr-not-available-Has-well-behaved-GLBs ⦃ no-nr ⦄ =
     Natrec-mode-Has-well-behaved-GLBs no-nr
+
+instance
+
+  JK-with-omega-has-omega :
+    ⦃ ok : JK-with-omega ⦄ →
+    Has-omega M 𝕄
+  JK-with-omega-has-omega ⦃ ok ⦄ =
+    JK-Any-erased-matches-has-omega ok

--- a/Graded/Usage/Restrictions/JK.agda
+++ b/Graded/Usage/Restrictions/JK.agda
@@ -1,0 +1,62 @@
+------------------------------------------------------------------------
+-- Definitions related to usage restrictions controling which usage
+-- rules for J and K should be used.
+------------------------------------------------------------------------
+
+import Graded.Modality
+
+module Graded.Usage.Restrictions.JK
+  {a} {M : Set a}
+  (open Graded.Modality M)
+  (𝕄 : Modality)
+  where
+
+open import Tools.Empty
+open import Tools.PropositionalEquality
+open import Tools.Product
+
+open Modality 𝕄
+
+-- The type JK corresponds to the eliminators J and K.
+
+data JK : Set where
+  J K : JK
+
+-- The type JK-supported-erased-matches represents whether erased
+-- matches for J and K that require the modality to have grade ω should
+-- be allowed. If any kind of erased matches are allowed the modality is
+-- required to have grade ω. If only "all" erased matches are allowed
+-- there are no conditions on the modality.
+
+data JK-Supported-erased-matches : Set a where
+  any : ⦃ ok : Has-omega 𝕄 ⦄ → JK-Supported-erased-matches
+  only-all : JK-Supported-erased-matches
+
+-- A predicate on JK-Supported-erased-matches corresponding to
+-- any erased matches being allowed.
+
+data JK-Any-erased-matches : JK-Supported-erased-matches → Set a where
+  any : ⦃ ok : Has-omega 𝕄 ⦄ → JK-Any-erased-matches any
+
+JK-Any-erased-matches-has-omega :
+  ∀ {x} → JK-Any-erased-matches x → Has-omega 𝕄
+JK-Any-erased-matches-has-omega (any ⦃ ok ⦄) = ok
+
+opaque
+
+  -- JK-Any-erased-matches is propositional
+
+  JK-Any-erased-matches-propositional :
+    ∀ {x} → (p q : JK-Any-erased-matches x) → p ≡ q
+  JK-Any-erased-matches-propositional any any = refl
+
+opaque
+
+  -- The grade ω given by two different proofs that J and K
+  -- supports usage rules with ω are equal.
+
+  ω≡ω :
+    ∀ {x} → (ok₁ ok₂ : JK-Any-erased-matches x) →
+    Has-omega.ω (JK-Any-erased-matches-has-omega ok₁) ≡
+    Has-omega.ω (JK-Any-erased-matches-has-omega ok₂)
+  ω≡ω any any = refl

--- a/Graded/Usage/Restrictions/Satisfied.agda
+++ b/Graded/Usage/Restrictions/Satisfied.agda
@@ -22,6 +22,7 @@ open Usage-restrictions R
 open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
 open import Graded.Modality.Properties 𝕄
+open import Graded.Modality.Omega-instances
 open import Graded.Usage R
 open import Graded.Usage.Erased-matches
 open import Graded.Usage.Restrictions.Natrec 𝕄
@@ -169,7 +170,7 @@ data Usage-restrictions-satisfied {n} (m : Mode) :
   rflᵤ :
     Usage-restrictions-satisfied m rfl
   Jᵤ :
-    erased-matches-for-J m ≤ᵉᵐ some →
+    ⦃ ok : erased-matches-for-J m ≤ᵉᵐ some ⦄ →
     (erased-matches-for-J m ≡ some → ¬ (p ≡ 𝟘 × q ≡ 𝟘)) →
     Usage-restrictions-satisfied 𝟘ᵐ A →
     Usage-restrictions-satisfied m t →
@@ -179,7 +180,7 @@ data Usage-restrictions-satisfied {n} (m : Mode) :
     Usage-restrictions-satisfied m w →
     Usage-restrictions-satisfied m (J p q A t B u v w)
   J₀ᵤ₁ :
-    erased-matches-for-J m ≡ some →
+    ⦃ ok : erased-matches-for-J m ≡ some ⦄ →
     p ≡ 𝟘 →
     q ≡ 𝟘 →
     Usage-restrictions-satisfied 𝟘ᵐ A →
@@ -190,7 +191,7 @@ data Usage-restrictions-satisfied {n} (m : Mode) :
     Usage-restrictions-satisfied 𝟘ᵐ w →
     Usage-restrictions-satisfied m (J p q A t B u v w)
   J₀ᵤ₂ :
-    erased-matches-for-J m ≡ all →
+    ⦃ ok : erased-matches-for-J m ≡ all ⦄ →
     Usage-restrictions-satisfied 𝟘ᵐ A →
     Usage-restrictions-satisfied 𝟘ᵐ t →
     Usage-restrictions-satisfied 𝟘ᵐ B →
@@ -199,7 +200,7 @@ data Usage-restrictions-satisfied {n} (m : Mode) :
     Usage-restrictions-satisfied 𝟘ᵐ w →
     Usage-restrictions-satisfied m (J p q A t B u v w)
   Kᵤ :
-    erased-matches-for-K m ≤ᵉᵐ some →
+    ⦃ ok : erased-matches-for-K m ≤ᵉᵐ some ⦄ →
     (erased-matches-for-K m ≡ some → p ≢ 𝟘) →
     Usage-restrictions-satisfied 𝟘ᵐ A →
     Usage-restrictions-satisfied m t →
@@ -208,7 +209,7 @@ data Usage-restrictions-satisfied {n} (m : Mode) :
     Usage-restrictions-satisfied m v →
     Usage-restrictions-satisfied m (K p A t B u v)
   K₀ᵤ₁ :
-    erased-matches-for-K m ≡ some →
+    ⦃ ok : erased-matches-for-K m ≡ some ⦄ →
     p ≡ 𝟘 →
     Usage-restrictions-satisfied 𝟘ᵐ A →
     Usage-restrictions-satisfied 𝟘ᵐ t →
@@ -217,7 +218,7 @@ data Usage-restrictions-satisfied {n} (m : Mode) :
     Usage-restrictions-satisfied 𝟘ᵐ v →
     Usage-restrictions-satisfied m (K p A t B u v)
   K₀ᵤ₂ :
-    erased-matches-for-K m ≡ all →
+    ⦃ ok : erased-matches-for-K m ≡ all ⦄ →
     Usage-restrictions-satisfied 𝟘ᵐ A →
     Usage-restrictions-satisfied 𝟘ᵐ t →
     Usage-restrictions-satisfied 𝟘ᵐ B →
@@ -270,14 +271,14 @@ opaque mutual
     Usage-restrictions-satisfied m (J p q A t B u v w)
   Jᵤ-generalised {m} {p} {q} A t B u v w
     with J-view p q m
-  … | is-other ≤some ≢𝟘 =
-    Jᵤ ≤some ≢𝟘 A t B u v w
-  … | is-some-yes ≡some (refl , refl) =
-    J₀ᵤ₁ ≡some refl refl A (Usage-restrictions-satisfied-→𝟘ᵐ t)
+  … | is-other ≢𝟘 =
+    Jᵤ ≢𝟘 A t B u v w
+  … | is-some-yes (refl , refl) =
+    J₀ᵤ₁ refl refl A (Usage-restrictions-satisfied-→𝟘ᵐ t)
       B u (Usage-restrictions-satisfied-→𝟘ᵐ v)
       (Usage-restrictions-satisfied-→𝟘ᵐ w)
-  … | is-all ≡all =
-    J₀ᵤ₂ ≡all A (Usage-restrictions-satisfied-→𝟘ᵐ t)
+  … | is-all =
+    J₀ᵤ₂ A (Usage-restrictions-satisfied-→𝟘ᵐ t)
       (Usage-restrictions-satisfied-→𝟘ᵐ B) u
       (Usage-restrictions-satisfied-→𝟘ᵐ v)
       (Usage-restrictions-satisfied-→𝟘ᵐ w)
@@ -299,9 +300,9 @@ opaque mutual
     with erased-matches-for-J m in ok
   … | none = case ≡not-none of λ ()
   … | some =
-    J₀ᵤ₁ ok refl refl A t B u v w
+    J₀ᵤ₁ ⦃ ok = ok ⦄ refl refl A t B u v w
   … | all =
-    J₀ᵤ₂ ok A (Usage-restrictions-satisfied-→𝟘ᵐ t)
+    J₀ᵤ₂ ⦃ ok = ok ⦄ A (Usage-restrictions-satisfied-→𝟘ᵐ t)
       (Usage-restrictions-satisfied-→𝟘ᵐ B) u
       (Usage-restrictions-satisfied-→𝟘ᵐ v)
       (Usage-restrictions-satisfied-→𝟘ᵐ w)
@@ -318,13 +319,13 @@ opaque mutual
     Usage-restrictions-satisfied m v →
     Usage-restrictions-satisfied m (K p A t B u v)
   Kᵤ-generalised {m} {p} A t B u v with K-view p m
-  … | is-other ≤some ≢𝟘 =
-    Kᵤ ≤some ≢𝟘 A t B u v
-  … | is-some-yes ≡some refl =
-    K₀ᵤ₁ ≡some refl A (Usage-restrictions-satisfied-→𝟘ᵐ t) B u
+  … | is-other ≢𝟘 =
+    Kᵤ ≢𝟘 A t B u v
+  … | is-some-yes refl =
+    K₀ᵤ₁ refl A (Usage-restrictions-satisfied-→𝟘ᵐ t) B u
       (Usage-restrictions-satisfied-→𝟘ᵐ v)
-  … | is-all ≡all =
-    K₀ᵤ₂ ≡all A (Usage-restrictions-satisfied-→𝟘ᵐ t)
+  … | is-all =
+    K₀ᵤ₂ A (Usage-restrictions-satisfied-→𝟘ᵐ t)
       (Usage-restrictions-satisfied-→𝟘ᵐ B) u
       (Usage-restrictions-satisfied-→𝟘ᵐ v)
 
@@ -344,9 +345,9 @@ opaque mutual
   … | none =
     case hyp of λ ()
   … | some =
-    K₀ᵤ₁ ok refl A t B u v
+    K₀ᵤ₁ ⦃ ok = ok ⦄ refl A t B u v
   … | all =
-    K₀ᵤ₂ ok A (Usage-restrictions-satisfied-→𝟘ᵐ t)
+    K₀ᵤ₂ ⦃ ok = ok ⦄ A (Usage-restrictions-satisfied-→𝟘ᵐ t)
       (Usage-restrictions-satisfied-→𝟘ᵐ B) u
       (Usage-restrictions-satisfied-→𝟘ᵐ v)
 
@@ -428,13 +429,13 @@ opaque mutual
     (Id₀ᵤ ok A t u) →
       Id₀ᵤ ok A t u
     rflᵤ → rflᵤ
-    (Jᵤ _ _ A t B u v w) →
+    (Jᵤ _ A t B u v w) →
       Jᵤ-generalised A (Usage-restrictions-satisfied-≤ᵐ m≤m′ t)
         (Usage-restrictions-satisfied-≤ᵐ m≤m′ B)
         (Usage-restrictions-satisfied-≤ᵐ m≤m′ u)
         (Usage-restrictions-satisfied-≤ᵐ m≤m′ v)
         (Usage-restrictions-satisfied-≤ᵐ m≤m′ w)
-    (J₀ᵤ₁ ≡some p≡𝟘 q≡𝟘 A t B u v w) →
+    (J₀ᵤ₁ ⦃ ok = ≡some ⦄ p≡𝟘 q≡𝟘 A t B u v w) →
       case singleton $ erased-matches-for-J m′ of λ where
         (not-none _ , ≡not-none) →
           J₀ᵤ₁-generalised ≡not-none p≡𝟘 q≡𝟘 A t
@@ -447,16 +448,16 @@ opaque mutual
             trans (sym ≡some)
               (≤ᵉᵐ→≡none→≡none (erased-matches-for-J-≤ᵉᵐ m≤m′) ≡none)
           of λ ()
-    (J₀ᵤ₂ ≡all A t B u v w) →
-      J₀ᵤ₂ (subst (λ x → erased-matches-for-J x ≡ all) (sym m≤m′)
-             (erased-matches-for-J-all·ᵐ ≡all))
+    (J₀ᵤ₂ ⦃ ok = ≡all ⦄ A t B u v w) →
+      J₀ᵤ₂ ⦃ ok = subst (λ x → erased-matches-for-J x ≡ all) (sym m≤m′)
+             (erased-matches-for-J-all·ᵐ ≡all) ⦄
         A t B (Usage-restrictions-satisfied-≤ᵐ m≤m′ u) v w
-    (Kᵤ _ _ A t B u v) →
+    (Kᵤ _ A t B u v) →
       Kᵤ-generalised A (Usage-restrictions-satisfied-≤ᵐ m≤m′ t)
         (Usage-restrictions-satisfied-≤ᵐ m≤m′ B)
         (Usage-restrictions-satisfied-≤ᵐ m≤m′ u)
         (Usage-restrictions-satisfied-≤ᵐ m≤m′ v)
-    (K₀ᵤ₁ ≡some p≡𝟘 A t B u v) →
+    (K₀ᵤ₁ ⦃ ok = ≡some ⦄ p≡𝟘 A t B u v) →
       case singleton $ erased-matches-for-K m′ of λ where
         (not-none _ , ≡not-none) →
           K₀ᵤ₁-generalised ≡not-none p≡𝟘 A
@@ -469,8 +470,8 @@ opaque mutual
             trans (sym ≡some)
               (≤ᵉᵐ→≡none→≡none (erased-matches-for-K-≤ᵉᵐ m≤m′) ≡none)
           of λ ()
-    (K₀ᵤ₂ ≡all A t B u v) →
-      K₀ᵤ₂ (≤ᵉᵐ→≡all→≡all (erased-matches-for-K-≤ᵉᵐ m≤m′) ≡all) A t B
+    (K₀ᵤ₂ ⦃ ok = ≡all ⦄ A t B u v) →
+      K₀ᵤ₂ ⦃ ok = ≤ᵉᵐ→≡all→≡all (erased-matches-for-K-≤ᵉᵐ m≤m′) ≡all ⦄ A t B
         (Usage-restrictions-satisfied-≤ᵐ m≤m′ u) v
     ([]-congᵤ ok l A t u v) →
       []-congᵤ ([]-cong-allowed-mode-upwards-closed ok m≤m′) l A t u v
@@ -608,41 +609,41 @@ opaque
         (▸→Usage-restrictions-satisfied ▸u)
     rflₘ →
       rflᵤ
-    (Jₘ ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v ▸w) →
-      Jᵤ ok₁ ok₂ (▸→Usage-restrictions-satisfied ▸A)
+    (Jₘ ok ▸A ▸t ▸B ▸u ▸v ▸w) →
+      Jᵤ ok (▸→Usage-restrictions-satisfied ▸A)
         (▸→Usage-restrictions-satisfied ▸t)
         (▸→Usage-restrictions-satisfied ▸B)
         (▸→Usage-restrictions-satisfied ▸u)
         (▸→Usage-restrictions-satisfied ▸v)
         (▸→Usage-restrictions-satisfied ▸w)
-    (J₀ₘ₁ ok p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸v ▸w) →
-      J₀ᵤ₁ ok p≡𝟘 q≡𝟘 (▸→Usage-restrictions-satisfied ▸A)
+    (J₀ₘ₁ p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸v ▸w) →
+      J₀ᵤ₁ p≡𝟘 q≡𝟘 (▸→Usage-restrictions-satisfied ▸A)
         (▸→Usage-restrictions-satisfied ▸t)
         (▸→Usage-restrictions-satisfied ▸B)
         (▸→Usage-restrictions-satisfied ▸u)
         (▸→Usage-restrictions-satisfied ▸v)
         (▸→Usage-restrictions-satisfied ▸w)
-    (J₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸v ▸w) →
-      J₀ᵤ₂ ok (▸→Usage-restrictions-satisfied ▸A)
+    (J₀ₘ₂ ▸A ▸t ▸B ▸u ▸v ▸w) →
+      J₀ᵤ₂ (▸→Usage-restrictions-satisfied ▸A)
         (▸→Usage-restrictions-satisfied ▸t)
         (▸→Usage-restrictions-satisfied ▸B)
         (▸→Usage-restrictions-satisfied ▸u)
         (▸→Usage-restrictions-satisfied ▸v)
         (▸→Usage-restrictions-satisfied ▸w)
-    (Kₘ ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v) →
-      Kᵤ ok₁ ok₂ (▸→Usage-restrictions-satisfied ▸A)
+    (Kₘ ok ▸A ▸t ▸B ▸u ▸v) →
+      Kᵤ ok (▸→Usage-restrictions-satisfied ▸A)
         (▸→Usage-restrictions-satisfied ▸t)
         (▸→Usage-restrictions-satisfied ▸B)
         (▸→Usage-restrictions-satisfied ▸u)
         (▸→Usage-restrictions-satisfied ▸v)
-    (K₀ₘ₁ ok p≡𝟘 ▸A ▸t ▸B ▸u ▸v) →
-      K₀ᵤ₁ ok p≡𝟘 (▸→Usage-restrictions-satisfied ▸A)
+    (K₀ₘ₁ p≡𝟘 ▸A ▸t ▸B ▸u ▸v) →
+      K₀ᵤ₁ p≡𝟘 (▸→Usage-restrictions-satisfied ▸A)
         (▸→Usage-restrictions-satisfied ▸t)
         (▸→Usage-restrictions-satisfied ▸B)
         (▸→Usage-restrictions-satisfied ▸u)
         (▸→Usage-restrictions-satisfied ▸v)
-    (K₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸v) →
-      K₀ᵤ₂ ok (▸→Usage-restrictions-satisfied ▸A)
+    (K₀ₘ₂ ▸A ▸t ▸B ▸u ▸v) →
+      K₀ᵤ₂ (▸→Usage-restrictions-satisfied ▸A)
         (▸→Usage-restrictions-satisfied ▸t)
         (▸→Usage-restrictions-satisfied ▸B)
         (▸→Usage-restrictions-satisfied ▸u)
@@ -795,8 +796,8 @@ opaque
           (lemma A-ok)
           (lemma t-ok)
           (lemma u-ok)
-      (Jᵤ {p} {q} ok₁ ok₂ A-ok t-ok B-ok u-ok v-ok w-ok) → sub
-        (Jₘ ok₁ ok₂
+      (Jᵤ {p} {q} ok A-ok t-ok B-ok u-ok v-ok w-ok) → sub
+        (Jₘ ok
            (lemma A-ok)
            (lemma t-ok)
            (sub (lemma B-ok) $ begin
@@ -808,14 +809,14 @@ opaque
         (begin
            𝟘ᶜ                                 ≈˘⟨ ω·ᶜ+ᶜ⁵𝟘ᶜ ⟩
            ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ)  ∎)
-      (J₀ᵤ₁ ok p≡𝟘 q≡𝟘 A-ok t-ok B-ok u-ok v-ok w-ok) → sub
-        (J₀ₘ₁ ok p≡𝟘 q≡𝟘 (lemma A-ok) (lemma t-ok) (lemma B-ok)
+      (J₀ᵤ₁ p≡𝟘 q≡𝟘 A-ok t-ok B-ok u-ok v-ok w-ok) → sub
+        (J₀ₘ₁ p≡𝟘 q≡𝟘 (lemma A-ok) (lemma t-ok) (lemma B-ok)
            (lemma u-ok) (lemma v-ok) (lemma w-ok))
         (begin
            𝟘ᶜ               ≈˘⟨ ω·ᶜ+ᶜ²𝟘ᶜ ⟩
            ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ)  ∎)
-      (J₀ᵤ₂ {p} {q} ok A-ok t-ok B-ok u-ok v-ok w-ok) →
-        J₀ₘ₂ ok
+      (J₀ᵤ₂ {p} {q} A-ok t-ok B-ok u-ok v-ok w-ok) →
+        J₀ₘ₂
           (lemma A-ok)
           (lemma t-ok)
           (sub (lemma B-ok) $ begin
@@ -824,8 +825,8 @@ opaque
           (lemma u-ok)
           (lemma v-ok)
           (lemma w-ok)
-      (Kᵤ {p} ok₁ ok₂ A-ok t-ok B-ok u-ok v-ok) → sub
-        (Kₘ ok₁ ok₂
+      (Kᵤ {p} ok A-ok t-ok B-ok u-ok v-ok) → sub
+        (Kₘ ok
            (lemma A-ok)
            (lemma t-ok)
            (sub (lemma B-ok) $ begin
@@ -836,14 +837,14 @@ opaque
         (begin
            𝟘ᶜ                           ≈˘⟨ ω·ᶜ+ᶜ⁴𝟘ᶜ ⟩
            ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ +ᶜ 𝟘ᶜ)  ∎)
-      (K₀ᵤ₁ ok p≡𝟘 A-ok t-ok B-ok u-ok v-ok) → sub
-        (K₀ₘ₁ ok p≡𝟘 (lemma A-ok) (lemma t-ok) (lemma B-ok)
+      (K₀ᵤ₁ p≡𝟘 A-ok t-ok B-ok u-ok v-ok) → sub
+        (K₀ₘ₁ p≡𝟘 (lemma A-ok) (lemma t-ok) (lemma B-ok)
            (lemma u-ok) (lemma v-ok))
         (begin
            𝟘ᶜ               ≈˘⟨ ω·ᶜ+ᶜ²𝟘ᶜ ⟩
            ω ·ᶜ (𝟘ᶜ +ᶜ 𝟘ᶜ)  ∎)
-      (K₀ᵤ₂ {p} ok A-ok t-ok B-ok u-ok v-ok) →
-        K₀ₘ₂ ok
+      (K₀ᵤ₂ {p} A-ok t-ok B-ok u-ok v-ok) →
+        K₀ₘ₂
           (lemma A-ok)
           (lemma t-ok)
           (sub (lemma B-ok) $ begin
@@ -1089,34 +1090,34 @@ opaque
         sub
           (Id₀ₘ erased (lemma₀ A-ok) (lemma₀ t-ok) (lemma₀ u-ok))
           (≈ᶜ-trivial 𝟙≡𝟘)
-      (Jᵤ ok₁ ok₂ A-ok t-ok B-ok u-ok v-ok w-ok) →
+      (Jᵤ ok A-ok t-ok B-ok u-ok v-ok w-ok) →
         sub
-          (Jₘ {γ₃ = 𝟘ᶜ} ok₁ ok₂ (lemma₀ A-ok) (lemma₀ t-ok) (lemma B-ok)
+          (Jₘ {γ₃ = 𝟘ᶜ} ok (lemma₀ A-ok) (lemma₀ t-ok) (lemma B-ok)
              (lemma₀ u-ok) (lemma₀ v-ok) (lemma₀ w-ok))
           (≈ᶜ-trivial 𝟙≡𝟘)
-      (J₀ᵤ₁ ok p≡𝟘 q≡𝟘 A-ok t-ok B-ok u-ok v-ok w-ok) →
+      (J₀ᵤ₁ p≡𝟘 q≡𝟘 A-ok t-ok B-ok u-ok v-ok w-ok) →
         sub
-          (J₀ₘ₁ {γ₃ = 𝟘ᶜ} ok p≡𝟘 q≡𝟘 (lemma₀ A-ok) (lemma₀ t-ok)
+          (J₀ₘ₁ {γ₃ = 𝟘ᶜ} p≡𝟘 q≡𝟘 (lemma₀ A-ok) (lemma₀ t-ok)
              (lemma B-ok) (lemma₀ u-ok) (lemma₀ v-ok) (lemma₀ w-ok))
           (≈ᶜ-trivial 𝟙≡𝟘)
-      (J₀ᵤ₂ ok A-ok t-ok B-ok u-ok v-ok w-ok) →
+      (J₀ᵤ₂ A-ok t-ok B-ok u-ok v-ok w-ok) →
         sub
-          (J₀ₘ₂ {γ₃ = 𝟘ᶜ} ok (lemma₀ A-ok) (lemma₀ t-ok) (lemma B-ok)
+          (J₀ₘ₂ {γ₃ = 𝟘ᶜ} (lemma₀ A-ok) (lemma₀ t-ok) (lemma B-ok)
              (lemma₀ u-ok) (lemma₀ v-ok) (lemma₀ w-ok))
           (≈ᶜ-trivial 𝟙≡𝟘)
-      (Kᵤ ok₁ ok₂ A-ok t-ok B-ok u-ok v-ok) →
+      (Kᵤ ok A-ok t-ok B-ok u-ok v-ok) →
         sub
-          (Kₘ {γ₃ = 𝟘ᶜ} ok₁ ok₂ (lemma₀ A-ok) (lemma₀ t-ok) (lemma B-ok)
+          (Kₘ {γ₃ = 𝟘ᶜ} ok (lemma₀ A-ok) (lemma₀ t-ok) (lemma B-ok)
              (lemma₀ u-ok) (lemma₀ v-ok))
           (≈ᶜ-trivial 𝟙≡𝟘)
-      (K₀ᵤ₁ ok p≡𝟘 A-ok t-ok B-ok u-ok v-ok) →
+      (K₀ᵤ₁ p≡𝟘 A-ok t-ok B-ok u-ok v-ok) →
         sub
-          (K₀ₘ₁ {γ₃ = 𝟘ᶜ} ok p≡𝟘 (lemma₀ A-ok) (lemma₀ t-ok)
+          (K₀ₘ₁ {γ₃ = 𝟘ᶜ} p≡𝟘 (lemma₀ A-ok) (lemma₀ t-ok)
              (lemma B-ok) (lemma₀ u-ok) (lemma₀ v-ok))
           (≈ᶜ-trivial 𝟙≡𝟘)
-      (K₀ᵤ₂ ok A-ok t-ok B-ok u-ok v-ok) →
+      (K₀ᵤ₂ A-ok t-ok B-ok u-ok v-ok) →
         sub
-          (K₀ₘ₂ {γ₃ = 𝟘ᶜ} ok (lemma₀ A-ok) (lemma₀ t-ok) (lemma B-ok)
+          (K₀ₘ₂ {γ₃ = 𝟘ᶜ} (lemma₀ A-ok) (lemma₀ t-ok) (lemma B-ok)
              (lemma₀ u-ok) (lemma₀ v-ok))
           (≈ᶜ-trivial 𝟙≡𝟘)
       ([]-congᵤ ok l-ok A-ok t-ok u-ok v-ok) →

--- a/Graded/Usage/Weakening.agda
+++ b/Graded/Usage/Weakening.agda
@@ -17,10 +17,12 @@ module Graded.Usage.Weakening
 
 open Modality 𝕄
 open IsMode 𝐌
+open Usage-restrictions R
 
 open import Graded.Context 𝕄
 open import Graded.Context.Properties 𝕄
 open import Graded.Context.Weakening 𝕄
+open import Graded.Modality.Omega-instances
 open import Graded.Usage R
 open import Graded.Usage.Restrictions.Instance R
 open import Definition.Untyped M
@@ -182,8 +184,8 @@ wkUsage ρ rflₘ =
   open Tools.Reasoning.PropositionalEquality
 wkUsage ρ
   (Jₘ {γ₂ = γ₂} {γ₃ = γ₃} {γ₄ = γ₄} {γ₅ = γ₅} {γ₆ = γ₆}
-     ok₁ ok₂ ▸A ▸t ▸B ▸u ▸t′ ▸v) = sub
-  (Jₘ ok₁ ok₂ (wkUsage _ ▸A) (wkUsage _ ▸t) (wkUsage _ ▸B)
+     ok ▸A ▸t ▸B ▸u ▸t′ ▸v) = sub
+  (Jₘ ok (wkUsage _ ▸A) (wkUsage _ ▸t) (wkUsage _ ▸B)
      (wkUsage _ ▸u) (wkUsage _ ▸t′) (wkUsage _ ▸v))
   (begin
      wkConₘ ρ (ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆))                  ≈⟨ ≈ᶜ-trans (wk-·ᶜ ρ) $ ·ᶜ-congˡ $
@@ -196,21 +198,21 @@ wkUsage ρ
       wkConₘ ρ γ₆)                                                 ∎)
   where
   open Tools.Reasoning.PartialOrder ≤ᶜ-poset
-wkUsage ρ (J₀ₘ₁ {γ₃} {γ₄} ok p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸t′ ▸v) = sub
-  (J₀ₘ₁ ok p≡𝟘 q≡𝟘 (wkUsage _ ▸A) (wkUsage _ ▸t) (wkUsage _ ▸B)
+wkUsage ρ (J₀ₘ₁ {γ₃} {γ₄} p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸t′ ▸v) = sub
+  (J₀ₘ₁ p≡𝟘 q≡𝟘 (wkUsage _ ▸A) (wkUsage _ ▸t) (wkUsage _ ▸B)
      (wkUsage _ ▸u) (wkUsage _ ▸t′) (wkUsage _ ▸v))
   (begin
      wkConₘ ρ (ω ·ᶜ (γ₃ +ᶜ γ₄))         ≈⟨ ≈ᶜ-trans (wk-·ᶜ ρ) $ ·ᶜ-congˡ $ wk-+ᶜ ρ ⟩
      ω ·ᶜ (wkConₘ ρ γ₃ +ᶜ wkConₘ ρ γ₄)  ∎)
   where
   open Tools.Reasoning.PartialOrder ≤ᶜ-poset
-wkUsage _ (J₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸t′ ▸v) =
-  J₀ₘ₂ ok (wkUsage _ ▸A) (wkUsage _ ▸t) (wkUsage _ ▸B) (wkUsage _ ▸u)
+wkUsage _ (J₀ₘ₂ ▸A ▸t ▸B ▸u ▸t′ ▸v) =
+  J₀ₘ₂ (wkUsage _ ▸A) (wkUsage _ ▸t) (wkUsage _ ▸B) (wkUsage _ ▸u)
     (wkUsage _ ▸t′) (wkUsage _ ▸v)
 wkUsage ρ
   (Kₘ {γ₂ = γ₂} {γ₃ = γ₃} {γ₄ = γ₄} {γ₅ = γ₅}
-     ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v) = sub
-  (Kₘ ok₁ ok₂ (wkUsage _ ▸A) (wkUsage _ ▸t) (wkUsage _ ▸B)
+     ok ▸A ▸t ▸B ▸u ▸v) = sub
+  (Kₘ ok (wkUsage _ ▸A) (wkUsage _ ▸t) (wkUsage _ ▸B)
      (wkUsage _ ▸u) (wkUsage _ ▸v))
   (begin
      wkConₘ ρ (ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅))                           ≈⟨ ≈ᶜ-trans (wk-·ᶜ ρ) $ ·ᶜ-congˡ $
@@ -220,16 +222,16 @@ wkUsage ρ
      ω ·ᶜ (wkConₘ ρ γ₂ +ᶜ wkConₘ ρ γ₃ +ᶜ wkConₘ ρ γ₄ +ᶜ wkConₘ ρ γ₅)  ∎)
   where
   open Tools.Reasoning.PartialOrder ≤ᶜ-poset
-wkUsage ρ (K₀ₘ₁ {γ₃} {γ₄} ok p≡𝟘 ▸A ▸t ▸B ▸u ▸v) = sub
-  (K₀ₘ₁ ok p≡𝟘 (wkUsage _ ▸A) (wkUsage _ ▸t) (wkUsage _ ▸B)
+wkUsage ρ (K₀ₘ₁ {γ₃} {γ₄} p≡𝟘 ▸A ▸t ▸B ▸u ▸v) = sub
+  (K₀ₘ₁ p≡𝟘 (wkUsage _ ▸A) (wkUsage _ ▸t) (wkUsage _ ▸B)
      (wkUsage _ ▸u) (wkUsage _ ▸v))
   (begin
      wkConₘ ρ (ω ·ᶜ (γ₃ +ᶜ γ₄))         ≈⟨ ≈ᶜ-trans (wk-·ᶜ ρ) $ ·ᶜ-congˡ $ wk-+ᶜ ρ ⟩
      ω ·ᶜ (wkConₘ ρ γ₃ +ᶜ wkConₘ ρ γ₄)  ∎)
   where
   open Tools.Reasoning.PartialOrder ≤ᶜ-poset
-wkUsage _ (K₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸v) =
-  K₀ₘ₂ ok (wkUsage _ ▸A) (wkUsage _ ▸t) (wkUsage _ ▸B) (wkUsage _ ▸u)
+wkUsage _ (K₀ₘ₂ ▸A ▸t ▸B ▸u ▸v) =
+  K₀ₘ₂ (wkUsage _ ▸A) (wkUsage _ ▸t) (wkUsage _ ▸B) (wkUsage _ ▸u)
     (wkUsage _ ▸v)
 wkUsage ρ ([]-congₘ ▸l ▸A ▸t ▸u ▸v ok) =
   subst (_▸[ _ ] _)
@@ -464,13 +466,13 @@ wkUsage⁻¹ ▸t = wkUsage⁻¹′ ▸t refl
         case wk-rfl eq of λ {
           refl →
         sub-≈ᶜ rflₘ (wkConₘ⁻¹-𝟘ᶜ ρ) }
-      (Jₘ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} ok₁ ok₂ ▸A ▸t ▸B ▸u ▸t′ ▸v)
+      (Jₘ {γ₂} {γ₃} {γ₄} {γ₅} {γ₆} ok ▸A ▸t ▸B ▸u ▸t′ ▸v)
         eq →
         case wk-J eq of λ {
           (_ , _ , _ , _ , _ , _ ,
            refl , refl , refl , refl , refl , refl , refl) →
         sub
-          (Jₘ ok₁ ok₂ (wkUsage⁻¹ ▸A) (wkUsage⁻¹ ▸t) (wkUsage⁻¹ ▸B)
+          (Jₘ ok (wkUsage⁻¹ ▸A) (wkUsage⁻¹ ▸t) (wkUsage⁻¹ ▸B)
              (wkUsage⁻¹ ▸u) (wkUsage⁻¹ ▸t′) (wkUsage⁻¹ ▸v)) $ begin
         wkConₘ⁻¹ ρ (ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅ +ᶜ γ₆))         ≈⟨ wkConₘ⁻¹-·ᶜ ρ ⟩
 
@@ -482,29 +484,29 @@ wkUsage⁻¹ ▸t = wkUsage⁻¹′ ▸t refl
         ω ·ᶜ
           (wkConₘ⁻¹ ρ γ₂ +ᶜ wkConₘ⁻¹ ρ γ₃ +ᶜ wkConₘ⁻¹ ρ γ₄ +ᶜ
            wkConₘ⁻¹ ρ γ₅ +ᶜ wkConₘ⁻¹ ρ γ₆)                     ∎ }
-      (J₀ₘ₁ {γ₃} {γ₄} ok p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸t′ ▸v) eq →
+      (J₀ₘ₁ {γ₃} {γ₄} p≡𝟘 q≡𝟘 ▸A ▸t ▸B ▸u ▸t′ ▸v) eq →
         case wk-J eq of λ {
           (_ , _ , _ , _ , _ , _ ,
            refl , refl , refl , refl , refl , refl , refl) →
         sub
-          (J₀ₘ₁ ok p≡𝟘 q≡𝟘 (wkUsage⁻¹ ▸A) (wkUsage⁻¹ ▸t) (wkUsage⁻¹ ▸B)
+          (J₀ₘ₁ p≡𝟘 q≡𝟘 (wkUsage⁻¹ ▸A) (wkUsage⁻¹ ▸t) (wkUsage⁻¹ ▸B)
              (wkUsage⁻¹ ▸u) (wkUsage⁻¹ ▸t′) (wkUsage⁻¹ ▸v)) $ begin
         wkConₘ⁻¹ ρ (ω ·ᶜ (γ₃ +ᶜ γ₄))           ≈⟨ wkConₘ⁻¹-·ᶜ ρ ⟩
         ω ·ᶜ wkConₘ⁻¹ ρ (γ₃ +ᶜ γ₄)             ≈⟨ ·ᶜ-congˡ $ wkConₘ⁻¹-+ᶜ ρ ⟩
         ω ·ᶜ (wkConₘ⁻¹ ρ γ₃ +ᶜ wkConₘ⁻¹ ρ γ₄)  ∎ }
-      (J₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸t′ ▸v) eq →
+      (J₀ₘ₂ ▸A ▸t ▸B ▸u ▸t′ ▸v) eq →
         case wk-J eq of λ {
           (_ , _ , _ , _ , _ , _ ,
            refl , refl , refl , refl , refl , refl , refl) →
-        J₀ₘ₂ ok (wkUsage⁻¹ ▸A) (wkUsage⁻¹ ▸t) (wkUsage⁻¹ ▸B)
+        J₀ₘ₂ (wkUsage⁻¹ ▸A) (wkUsage⁻¹ ▸t) (wkUsage⁻¹ ▸B)
           (wkUsage⁻¹ ▸u) (wkUsage⁻¹ ▸t′) (wkUsage⁻¹ ▸v) }
-      (Kₘ {γ₂} {γ₃} {γ₄} {γ₅} ok₁ ok₂ ▸A ▸t ▸B ▸u ▸v)
+      (Kₘ {γ₂} {γ₃} {γ₄} {γ₅} ok ▸A ▸t ▸B ▸u ▸v)
         eq →
         case wk-K eq of λ {
           (_ , _ , _ , _ , _ ,
            refl , refl , refl , refl , refl , refl) →
         sub
-          (Kₘ ok₁ ok₂ (wkUsage⁻¹ ▸A) (wkUsage⁻¹ ▸t) (wkUsage⁻¹ ▸B)
+          (Kₘ ok (wkUsage⁻¹ ▸A) (wkUsage⁻¹ ▸t) (wkUsage⁻¹ ▸B)
              (wkUsage⁻¹ ▸u) (wkUsage⁻¹ ▸v)) $ begin
         wkConₘ⁻¹ ρ (ω ·ᶜ (γ₂ +ᶜ γ₃ +ᶜ γ₄ +ᶜ γ₅))               ≈⟨ wkConₘ⁻¹-·ᶜ ρ ⟩
 
@@ -515,21 +517,21 @@ wkUsage⁻¹ ▸t = wkUsage⁻¹′ ▸t refl
         ω ·ᶜ
           (wkConₘ⁻¹ ρ γ₂ +ᶜ wkConₘ⁻¹ ρ γ₃ +ᶜ wkConₘ⁻¹ ρ γ₄ +ᶜ
            wkConₘ⁻¹ ρ γ₅)                                      ∎ }
-      (K₀ₘ₁ {γ₃} {γ₄} ok p≡𝟘 ▸A ▸t ▸B ▸u ▸v) eq →
+      (K₀ₘ₁ {γ₃} {γ₄} p≡𝟘 ▸A ▸t ▸B ▸u ▸v) eq →
         case wk-K eq of λ {
           (_ , _ , _ , _ , _ ,
            refl , refl , refl , refl , refl , refl) →
         sub
-          (K₀ₘ₁ ok p≡𝟘 (wkUsage⁻¹ ▸A) (wkUsage⁻¹ ▸t) (wkUsage⁻¹ ▸B)
+          (K₀ₘ₁ p≡𝟘 (wkUsage⁻¹ ▸A) (wkUsage⁻¹ ▸t) (wkUsage⁻¹ ▸B)
              (wkUsage⁻¹ ▸u) (wkUsage⁻¹ ▸v)) $ begin
         wkConₘ⁻¹ ρ (ω ·ᶜ (γ₃ +ᶜ γ₄))           ≈⟨ wkConₘ⁻¹-·ᶜ ρ ⟩
         ω ·ᶜ wkConₘ⁻¹ ρ (γ₃ +ᶜ γ₄)             ≈⟨ ·ᶜ-congˡ $ wkConₘ⁻¹-+ᶜ ρ ⟩
         ω ·ᶜ (wkConₘ⁻¹ ρ γ₃ +ᶜ wkConₘ⁻¹ ρ γ₄)  ∎ }
-      (K₀ₘ₂ ok ▸A ▸t ▸B ▸u ▸v) eq →
+      (K₀ₘ₂ ▸A ▸t ▸B ▸u ▸v) eq →
         case wk-K eq of λ {
           (_ , _ , _ , _ , _ ,
            refl , refl , refl , refl , refl , refl) →
-        K₀ₘ₂ ok (wkUsage⁻¹ ▸A) (wkUsage⁻¹ ▸t) (wkUsage⁻¹ ▸B)
+        K₀ₘ₂ (wkUsage⁻¹ ▸A) (wkUsage⁻¹ ▸t) (wkUsage⁻¹ ▸B)
           (wkUsage⁻¹ ▸u) (wkUsage⁻¹ ▸v) }
       ([]-congₘ ▸l ▸A ▸t ▸u ▸v ok) eq →
         case wk-[]-cong eq of λ {

--- a/graded-type-theory.agda-lib
+++ b/graded-type-theory.agda-lib
@@ -7,3 +7,4 @@ flags:
   --hidden-argument-puns
   --no-infer-absurd-clauses
   -WnoUnsupportedIndexedMatch
+


### PR DESCRIPTION
The definition of `Modality` no longer has the grade ω, instead there is a new property `Has-omega` for modalities with such a grade.
The grade ω is required to exist (with some properties) if J or K uses either `some` or `none` erased matches. This is controlled by `Usage-restrictions`.

In some places there are now assumptions that the modality has grade ω or that the `Usage-restrictions` allow `some` or `none` erased matches. Some of these might not be necessary but before we essentially had these everywhere (just less explicit) so they shouldn't make anything less general than before.